### PR TITLE
feat: 支持对js脚本状态进行控制

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -363,6 +363,8 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.GET(prefix+"/js/get_record", jsGetRecord)
 	e.POST(prefix+"/js/shutdown", jsShutdown)
 	e.GET(prefix+"/js/status", jsStatus)
+	e.POST(prefix+"/js/enable", jsEnable)
+	e.POST(prefix+"/js/disable", jsDisable)
 
 	e.POST(prefix+"/tool/onebot", onebotTool)
 	e.GET(prefix+"/utils/ga/:uid", getGithubAvatar)

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -361,6 +361,8 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.GET(prefix+"/js/list", jsList)
 	e.POST(prefix+"/js/delete", jsDelete)
 	e.GET(prefix+"/js/get_record", jsGetRecord)
+	e.POST(prefix+"/js/shutdown", jsShutdown)
+	e.GET(prefix+"/js/status", jsStatus)
 
 	e.POST(prefix+"/tool/onebot", onebotTool)
 	e.GET(prefix+"/utils/ga/:uid", getGithubAvatar)

--- a/api/js.go
+++ b/api/js.go
@@ -234,3 +234,52 @@ func jsStatus(c echo.Context) error {
 		"status": myDice.JsEnable,
 	})
 }
+
+func jsEnable(c echo.Context) error {
+	if !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	if dm.JustForTest {
+		return c.JSON(200, map[string]interface{}{
+			"testMode": true,
+		})
+	}
+	v := struct {
+		Name string `form:"name" json:"name"`
+	}{}
+	err := c.Bind(&v)
+
+	if err == nil {
+		dice.JsEnable(myDice, v.Name)
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"result": true,
+			"name":   v.Name,
+		})
+	}
+	return c.JSON(http.StatusBadRequest, nil)
+}
+
+func jsDisable(c echo.Context) error {
+	if !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	if dm.JustForTest {
+		return c.JSON(200, map[string]interface{}{
+			"testMode": true,
+		})
+	}
+	v := struct {
+		Name string `form:"name" json:"name"`
+	}{}
+	err := c.Bind(&v)
+
+	if err == nil {
+		dice.JsDisable(myDice, v.Name)
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"result": true,
+			"name":   v.Name,
+		})
+	}
+
+	return c.JSON(http.StatusBadRequest, nil)
+}

--- a/api/js.go
+++ b/api/js.go
@@ -24,6 +24,13 @@ func jsExec(c echo.Context) error {
 			"testMode": true,
 		})
 	}
