### PR TITLE
feat(gocqhttp): 使用内建的gocqhttp，支持填写签名服务器信息

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -499,9 +499,12 @@ func ImConnectionsAdd(c echo.Context) error {
 	}
 
 	v := struct {
-		Account  string `yaml:"account" json:"account"`
-		Password string `yaml:"password" json:"password"`
-		Protocol int    `json:"protocol"`
+		Account       string `yaml:"account" json:"account"`
+		Password      string `yaml:"password" json:"password"`
+		Protocol      int    `json:"protocol"`
+		UseSignServer bool   `json:"useSignServer"`
+		SignServerUrl string `json:"signServerUrl"`
+		SignServerKey string `json:"signServerKey"`
 		//ConnectUrl        string `yaml:"connectUrl" json:"connectUrl"`               // 连接地址
 		//Platform          string `yaml:"platform" json:"platform"`                   // 平台，如QQ、QQ频道
 		//Enable            bool   `yaml:"enable" json:"enable"`                       // 是否启用
@@ -532,7 +535,14 @@ func ImConnectionsAdd(c echo.Context) error {
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 
-		dice.GoCqHttpServe(myDice, conn, v.Password, v.Protocol, true)
+		dice.GoCqHttpServe(myDice, conn, dice.GoCqHttpLoginInfo{
+			Password:      v.Password,
+			Protocol:      v.Protocol,
+			IsAsyncRun:    true,
+			UseSignServer: v.UseSignServer,
+			SignServerUrl: v.SignServerUrl,
+			SignServerKey: v.SignServerKey,
+		})
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
 		return c.JSON(200, conn)

--- a/dice/platform_adapter_qq.go
+++ b/dice/platform_adapter_qq.go
@@ -3,7 +3,6 @@ package dice
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sacOO7/gowebsocket"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/sacOO7/gowebsocket"
 )
 
 // 0 默认 1登录中 2登录中-二维码 3登录中-滑条 4登录中-手机验证码 10登录成功 11登录失败
@@ -879,7 +880,11 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 		pa.GoCqHttpLastRestrictedTime = 0           // 重置风控时间
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
-		GoCqHttpServe(myDice, ep, pa.InPackGoCqHttpPassword, pa.InPackGoCqHttpProtocol, true)
+		GoCqHttpServe(myDice, ep, GoCqHttpLoginInfo{
+			Password:   pa.InPackGoCqHttpPassword,
+			Protocol:   pa.InPackGoCqHttpProtocol,
+			IsAsyncRun: true,
+		})
 		return true
 	}
 	return false
@@ -895,7 +900,11 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 		if pa.UseInPackGoCqhttp {
 			GoCqHttpServeProcessKill(d, c)
 			time.Sleep(1 * time.Second)
-			GoCqHttpServe(d, c, pa.InPackGoCqHttpPassword, pa.InPackGoCqHttpProtocol, true)
+			GoCqHttpServe(d, c, GoCqHttpLoginInfo{
+				Password:   pa.InPackGoCqHttpPassword,
+				Protocol:   pa.InPackGoCqHttpProtocol,
+				IsAsyncRun: true,
+			})
 			go ServeQQ(d, c)
 		} else {
 			go ServeQQ(d, c)

--- a/main.go
+++ b/main.go
@@ -3,16 +3,18 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/jessevdk/go-flags"
-	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
-	cp "github.com/otiai10/copy"
 	"mime"
 	"net"
 	"net/http"
 	"path/filepath"
 	"sealdice-core/dice/model"
 	"sealdice-core/migrate"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	cp "github.com/otiai10/copy"
+
 	//_ "net/http/pprof"
 	"os"
 	"os/exec"
@@ -479,7 +481,11 @@ func diceServe(d *dice.Dice) {
 					}
 					if conn.EndPointInfoBase.ProtocolType == "onebot" {
 						pa := conn.Adapter.(*dice.PlatformAdapterGocq)
-						dice.GoCqHttpServe(d, conn, pa.InPackGoCqHttpPassword, pa.InPackGoCqHttpProtocol, true)
+						dice.GoCqHttpServe(d, conn, dice.GoCqHttpLoginInfo{
+							Password:   pa.InPackGoCqHttpPassword,
+							Protocol:   pa.InPackGoCqHttpProtocol,
+							IsAsyncRun: true,
+						})
 					}
 					time.Sleep(10 * time.Second) // 稍作等待再连接
 					dice.ServeQQ(d, conn)


### PR DESCRIPTION
支持在新增使用内建gocqhttp的qq账号时，填入签名服务器的相关信息
ui调整：sealdice/sealdice-ui#19

![image](https://github.com/sealdice/sealdice-core/assets/42864805/a8d132e0-0e78-41be-ac30-fefae2c54b5f)