### PR TITLE
fix: PR#140 导致无法发送通知的问题；添加 `OnGuildJoined` 事件并适配 KOOK 与 Discord

### DIFF
--- a/dice/dice.go
+++ b/dice/dice.go
@@ -89,6 +89,7 @@ type ExtInfo struct {
 	OnMessageSend     func(ctx *MsgContext, msg *Message, flag string)      `yaml:"-" json:"-" jsbind:"onMessageSend"`
 	OnMessageDeleted  func(ctx *MsgContext, msg *Message)                   `yaml:"-" json:"-" jsbind:"onMessageDeleted"`
 	OnGroupJoined     func(ctx *MsgContext, msg *Message)                   `yaml:"-" json:"-" jsbind:"onGroupJoined"`
+	OnGuildJoined     func(ctx *MsgContext, msg *Message)                   `yaml:"-" json:"-" jsbind:"onGuildJoined"`
 	OnBecomeFriend    func(ctx *MsgContext, msg *Message)                   `yaml:"-" json:"-" jsbind:"onBecomeFriend"`
 	GetDescText       func(i *ExtInfo) string                               `yaml:"-" json:"-" jsbind:"getDescText"`
 	IsLoaded          bool                                                  `yaml:"-" json:"-" jsbind:"isLoaded"`

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1079,13 +1079,13 @@ func (ctx *MsgContext) Notice(txt string) {
 		}
 
 		for _, i := range ctx.Dice.NoticeIds {
-			seg := strings.Split(i, "-")[0]
-			if ctx.EndPoint.Platform != seg {
-				//ctx.Dice.Logger.Infof("Endpoint platform %s, ID platform %s", ctx.EndPoint.Platform, seg[0])
-				return
-			}
 			n := strings.Split(i, ":")
 			if len(n) >= 2 {
+				seg := strings.Split(n[0], "-")[0]
+				if ctx.EndPoint.Platform != seg {
+					ctx.Dice.Logger.Infof("发给 %s，但由于平台不同而未发送通知：%s", i, txt)
+					continue
+				}
 				if strings.HasSuffix(n[0], "-Group") {
 					ReplyGroup(ctx, &Message{GroupId: i}, txt)
 				} else {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/xuri/excelize/v2 v2.7.1
 	go.etcd.io/bbolt v1.3.7
 	go.uber.org/zap v1.24.0
-	golang.org/x/sys v0.8.0
+	golang.org/x/sys v0.10.0
 	golang.org/x/text v0.9.0
 	gopkg.in/elazarl/goproxy.v1 v1.0.0-20180725130230-947c36da3153
 	gopkg.in/yaml.v3 v3.0.1
@@ -51,11 +51,13 @@ require (
 	github.com/fyrchik/go-shlex v0.0.0-20210215145004-cd7f49bfd959
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/go-creed/sat v1.0.3
+	github.com/gorilla/websocket v1.5.0
 	github.com/grokify/html-strip-tags-go v0.0.1
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/tdewolff/minify/v2 v2.12.8
 	github.com/yuin/goldmark v1.5.4
 	golang.org/x/time v0.3.0
 )
@@ -101,7 +103,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20220221023154-0b2280d3ff96 // indirect
 	github.com/gopherjs/gopherwasm v1.1.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
@@ -119,6 +120,7 @@ require (
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/sacOO7/go-logger v0.0.0-20180719173527-9ac9add5a50d // indirect
 	github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af // indirect
+	github.com/tdewolff/parse/v2 v2.6.7 // indirect
 	github.com/tidwall/btree v1.4.2 // indirect
 	github.com/tidwall/gjson v1.14.3 // indirect
 	github.com/tidwall/grect v0.1.4 // indirect


### PR DESCRIPTION
修复了一个 #140 中导致 `(*MsgContext).Notice` 无法正确发送消息通知的问题

加入新服务器时，触发 JS 插件的 `onGuildJoined` 事件，主要在 `msg` 中包含 `guildId`。

同时采取方法发送入群致辞。