### PR TITLE
将`.drl`指令改为与 SyncMap 互动

### DIFF
--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -730,6 +730,13 @@ func RegisterBuiltinExtFun(self *Dice) {
 					roulette.Reason = m
 				}
 
+				if roulette.Time > roulette.Face {
+					ReplyToSender(ctx, msg, fmt.Sprintf("创建错误：无法不重复地投掷%d次%d面骰。",
+						roulette.Time,
+						roulette.Face))
+					return CmdExecuteResult{Matched: true, Solved: false}
+				}
+
 				//创建pool后直接先随机了
 				var pool []int
 				ma := make(map[int]bool)


### PR DESCRIPTION
- 现在 _roulettes 是 SyncMap 类型
- 修复了可能导致下标越界的逻辑（但方法似乎不是最优的）
- `.drl mk`的格式尽可能靠近`.r`（现在要求规定点数时前面加 d）