### PR TITLE
fix(helpdoc): 帮助文档相关问题修复

### DIFF
--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -275,6 +275,9 @@ func (m *HelpManager) Load() {
 		fmt.Println("unable to read helpdoc folder: ", err.Error())
 	}
 	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
 		var child HelpDoc
 		child.Key = generateHelpDocKey()
 		child.Name = entry.Name()
@@ -644,6 +647,9 @@ func buildHelpDocTree(node *HelpDoc, fn func(d *HelpDoc)) {
 	}
 
 	for _, sub := range subs {
+		if strings.HasPrefix(sub.Name(), ".") {
+			continue
+		}
 		var child HelpDoc
 		child.Key = generateHelpDocKey()
 		child.Name = sub.Name()

--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -660,9 +660,9 @@ func buildHelpDocTree(node *HelpDoc, fn func(d *HelpDoc)) {
 		fn(&child)
 		if sub.IsDir() {
 			buildHelpDocTree(&child, fn)
-		} else {
-			node.Children = append(node.Children, &child)
 		}
+		node.Children = append(node.Children, &child)
+
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/grokify/html-strip-tags-go v0.0.1
 	github.com/jmoiron/sqlx v1.3.5
+	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pkg/errors v0.9.1
@@ -106,7 +107,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
-	github.com/matoous/go-nanoid/v2 v2.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect


### PR DESCRIPTION
- 修复帮助目录下存在多级时不读取的问题
- 读取帮助文件时，过滤以.开头的文件 （主要处理mac端的.DS_Store）