### PR TITLE
fix(JsExt): JS重载时,去除已删除JS对应的插件配置

### DIFF
--- a/api/js.go
+++ b/api/js.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"fmt"
-	"github.com/dop251/goja"
-	"github.com/labstack/echo/v4"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -11,6 +9,9 @@ import (
 	"path/filepath"
 	"sealdice-core/dice"
 	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/labstack/echo/v4"
 )
 
 func jsExec(c echo.Context) error {
@@ -138,8 +139,7 @@ func jsReload(c echo.Context) error {
 
 	//myDice.JsLock.Lock()
 	//defer myDice.JsLock.Unlock()
-	myDice.JsInit()
-	myDice.JsLoadScripts()
+	myDice.JsReload()
 	return c.JSON(200, nil)
 }
 

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -898,8 +898,7 @@ func (d *Dice) registerCoreCommands() {
 					DeckReload(dice)
 					ReplyToSender(ctx, msg, "牌堆已重载")
 				case "js":
-					dice.JsInit()
-					dice.JsLoadScripts()
+					dice.JsReload()
 					ReplyToSender(ctx, msg, "js已重载")
 				case "help":
 					// 别名


### PR DESCRIPTION
这个bug与UI并无关系, 因此[UI仓库的这个Issue #10](https://github.com/sealdice/sealdice-ui/issues/10)可以一并关掉

Close #207