### PR TITLE
feat(gocghttp): 适配新版本gocq签名配置项

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -81,8 +81,7 @@ func ImConnectionsSetData(c echo.Context) error {
 		Protocol            int    `form:"protocol" json:"protocol"`
 		IgnoreFriendRequest bool   `json:"ignoreFriendRequest"` // 忽略好友请求
 		UseSignServer       bool   `json:"useSignServer"`
-		SignServerUrl       string `json:"signServerUrl"`
-		SignServerKey       string `json:"signServerKey"`
+		SignServerConfig    *dice.SignServerConfig
 	}{}
 
 	err := c.Bind(&v)
@@ -100,10 +99,9 @@ func ImConnectionsSetData(c echo.Context) error {
 					}
 					ad.SetQQProtocol(v.Protocol)
 					if v.UseSignServer {
-						ad.SetSignServer(v.SignServerUrl, v.SignServerKey)
+						ad.SetSignServer(v.SignServerConfig)
 						ad.UseSignServer = v.UseSignServer
-						ad.SignServerUrl = v.SignServerUrl
-						ad.SignServerKey = v.SignServerKey
+						ad.SignServerConfig = v.SignServerConfig
 					}
 					ad.IgnoreFriendRequest = v.IgnoreFriendRequest
 				}
@@ -508,12 +506,11 @@ func ImConnectionsAdd(c echo.Context) error {
 	}
 
 	v := struct {
-		Account       string `yaml:"account" json:"account"`
-		Password      string `yaml:"password" json:"password"`
-		Protocol      int    `json:"protocol"`
-		UseSignServer bool   `json:"useSignServer"`
-		SignServerUrl string `json:"signServerUrl"`
-		SignServerKey string `json:"signServerKey"`
+		Account          string                 `yaml:"account" json:"account"`
+		Password         string                 `yaml:"password" json:"password"`
+		Protocol         int                    `json:"protocol"`
+		UseSignServer    bool                   `json:"useSignServer"`
+		SignServerConfig *dice.SignServerConfig `json:"signServerConfig"`
 		//ConnectUrl        string `yaml:"connectUrl" json:"connectUrl"`               // 连接地址
 		//Platform          string `yaml:"platform" json:"platform"`                   // 平台，如QQ、QQ频道
 		//Enable            bool   `yaml:"enable" json:"enable"`                       // 是否启用
@@ -541,19 +538,17 @@ func ImConnectionsAdd(c echo.Context) error {
 		pa.InPackGoCqHttpPassword = v.Password
 		pa.Session = myDice.ImSession
 		pa.UseSignServer = v.UseSignServer
-		pa.SignServerUrl = v.SignServerUrl
-		pa.SignServerKey = v.SignServerKey
+		pa.SignServerConfig = v.SignServerConfig
 
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 
 		dice.GoCqHttpServe(myDice, conn, dice.GoCqHttpLoginInfo{
-			Password:      v.Password,
-			Protocol:      v.Protocol,
-			IsAsyncRun:    true,
-			UseSignServer: v.UseSignServer,
-			SignServerUrl: v.SignServerUrl,
-			SignServerKey: v.SignServerKey,
+			Password:         v.Password,
+			Protocol:         v.Protocol,
+			IsAsyncRun:       true,
+			UseSignServer:    v.UseSignServer,
+			SignServerConfig: v.SignServerConfig,
 		})
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)

--- a/dice/gocqhttp_helper.go
+++ b/dice/gocqhttp_helper.go
@@ -291,20 +291,8 @@ account: # 账号相关
   use-sso-address: true
   # 是否允许发送临时会话消息
   allow-temp-session: false
-
-  # 数据包的签名服务器
-  # 兼容 https://github.com/fuqiuluo/unidbg-fetch-qsign
-  # 如果遇到 登录 45 错误, 或者发送信息风控的话需要填入一个服务器
-  # 示例:
-  # sign-server: 'http://127.0.0.1:8080' # 本地签名服务器
-  # sign-server: 'https://signserver.example.com' # 线上签名服务器
-  # 服务器可使用docker在本地搭建或者使用他人开放的服务
-  {是否使用签名服务}sign-server: '{签名服务器url}'
-  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
-  {是否使用签名服务}is-below-110: false
-  # 签名服务器所需要的apikey, 如果签名服务器的版本在1.1.0及以下则此项无效
-  # 本地部署的默认为114514
-  {是否使用签名服务}key: '{签名服务器key}'
+{旧版签名服务相关配置信息}
+{新版签名服务相关配置信息}
 
 heartbeat:
   # 心跳频率, 单位秒
@@ -398,14 +386,99 @@ func GenerateConfig(qq int64, port int, info GoCqHttpLoginInfo) string {
 	ret = strings.Replace(ret, "{QQ帐号}", fmt.Sprintf("%d", qq), 1)
 	ret = strings.Replace(ret, "{QQ密码}", info.Password, 1)
 
-	if info.UseSignServer {
-		ret = strings.Replace(ret, "{是否使用签名服务}", "", 3)
-		ret = strings.Replace(ret, "{签名服务器url}", info.SignServerUrl, 1)
-		ret = strings.Replace(ret, "{签名服务器key}", info.SignServerKey, 1)
+	if info.UseSignServer && info.SignServerConfig != nil {
+		ret = strings.Replace(ret, "{旧版签名服务相关配置信息}", generateOldSignServerConfigStr(info.SignServerConfig), 1)
+		ret = strings.Replace(ret, "{新版签名服务相关配置信息}", generateNewSignServerConfigStr(info.SignServerConfig), 1)
 	} else {
-		ret = strings.Replace(ret, "{是否使用签名服务}", "# ", 3)
+		ret = strings.Replace(ret, "{旧版签名服务相关配置信息}", "", 1)
+		ret = strings.Replace(ret, "{新版签名服务相关配置信息}", "", 1)
 	}
 	return ret
+}
+
+func generateOldSignServerConfigStr(config *SignServerConfig) string {
+	if config.SignServers != nil {
+		mainServer := config.SignServers[0]
+		return fmt.Sprintf(`
+  # 旧版签名服务相关配置信息
+  sign-server: '%s'
+  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
+  # 该字段在新签名配置信息中也存在，防止重复此处不配置
+  # is-below-110: false
+  # 签名服务器所需要的apikey, 如果签名服务器的版本在1.1.0及以下则此项无效
+  key: '%s'
+`, mainServer.Url, mainServer.Key)
+	} else {
+		return ""
+	}
+}
+
+func generateNewSignServerConfigStr(config *SignServerConfig) string {
+	var signServers []string
+	for _, server := range config.SignServers {
+		signServers = append(
+			signServers,
+			fmt.Sprintf(`    - url: '%s'
+      key: "%s"
+      authorization: "%s"`, server.Url, server.Key, server.Authorization),
+		)
+	}
+	signServersStr := "  sign-servers:\n" + strings.Join(signServers, "\n")
+
+	return fmt.Sprintf(`  # 新版签名服务相关配置信息
+  # 数据包的签名服务器列表，第一个作为主签名服务器，后续作为备用
+  # 兼容 https://github.com/fuqiuluo/unidbg-fetch-qsign
+  # 如果遇到 登录 45 错误, 或者发送信息风控的话需要填入一个或多个服务器
+  # 不建议设置过多，设置主备各一个即可，超过 5 个只会取前五个
+  # 示例:
+  # sign-servers: 
+  #   - url: 'http://127.0.0.1:8080' # 本地签名服务器
+  #     key: "114514"  # 相应 key
+  #     authorization: "-"   # authorization 内容, 依服务端设置
+  #   - url: 'https://signserver.example.com' # 线上签名服务器
+  #     key: "114514"  
+  #     authorization: "-"   
+  #   ...
+  # 
+  # 服务器可使用docker在本地搭建或者使用他人开放的服务
+%s
+
+  # 判断签名服务不可用（需要切换）的额外规则
+  # 0: 不设置 （此时仅在请求无法返回结果时判定为不可用）
+  # 1: 在获取到的 sign 为空 （若选此建议关闭 auto-register，一般为实例未注册但是请求签名的情况）
+  # 2: 在获取到的 sign 或 token 为空（若选此建议关闭 auto-refresh-token ）
+  rule-change-sign-server: %d
+
+  # 连续寻找可用签名服务器最大尝试次数
+  # 为 0 时会在连续 3 次没有找到可用签名服务器后保持使用主签名服务器，不再尝试进行切换备用
+  # 否则会在达到指定次数后 **退出** 主程序
+  max-check-count: %d
+  # 签名服务请求超时时间(s)
+  sign-server-timeout: %d
+  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
+  # 建议使用 1.1.6 以上版本，低版本普遍半个月冻结一次
+  is-below-110: false
+  # 在实例可能丢失（获取到的签名为空）时是否尝试重新注册
+  # 为 true 时，在签名服务不可用时可能每次发消息都会尝试重新注册并签名。
+  # 为 false 时，将不会自动注册实例，在签名服务器重启或实例被销毁后需要重启 go-cqhttp 以获取实例
+  # 否则后续消息将不会正常签名。关闭此项后可以考虑开启签名服务器端 auto_register 避免需要重启
+  # 由于实现问题，当前建议关闭此项，推荐开启签名服务器的自动注册实例
+  auto-register: %v
+  # 是否在 token 过期后立即自动刷新签名 token（在需要签名时才会检测到，主要防止 token 意外丢失）
+  # 独立于定时刷新
+  auto-refresh-token: %v
+  # 定时刷新 token 间隔时间，单位为分钟, 建议 30~40 分钟, 不可超过 60 分钟
+  # 目前丢失token也不会有太大影响，可设置为 0 以关闭，推荐开启
+  refresh-interval: %d
+`,
+		signServersStr,
+		config.RuleChangeSignServer,
+		config.MaxCheckCount,
+		config.SignServerTimeout,
+		config.AutoRegister,
+		config.AutoRefreshToken,
+		config.RefreshInterval,
+	)
 }
 
 func NewGoCqhttpConnectInfoItem(account string) *EndPointInfo {
@@ -482,12 +555,27 @@ func GoCqHttpServeRemoveSessionToken(dice *Dice, conn *EndPointInfo) {
 }
 
 type GoCqHttpLoginInfo struct {
-	Password      string
-	Protocol      int
-	IsAsyncRun    bool
-	UseSignServer bool
-	SignServerUrl string
-	SignServerKey string
+	Password         string
+	Protocol         int
+	IsAsyncRun       bool
+	UseSignServer    bool
+	SignServerConfig *SignServerConfig
+}
+
+type SignServerConfig struct {
+	SignServers          []*SignServer `yaml:"signServers" json:"signServers"`
+	RuleChangeSignServer int           `yaml:"ruleChangeSignServer" json:"ruleChangeSignServer"`
+	MaxCheckCount        int           `yaml:"maxCheckCount" json:"maxCheckCount"`
+	SignServerTimeout    int           `yaml:"signServerTimeout" json:"signServerTimeout"`
+	AutoRegister         bool          `yaml:"autoRegister" json:"autoRegister"`
+	AutoRefreshToken     bool          `yaml:"autoRefreshToken" json:"autoRefreshToken"`
+	RefreshInterval      int           `yaml:"refreshInterval" json:"refreshInterval"`
+}
+
+type SignServer struct {
+	Url           string `yaml:"url" json:"url"`
+	Key           string `yaml:"key" json:"key"`
+	Authorization string `yaml:"authorization" json:"authorization"`
 }
 
 func GoCqHttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqHttpLoginInfo) {

--- a/dice/gocqhttp_helper_test.go
+++ b/dice/gocqhttp_helper_test.go
@@ -1,0 +1,131 @@
+package dice
+
+import "testing"
+
+var testSignServerConfig = &SignServerConfig{
+	SignServers: []*SignServer{
+		{
+			Url:           "http://127.0.0.1:8080",
+			Key:           "114514",
+			Authorization: "-",
+		},
+		{
+			Url:           "https://signserver.example.com",
+			Key:           "114514",
+			Authorization: "Bearer xxxx",
+		},
+	},
+	RuleChangeSignServer: 1,
+	MaxCheckCount:        0,
+	SignServerTimeout:    60,
+	AutoRegister:         false,
+	AutoRefreshToken:     false,
+	RefreshInterval:      40,
+}
+
+func Test_generateOldSignServerConfigStr(t *testing.T) {
+	type args struct {
+		config *SignServerConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"default",
+			args{config: testSignServerConfig},
+			`
+  # 旧版签名服务相关配置信息
+  sign-server: 'http://127.0.0.1:8080'
+  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
+  # 该字段在新签名配置信息中也存在，防止重复此处不配置
+  # is-below-110: false
+  # 签名服务器所需要的apikey, 如果签名服务器的版本在1.1.0及以下则此项无效
+  key: '114514'
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateOldSignServerConfigStr(tt.args.config); got != tt.want {
+				t.Errorf("generateOldSignServerConfigStr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_generateNewSignServerConfigStr(t *testing.T) {
+	type args struct {
+		config *SignServerConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"default",
+			args{config: testSignServerConfig},
+			`  # 新版签名服务相关配置信息
+  # 数据包的签名服务器列表，第一个作为主签名服务器，后续作为备用
+  # 兼容 https://github.com/fuqiuluo/unidbg-fetch-qsign
+  # 如果遇到 登录 45 错误, 或者发送信息风控的话需要填入一个或多个服务器
+  # 不建议设置过多，设置主备各一个即可，超过 5 个只会取前五个
+  # 示例:
+  # sign-servers: 
+  #   - url: 'http://127.0.0.1:8080' # 本地签名服务器
+  #     key: "114514"  # 相应 key
+  #     authorization: "-"   # authorization 内容, 依服务端设置
+  #   - url: 'https://signserver.example.com' # 线上签名服务器
+  #     key: "114514"  
+  #     authorization: "-"   
+  #   ...
+  # 
+  # 服务器可使用docker在本地搭建或者使用他人开放的服务
+  sign-servers:
+    - url: 'http://127.0.0.1:8080'
+      key: "114514"
+      authorization: "-"
+    - url: 'https://signserver.example.com'
+      key: "114514"
+      authorization: "Bearer xxxx"
+
+  # 判断签名服务不可用（需要切换）的额外规则
+  # 0: 不设置 （此时仅在请求无法返回结果时判定为不可用）
+  # 1: 在获取到的 sign 为空 （若选此建议关闭 auto-register，一般为实例未注册但是请求签名的情况）
+  # 2: 在获取到的 sign 或 token 为空（若选此建议关闭 auto-refresh-token ）
+  rule-change-sign-server: 1
+
+  # 连续寻找可用签名服务器最大尝试次数
+  # 为 0 时会在连续 3 次没有找到可用签名服务器后保持使用主签名服务器，不再尝试进行切换备用
+  # 否则会在达到指定次数后 **退出** 主程序
+  max-check-count: 0
+  # 签名服务请求超时时间(s)
+  sign-server-timeout: 60
+  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
+  # 建议使用 1.1.6 以上版本，低版本普遍半个月冻结一次
+  is-below-110: false
+  # 在实例可能丢失（获取到的签名为空）时是否尝试重新注册
+  # 为 true 时，在签名服务不可用时可能每次发消息都会尝试重新注册并签名。
+  # 为 false 时，将不会自动注册实例，在签名服务器重启或实例被销毁后需要重启 go-cqhttp 以获取实例
+  # 否则后续消息将不会正常签名。关闭此项后可以考虑开启签名服务器端 auto_register 避免需要重启
+  # 由于实现问题，当前建议关闭此项，推荐开启签名服务器的自动注册实例
+  auto-register: false
+  # 是否在 token 过期后立即自动刷新签名 token（在需要签名时才会检测到，主要防止 token 意外丢失）
+  # 独立于定时刷新
+  auto-refresh-token: false
+  # 定时刷新 token 间隔时间，单位为分钟, 建议 30~40 分钟, 不可超过 60 分钟
+  # 目前丢失token也不会有太大影响，可设置为 0 以关闭，推荐开启
+  refresh-interval: 40
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := generateNewSignServerConfigStr(tt.args.config); got != tt.want {
+				t.Errorf("generateNewSignServerConfigStr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/dice/platform_adapter_qq.go
+++ b/dice/platform_adapter_qq.go
@@ -981,9 +981,18 @@ func (pa *PlatformAdapterGocq) SetSignServer(signServerConfig *SignServerConfig)
 		err = yaml.Unmarshal(configFile, &info)
 
 		if err == nil {
-			//FIXME: 新签名服务配置
-			//(info["account"]).(map[string]interface{})["sign-server"] = signServerUrl
-			//(info["account"]).(map[string]interface{})["key"] = signServerKey
+			if signServerConfig.SignServers != nil {
+				mainServer := signServerConfig.SignServers[0]
+				(info["account"]).(map[string]interface{})["sign-server"] = mainServer.Url
+				(info["account"]).(map[string]interface{})["key"] = mainServer.Key
+				(info["account"]).(map[string]interface{})["sign-servers"] = signServerConfig.SignServers
+				(info["account"]).(map[string]interface{})["ruleChangeSignServer"] = signServerConfig.RuleChangeSignServer
+				(info["account"]).(map[string]interface{})["maxCheckCount"] = signServerConfig.MaxCheckCount
+				(info["account"]).(map[string]interface{})["signServerTimeout"] = signServerConfig.SignServerTimeout
+				(info["account"]).(map[string]interface{})["autoRegister"] = signServerConfig.AutoRegister
+				(info["account"]).(map[string]interface{})["autoRefreshToken"] = signServerConfig.AutoRefreshToken
+				(info["account"]).(map[string]interface{})["refreshInterval"] = signServerConfig.RefreshInterval
+			}
 			data, err := yaml.Marshal(info)
 			if err == nil {
 				_ = os.WriteFile(configFilePath, data, 0644)

--- a/dice/platform_adapter_qq.go
+++ b/dice/platform_adapter_qq.go
@@ -75,9 +75,8 @@ type PlatformAdapterGocq struct {
 	echoMap2       *SyncMap[int64, *echoMapInfo]    `yaml:"-"`
 	Implementation string                           `yaml:"implementation" json:"implementation"`
 
-	UseSignServer bool   `yaml:"useSignServer" json:"useSignServer"`
-	SignServerUrl string `yaml:"signServerUrl" json:"signServerUrl"`
-	SignServerKey string `yaml:"signServerKey" json:"signServerKey"`
+	UseSignServer    bool              `yaml:"useSignServer" json:"useSignServer"`
+	SignServerConfig *SignServerConfig `yaml:"signServerConfig" json:"signServerConfig"`
 }
 
 type Sender struct {
@@ -969,7 +968,7 @@ func (pa *PlatformAdapterGocq) SetQQProtocol(protocol int) bool {
 	return false
 }
 
-func (pa *PlatformAdapterGocq) SetSignServer(signServerUrl string, signServerKey string) bool {
+func (pa *PlatformAdapterGocq) SetSignServer(signServerConfig *SignServerConfig) bool {
 	workDir := filepath.Join(pa.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
 	configFilePath := filepath.Join(workDir, "config.yml")
 	if _, err := os.Stat(configFilePath); err == nil {
@@ -978,8 +977,9 @@ func (pa *PlatformAdapterGocq) SetSignServer(signServerUrl string, signServerKey
 		err = yaml.Unmarshal(configFile, &info)
 
 		if err == nil {
-			(info["account"]).(map[string]interface{})["sign-server"] = signServerUrl
-			(info["account"]).(map[string]interface{})["key"] = signServerKey
+			//FIXME: 新签名服务配置
+			//(info["account"]).(map[string]interface{})["sign-server"] = signServerUrl
+			//(info["account"]).(map[string]interface{})["key"] = signServerKey
 			data, err := yaml.Marshal(info)
 			if err == nil {
 				_ = os.WriteFile(configFilePath, data, 0644)

--- a/dice/platform_adapter_qq.go
+++ b/dice/platform_adapter_qq.go
@@ -904,9 +904,11 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
 		GoCqHttpServe(myDice, ep, GoCqHttpLoginInfo{
-			Password:   pa.InPackGoCqHttpPassword,
-			Protocol:   pa.InPackGoCqHttpProtocol,
-			IsAsyncRun: true,
+			Password:         pa.InPackGoCqHttpPassword,
+			Protocol:         pa.InPackGoCqHttpProtocol,
+			IsAsyncRun:       true,
+			UseSignServer:    pa.UseSignServer,
+			SignServerConfig: pa.SignServerConfig,
 		})
 		return true
 	}
@@ -924,9 +926,11 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 			GoCqHttpServeProcessKill(d, c)
 			time.Sleep(1 * time.Second)
 			GoCqHttpServe(d, c, GoCqHttpLoginInfo{
-				Password:   pa.InPackGoCqHttpPassword,
-				Protocol:   pa.InPackGoCqHttpProtocol,
-				IsAsyncRun: true,
+				Password:         pa.InPackGoCqHttpPassword,
+				Protocol:         pa.InPackGoCqHttpProtocol,
+				IsAsyncRun:       true,
+				UseSignServer:    pa.UseSignServer,
+				SignServerConfig: pa.SignServerConfig,
 			})
 			go ServeQQ(d, c)
 		} else {

--- a/main.go
+++ b/main.go
@@ -497,9 +497,11 @@ func diceServe(d *dice.Dice) {
 					if conn.EndPointInfoBase.ProtocolType == "onebot" {
 						pa := conn.Adapter.(*dice.PlatformAdapterGocq)
 						dice.GoCqHttpServe(d, conn, dice.GoCqHttpLoginInfo{
-							Password:   pa.InPackGoCqHttpPassword,
-							Protocol:   pa.InPackGoCqHttpProtocol,
-							IsAsyncRun: true,
+							Password:         pa.InPackGoCqHttpPassword,
+							Protocol:         pa.InPackGoCqHttpProtocol,
+							IsAsyncRun:       true,
+							UseSignServer:    pa.UseSignServer,
+							SignServerConfig: pa.SignServerConfig,
 						})
 					}
 					time.Sleep(10 * time.Second) // 稍作等待再连接


### PR DESCRIPTION
相关ui调整：sealdice/sealdice-ui#29

新版本的gocq调整了签名服务的配置项，新的config.yml中的签名部分如下：
```yaml
  # 数据包的签名服务器列表，第一个作为主签名服务器，后续作为备用
  # 兼容 https://github.com/fuqiuluo/unidbg-fetch-qsign
  # 如果遇到 登录 45 错误, 或者发送信息风控的话需要填入一个或多个服务器
  # 不建议设置过多，设置主备各一个即可，超过 5 个只会取前五个
  # 示例:
  # sign-servers: 
  #   - url: 'http://127.0.0.1:8080' # 本地签名服务器
  #     key: "114514"  # 相应 key
  #     authorization: "-"   # authorization 内容, 依服务端设置
  #   - url: 'https://signserver.example.com' # 线上签名服务器
  #     key: "114514"  
  #     authorization: "-"   
  #   ...
  # 
  # 服务器可使用docker在本地搭建或者使用他人开放的服务
  sign-servers: 
    - url: '-'  # 主签名服务器地址， 必填
      key: '114514'  # 签名服务器所需要的apikey, 如果签名服务器的版本在1.1.0及以下则此项无效
      authorization: '-'   # authorization 内容, 依服务端设置，如 'Bearer xxxx'
    - url: '-'  # 备用
      key: '114514'  
      authorization: '-' 

  # 判断签名服务不可用（需要切换）的额外规则
  # 0: 不设置 （此时仅在请求无法返回结果时判定为不可用）
  # 1: 在获取到的 sign 为空 （若选此建议关闭 auto-register，一般为实例未注册但是请求签名的情况）
  # 2: 在获取到的 sign 或 token 为空（若选此建议关闭 auto-refresh-token ）
  rule-change-sign-server: 1

  # 连续寻找可用签名服务器最大尝试次数
  # 为 0 时会在连续 3 次没有找到可用签名服务器后保持使用主签名服务器，不再尝试进行切换备用
  # 否则会在达到指定次数后 **退出** 主程序
  max-check-count: 0
  # 签名服务请求超时时间(s)
  sign-server-timeout: 60
  # 如果签名服务器的版本在1.1.0及以下, 请将下面的参数改成true
  # 建议使用 1.1.6 以上版本，低版本普遍半个月冻结一次
  is-below-110: false
  # 在实例可能丢失（获取到的签名为空）时是否尝试重新注册
  # 为 true 时，在签名服务不可用时可能每次发消息都会尝试重新注册并签名。
  # 为 false 时，将不会自动注册实例，在签名服务器重启或实例被销毁后需要重启 go-cqhttp 以获取实例
  # 否则后续消息将不会正常签名。关闭此项后可以考虑开启签名服务器端 auto_register 避免需要重启
  # 由于实现问题，当前建议关闭此项，推荐开启签名服务器的自动注册实例
  auto-register: false
  # 是否在 token 过期后立即自动刷新签名 token（在需要签名时才会检测到，主要防止 token 意外丢失）
  # 独立于定时刷新
  auto-refresh-token: false
  # 定时刷新 token 间隔时间，单位为分钟, 建议 30~40 分钟, 不可超过 60 分钟
  # 目前丢失token也不会有太大影响，可设置为 0 以关闭，推荐开启
  refresh-interval: 40
```

内置生成的config.yml需要支持新gocq的配置，同时适配老版本，故同时生成两个字段 `sign-server`（旧）和 `sign-servers`（新）的配置项，如下：（部分注释已省略）
```yaml
  # 旧版签名服务相关配置信息
  sign-server: 'http://127.0.0.1'
  # 该字段在新签名配置信息中也存在，防止重复此处不配置
  # is-below-110: false
  key: '114514'

  # 新版签名服务相关配置信息
  sign-servers:
    - url: 'http://127.0.0.1'
      key: "114514"
      authorization: ""

  rule-change-sign-server: 1

  max-check-count: 0
  sign-server-timeout: 60
  is-below-110: false
  auto-register: false
  auto-refresh-token: false
  refresh-interval: 40
```

相关ui调整如下：
![image](https://github.com/sealdice/sealdice-ui/assets/42864805/9a4bb66c-7804-40aa-bcf4-63b2fd769383)
![image](https://github.com/sealdice/sealdice-ui/assets/42864805/df2eea7f-2d99-4f6b-ab91-fdcb87b43f6d)