+	if !myDice.JsEnable {
+		resp := c.JSON(200, map[string]interface{}{
+			"result": false,
+			"err":    "js扩展支持已关闭",
+		})
+		return resp
+	}
 
 	v := struct {
 		Value string `json:"value"`
@@ -64,6 +71,7 @@ func jsExec(c echo.Context) error {
 	}
 
 	resp := c.JSON(200, map[string]interface{}{
+		"result":  true,
 		"ret":     retFinal,
 		"outputs": outputs,
 		"err":     errText,
@@ -75,6 +83,12 @@ func jsExec(c echo.Context) error {
 func jsGetRecord(c echo.Context) error {
 	if !doAuth(c) {
 		return c.JSON(http.StatusForbidden, nil)
+	}
+	if !myDice.JsEnable {
+		resp := c.JSON(200, map[string]interface{}{
+			"outputs": []string{},
+		})
+		return resp
 	}
 
 	outputs := myDice.JsPrinter.RecordEnd()
@@ -92,6 +106,13 @@ func jsDelete(c echo.Context) error {
 		return c.JSON(200, map[string]interface{}{
 			"testMode": true,
 		})
+	}
+	if !myDice.JsEnable {
+		resp := c.JSON(200, map[string]interface{}{
+			"result": false,
+			"err":    "js扩展支持已关闭",
+		})
+		return resp
 	}
 
 	v := struct {
@@ -180,6 +201,36 @@ func jsList(c echo.Context) error {
 	if !doAuth(c) {
 		return c.JSON(http.StatusForbidden, nil)
 	}
+	if !myDice.JsEnable {
+		resp := c.JSON(200, []*dice.JsScriptInfo{})
+		return resp
+	}
 
 	return c.JSON(http.StatusOK, myDice.JsScriptList)
+}
+
+func jsShutdown(c echo.Context) error {
+	if !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	if dm.JustForTest {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"testMode": true,
+		})
+	}
+
+	if myDice.JsEnable {
+		myDice.JsShutdown()
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"result": true,
+	})
+}
+
+func jsStatus(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"result": true,
+		"status": myDice.JsEnable,
+	})
 }

--- a/dice/config.go
+++ b/dice/config.go
@@ -1314,6 +1314,7 @@ func (d *Dice) loads() {
 			d.MailFrom = dNew.MailFrom
 			d.MailPassword = dNew.MailPassword
 			d.MailSmtp = dNew.MailSmtp
+			d.JsEnable = dNew.JsEnable
 
 			if dNew.BanList != nil {
 				d.BanList.BanBehaviorRefuseReply = dNew.BanList.BanBehaviorRefuseReply

--- a/dice/config.go
+++ b/dice/config.go
@@ -1315,6 +1315,7 @@ func (d *Dice) loads() {
 			d.MailPassword = dNew.MailPassword
 			d.MailSmtp = dNew.MailSmtp
 			d.JsEnable = dNew.JsEnable
+			d.DisabledJsScripts = dNew.DisabledJsScripts
 
 			if dNew.BanList != nil {
 				d.BanList.BanBehaviorRefuseReply = dNew.BanList.BanBehaviorRefuseReply

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -182,11 +182,12 @@ type Dice struct {
 	Cron             *cron.Cron           `yaml:"-" json:"-"`
 	AliveNoticeEntry cron.EntryID         `yaml:"-" json:"-"`
 	//JsVM             *goja.Runtime          `yaml:"-" json:"-"`
-	JsEnable     bool                   `yaml:"jsEnable" json:"jsEnable"`
-	JsPrinter    *PrinterFunc           `yaml:"-" json:"-"`
-	JsRequire    *require.RequireModule `yaml:"-" json:"-"`
-	JsLoop       *eventloop.EventLoop   `yaml:"-" json:"-"`
-	JsScriptList []*JsScriptInfo        `yaml:"-" json:"-"`
+	JsEnable          bool                   `yaml:"jsEnable" json:"jsEnable"`
+	DisabledJsScripts map[string]bool        `yaml:"disabledJsScripts" json:"disabledJsScripts"` // 作为set
+	JsPrinter         *PrinterFunc           `yaml:"-" json:"-"`
+	JsRequire         *require.RequireModule `yaml:"-" json:"-"`
+	JsLoop            *eventloop.EventLoop   `yaml:"-" json:"-"`
+	JsScriptList      []*JsScriptInfo        `yaml:"-" json:"-"`
 
 	// 游戏系统规则模板
 	GameSystemMap *SyncMap[string, *GameSystemTemplate] `yaml:"-" json:"-"`

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -182,6 +182,7 @@ type Dice struct {
 	Cron             *cron.Cron           `yaml:"-" json:"-"`
 	AliveNoticeEntry cron.EntryID         `yaml:"-" json:"-"`
 	//JsVM             *goja.Runtime          `yaml:"-" json:"-"`
+	JsEnable     bool                   `yaml:"jsEnable" json:"jsEnable"`
 	JsPrinter    *PrinterFunc           `yaml:"-" json:"-"`
 	JsRequire    *require.RequireModule `yaml:"-" json:"-"`
 	JsLoop       *eventloop.EventLoop   `yaml:"-" json:"-"`
@@ -267,7 +268,12 @@ func (d *Dice) Init() {
 	d.IsAlreadyLoadConfig = true
 
 	// 创建js运行时
-	d.JsInit()
+	if d.JsEnable {
+		d.Logger.Info("js扩展支持：开启")
+		d.JsInit()
+	} else {
+		d.Logger.Info("js扩展支持：关闭")
+	}
 
 	for _, i := range d.ExtList {
 		if i.OnLoad != nil {
@@ -349,7 +355,11 @@ func (d *Dice) Init() {
 	go refreshGroupInfo()
 
 	d.ApplyAliveNotice()
-	d.JsLoadScripts()
+	if d.JsEnable {
+		d.JsLoadScripts()
+	} else {
+		d.Logger.Info("js扩展支持已关闭，跳过js脚本的加载")
+	}
 
 	if d.UpgradeWindowId != "" {
 		go func() {

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -356,21 +356,22 @@ func (d *Dice) JsLoadScriptRaw(s string, info fs.FileInfo) {
 		re2 := regexp.MustCompile(`//[ \t]*@(\S+)\s+([^\r\n]+)`)
 		data := re2.FindAllStringSubmatch(text, -1)
 		for _, item := range data {
+			v := strings.TrimSpace(item[2])
 			switch item[1] {
 			case "name":
-				jsInfo.Name = item[2]
+				jsInfo.Name = v
 			case "homepageURL":
-				jsInfo.HomePage = item[2]
+				jsInfo.HomePage = v
 			case "license":
-				jsInfo.License = item[2]
+				jsInfo.License = v
 			case "author":
-				jsInfo.Author = item[2]
+				jsInfo.Author = v
 			case "version":
-				jsInfo.Version = item[2]
+				jsInfo.Version = v
 			case "description":
-				jsInfo.Desc = item[2]
+				jsInfo.Desc = v
 			case "timestamp":
-				v, err := strconv.ParseInt(item[2], 10, 64)
+				v, err := strconv.ParseInt(v, 10, 64)
 				if err == nil {
 					jsInfo.UpdateTime = v
 				}

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -68,19 +68,23 @@ func GetExtensionDesc(ei *ExtInfo) string {
 
 func (i *ExtInfo) callWithJsCheck(d *Dice, f func()) {
 	if i.IsJsExt {
-		waitRun := make(chan int, 1)
-		d.JsLoop.RunOnLoop(func(vm *goja.Runtime) {
-			defer func() {
-				// 防止崩掉进程
-				if r := recover(); r != nil {
-					d.Logger.Error("JS脚本报错:", r)
-				}
-				waitRun <- 1
-			}()
+		if d.JsEnable {
+			waitRun := make(chan int, 1)
+			d.JsLoop.RunOnLoop(func(vm *goja.Runtime) {
+				defer func() {
+					// 防止崩掉进程
+					if r := recover(); r != nil {
+						d.Logger.Error("JS脚本报错:", r)
+					}
+					waitRun <- 1
+				}()
 
-			f()
-		})
-		<-waitRun
+				f()
+			})
+			<-waitRun
+		} else {
+			d.Logger.Infof("当前已关闭js，跳过<%v>", i.Name)
+		}
 	} else {
 		f()
 	}


### PR DESCRIPTION
ui修改：sealdice/sealdice-ui#17

1. 可开启关闭js脚本支持
2. 可控制每个js脚本的状态，相应状态会保存到server.yaml中
3. 读取js脚本信息时去除每个值两端的空白