### PR TITLE
添加`jsr`和`drl`指令

### DIFF
--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -711,10 +711,11 @@ func RegisterBuiltinExtFun(self *Dice) {
 					pool = append(pool, i)
 				}
 				thisRoulette := map[string]interface{}{
-					"Reason": allArgsClean,
-					"Time":   t,
-					"Max":    m,
-					"Pool":   pool,
+					"Reason":      allArgsClean,
+					"Time":        t,
+					"Max":         m,
+					"Pool":        pool,
+					"DrawCounter": 0,
 				}
 				_roulettes[ctx.Group.GroupId] = thisRoulette
 				ReplyToSender(ctx, msg, fmt.Sprintf("创建骰轮%s成功，骰子面数%d，可抽取%d次。", allArgsClean, m, t))
@@ -743,8 +744,9 @@ func RegisterBuiltinExtFun(self *Dice) {
 				}
 				VarSetValueStr(ctx, "$t结果文本", result)
 				reply := DiceFormatTmpl(ctx, "核心:骰点")
+				_roulettes[ctx.Group.GroupId]["DrawCounter"] = _roulettes[ctx.Group.GroupId]["DrawCounter"].(int) + 1
 				_roulettes[ctx.Group.GroupId]["Pool"] = append(_roulettes[ctx.Group.GroupId]["Pool"].([]int)[:res], _roulettes[ctx.Group.GroupId]["Pool"].([]int)[res+1:]...)
-				if len(_roulettes[ctx.Group.GroupId]["Pool"].([]int)) <= 0 {
+				if _roulettes[ctx.Group.GroupId]["DrawCounter"].(int) >= _roulettes[ctx.Group.GroupId]["Time"].(int) {
 					reply += fmt.Sprintf("\n骰轮%s已经抽空，现在关闭。", _roulettes[ctx.Group.GroupId]["Reason"])
 					_roulettes[ctx.Group.GroupId] = nil
 				}


### PR DESCRIPTION
## `.drl mk t# m r`
在当前群组创建一个骰子面数为 m、可抽取 t 次的骰池（Pool），名字/原因为 r（可选）。之后可用`.drl`抽取，直到达到抽取上限 t。因为多人抽取应该不会导致骰子刷屏，所以对`specialExecuteTimes`不设上限。

## `.drl`
不重复地抽取当前群组的骰池一次。

## `.jsr t# m r`
类似`.drl`，但立即抽取完并展示所有结果。`specialExecuteTimes`的上限设为 45。