### PR TITLE
feat:添加Discord 账号的 http 代理配置

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -336,6 +336,11 @@ func ImConnectionsWalleQRelogin(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, nil)
 }
 
+type AddDiscordEcho struct {
+	Token    string
+	ProxyURL string
+}
+
 func ImConnectionsAddDiscord(c echo.Context) error {
 	if !doAuth(c) {
 		return c.JSON(http.StatusForbidden, nil)
@@ -347,13 +352,11 @@ func ImConnectionsAddDiscord(c echo.Context) error {
 	}
 
 	//myDice.Logger.Infof("后端add调用")
-	v := struct {
-		Token string `yaml:"token" json:"token"`
-	}{}
+	v := &AddDiscordEcho{}
 	err := c.Bind(&v)
 	if err == nil {
 		//myDice.Logger.Infof("bind无异常")
-		conn := dice.NewDiscordConnItem(v.Token)
+		conn := dice.NewDiscordConnItem(dice.AddDiscordEcho(*v))
 		//myDice.Logger.Infof("成功创建endpoint")
 		pa := conn.Adapter.(*dice.PlatformAdapterDiscord)
 		pa.Session = myDice.ImSession

--- a/dice/discord_helper.go
+++ b/dice/discord_helper.go
@@ -5,8 +5,13 @@ import (
 	"time"
 )
 
+type AddDiscordEcho struct {
+	Token    string
+	ProxyURL string
+}
+
 // NewDiscordConnItem 本来没必要写这个的，但是不知道为啥依赖出问题
-func NewDiscordConnItem(token string) *EndPointInfo {
+func NewDiscordConnItem(v AddDiscordEcho) *EndPointInfo {
 	conn := new(EndPointInfo)
 	conn.Id = uuid.New().String()
 	conn.Platform = "DISCORD"
@@ -15,7 +20,8 @@ func NewDiscordConnItem(token string) *EndPointInfo {
 	conn.RelWorkDir = "extra/discord-" + conn.Id
 	conn.Adapter = &PlatformAdapterDiscord{
 		EndPoint: conn,
-		Token:    token,
+		Token:    v.Token,
+		ProxyURL: v.ProxyURL,
 	}
 	return conn
 }

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -334,7 +334,7 @@ func (pa *PlatformAdapterDiscord) toStdMessage(m *discordgo.MessageCreate) *Mess
 		msg.MessageType = "private"
 	} else {
 		msg.MessageType = "group"
-		msg.GroupId = FormatDiceIdDiscordGuild(m.ChannelID)
+		msg.GroupId = FormatDiceIdDiscordChannel(m.ChannelID)
 		msg.GuildId = ch.GuildID
 	}
 	send := new(SenderBase)

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -62,6 +62,11 @@ func (pa *PlatformAdapterDiscord) updateChannelNum() {
 // Serve 启动服务，返回0就是成功，1就是失败
 func (pa *PlatformAdapterDiscord) Serve() int {
 	dg, err := discordgo.New("Bot " + pa.Token)
+	//这里出错很大概率是token不对
+	if err != nil {
+		pa.Session.Parent.Logger.Errorf("创建DiscordSession时出错:%s", err.Error())
+		return 1
+	}
 	if pa.ProxyURL != "" {
 		u, e := url.Parse(pa.ProxyURL)
 		if e != nil {
@@ -71,11 +76,6 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 			Proxy: http.ProxyURL(u),
 		}
 		dg.Dialer.Proxy = http.ProxyURL(u)
-	}
-	//这里出错很大概率是token不对
-	if err != nil {
-		pa.Session.Parent.Logger.Errorf("创建DiscordSession时出错:%s", err.Error())
-		return 1
 	}
 	dg.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
 		//忽略自己的消息……以及其他机器人的消息和系统消息


### PR DESCRIPTION
- feat:添加Discord 账号的 http 代理配置
- fix:Discord toStdMessage 时调用了错误的函数导致无法发送消息