### PR TITLE
feat: 对于`#{DRAW-x}`写法, 支持x是`{}`包裹的表达式, 以允许其中使用变量

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ walle-q/
 _help_cache
 .DS_Store
 !static/.nomedia
+
+.vscode/


### PR DESCRIPTION
# 请求详细Review和测试后再合入

一个可能的用法是在自定义回复中使用正则分组捕获, 然后回复`#{DRAW-{$t1}}`

Close #216