### PR TITLE
`drl` 现在支持暗骰抽取

### DIFF
--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -664,11 +664,11 @@ func RegisterBuiltinExtFun(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: false}
 			}
 			var pool []int
-			ma := SyncMap[int, bool]{}
+			ma := make(map[int]bool)
 			for len(pool) < t {
 				n := rand.Intn(m) + 1
-				if b, ok := ma.Load(n); (ok && !b) || !ok {
-					ma.Store(n, true)
+				if !ma[n] {
+					ma[n] = true
 					pool = append(pool, n)
 				}
 			}
@@ -742,11 +742,11 @@ func RegisterBuiltinExtFun(self *Dice) {
 
 				//创建pool后直接先随机了
 				var pool []int
-				ma := SyncMap[int, bool]{}
+				ma := make(map[int]bool)
 				for len(pool) < roulette.Time {
 					n := rand.Intn(roulette.Face) + 1
-					if b, ok := ma.Load(n); (ok && !b) || !ok {
-						ma.Store(n, true)
+					if !ma[n] {
+						ma[n] = true
 						pool = append(pool, n)
 					}
 				}

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 require (
 	github.com/glebarez/go-sqlite v1.20.3
 	github.com/go-creed/sat v1.0.3
-	github.com/gonutz/w32/v2 v2.7.0
 	github.com/grokify/html-strip-tags-go v0.0.1
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-sqlite3 v1.14.16


### PR DESCRIPTION
圣殿团的身份抽取似乎需要暗中发放，所以增加了一个 `.drlh` 指令，基本就是 `.drl` 的暗骰版。

另外，修改了 `.drl` 和 `.jsr` 的帮助文本，力图更易懂。