### PR TITLE
feat(backup): 提供批量删除备份接口

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -334,6 +334,7 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.POST(prefix+"/backup/config_set", backupConfigSave)
 	e.GET(prefix+"/backup/download", backupDownload)
 	e.POST(prefix+"/backup/delete", backupDelete)
+	e.POST(prefix+"/backup/batch_delete", backupBatchDelete)
 
 	e.GET(prefix+"/group/list", groupList)
 	e.POST(prefix+"/group/set_one", groupSetOne)


### PR DESCRIPTION
ui调整：sealdice/sealdice-ui#58
增加批量删除备份功能，默认勾选5个最近备份之外的备份，可自行调整。
close #239
<img width="761" alt="image" src="https://github.com/sealdice/sealdice-core/assets/42864805/69e7e9e2-ffa7-40ae-a70e-ff73bf9ba912">
