### PR TITLE
feat: 重构 `bot`，加入忽略群组裸指令支持

### DIFF
--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -58,9 +58,10 @@ type DiceConfigInfo struct {
 	LogSizeNoticeEnable bool `json:"logSizeNoticeEnable"` // 开启日志数量提示
 	LogSizeNoticeCount  int  `json:"logSizeNoticeCount"`  // 日志数量提示阈值，默认500
 
-	TextCmdTrustOnly     bool `json:"textCmdTrustOnly"`     // text命令只允许信任用户和master
-	QQEnablePoke         bool `json:"QQEnablePoke"`         // QQ允许戳一戳
-	PlayerNameWrapEnable bool `json:"playerNameWrapEnable"` // 玩家名外框
+	TextCmdTrustOnly        bool `json:"textCmdTrustOnly"`        // text命令只允许信任用户和master
+	IgnoreUnaddressedBotCmd bool `json:"ignoreUnaddressedBotCmd"` // 不响应群聊裸bot指令
+	QQEnablePoke            bool `json:"QQEnablePoke"`            // QQ允许戳一戳
+	PlayerNameWrapEnable    bool `json:"playerNameWrapEnable"`    // 玩家名外框
 
 	MailEnable   bool   `json:"mailEnable"`
 	MailFrom     string `json:"mailFrom"`     // 邮箱来源
@@ -157,14 +158,15 @@ func DiceConfig(c echo.Context) error {
 		PlayerNameWrapEnable: myDice.PlayerNameWrapEnable,
 
 		// 1.3?
-		MailEnable:          myDice.MailEnable,
-		MailFrom:            myDice.MailFrom,
-		MailPassword:        emailPasswordMasked,
-		MailSmtp:            myDice.MailSmtp,
-		MaxExecuteTime:      maxExec,
-		MaxCocCardGen:       maxCard,
-		CustomReplenishRate: myDice.CustomReplenishRate,
-		CustomBurst:         maxBurst,
+		MailEnable:              myDice.MailEnable,
+		MailFrom:                myDice.MailFrom,
+		MailPassword:            emailPasswordMasked,
+		MailSmtp:                myDice.MailSmtp,
+		MaxExecuteTime:          maxExec,
+		MaxCocCardGen:           maxCard,
+		CustomReplenishRate:     myDice.CustomReplenishRate,
+		CustomBurst:             maxBurst,
+		IgnoreUnaddressedBotCmd: myDice.IgnoreUnaddressedBotCmd,
 	}
 	return c.JSON(http.StatusOK, info)
 }
@@ -440,6 +442,10 @@ func DiceConfigSet(c echo.Context) error {
 
 		if val, ok := jsonMap["textCmdTrustOnly"]; ok {
 			myDice.TextCmdTrustOnly = val.(bool)
+		}
+
+		if val, ok := jsonMap["ignoreUnaddressedBotCmd"]; ok {
+			myDice.IgnoreUnaddressedBotCmd = val.(bool)
 		}
 
 		if val, ok := jsonMap["QQEnablePoke"]; ok {

--- a/dice/config.go
+++ b/dice/config.go
@@ -1489,6 +1489,7 @@ func (d *Dice) loads() {
 			d.QQChannelAutoOn = dNew.QQChannelAutoOn
 			d.QQEnablePoke = dNew.QQEnablePoke
 			d.TextCmdTrustOnly = dNew.TextCmdTrustOnly
+			d.IgnoreUnaddressedBotCmd = dNew.IgnoreUnaddressedBotCmd
 			d.UILogLimit = dNew.UILogLimit
 			d.FriendAddComment = dNew.FriendAddComment
 			d.AutoReloginEnable = dNew.AutoReloginEnable

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -147,14 +147,15 @@ type Dice struct {
 	MessageDelayRangeStart  float64                `yaml:"messageDelayRangeStart"`               // 指令延迟区间
 	MessageDelayRangeEnd    float64                `yaml:"messageDelayRangeEnd"`
 	WorkInQQChannel         bool                   `yaml:"workInQQChannel"`
-	QQChannelAutoOn         bool                   `yaml:"QQChannelAutoOn"`     // QQ频道中自动开启(默认不开)
-	QQChannelLogMessage     bool                   `yaml:"QQChannelLogMessage"` // QQ频道中记录消息(默认不开)
-	QQEnablePoke            bool                   `yaml:"QQEnablePoke"`        // 启用戳一戳
-	RateLimitEnabled        bool                   `yaml:"rateLimitEnabled"`    // 启用频率限制 (刷屏限制)
-	CustomReplenishRate     string                 `yaml:"customReplenishRate"` // 原始自定义速率
-	ParsedReplenishRate     rate.Limit             `yaml:"-"`                   // 刷屏警告速率
-	CustomBurst             int64                  `yaml:"customBurst"`         // 自定义上限
-	TextCmdTrustOnly        bool                   `yaml:"textCmdTrustOnly"`    // 只允许信任用户或master使用text指令
+	QQChannelAutoOn         bool                   `yaml:"QQChannelAutoOn"`         // QQ频道中自动开启(默认不开)
+	QQChannelLogMessage     bool                   `yaml:"QQChannelLogMessage"`     // QQ频道中记录消息(默认不开)
+	QQEnablePoke            bool                   `yaml:"QQEnablePoke"`            // 启用戳一戳
+	RateLimitEnabled        bool                   `yaml:"rateLimitEnabled"`        // 启用频率限制 (刷屏限制)
+	CustomReplenishRate     string                 `yaml:"customReplenishRate"`     // 原始自定义速率
+	ParsedReplenishRate     rate.Limit             `yaml:"-"`                       // 刷屏警告速率
+	CustomBurst             int64                  `yaml:"customBurst"`             // 自定义上限
+	TextCmdTrustOnly        bool                   `yaml:"textCmdTrustOnly"`        // 只允许信任用户或master使用text指令
+	IgnoreUnaddressedBotCmd bool                   `yaml:"ignoreUnaddressedBotCmd"` // 不响应群聊裸bot指令
 	UILogLimit              int64                  `yaml:"UILogLimit"`
 	FriendAddComment        string                 `yaml:"friendAddComment"` // 加好友验证信息
 	MasterUnlockCode        string                 `yaml:"-"`                // 解锁码，每20分钟变化一次，使用后立即变化


### PR DESCRIPTION
测试中重构后的 `bot` 指令表现一致，但可能需要更多 review / 测试。

WebUI 见 https://github.com/sealdice/sealdice-ui/pull/51

close https://github.com/sealdice/sealdice-core/issues/266