### PR TITLE
限制了 `jsr` 和 `drl` 的骰点上限

### DIFF
--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -655,7 +655,7 @@ func RegisterBuiltinExtFun(self *Dice) {
 			if m == 0 {
 				m = 100
 			}
-			if t > 45 {
+			if t > 25 {
 				ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:骰点_轮数过多警告"))
 				return CmdExecuteResult{Matched: true, Solved: false}
 			}
@@ -731,6 +731,11 @@ func RegisterBuiltinExtFun(self *Dice) {
 					roulette.Reason = text
 				} else {
 					roulette.Reason = m
+				}
+
+				if roulette.Time > 25 {
+					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:骰点_轮数过多警告"))
+					return CmdExecuteResult{Matched: true, Solved: false}
 				}
 
 				if roulette.Time > roulette.Face {


### PR DESCRIPTION
`drl` 和 `jsr` 的骰点上限现在是 25 次，和 cmd_parse.go 中规定的一致。