### PR TITLE
feat: 减小QQ平台长文本切分阈值,调整切分逻辑

### DIFF
--- a/dice/platform_adapter_gocq_actions.go
+++ b/dice/platform_adapter_gocq_actions.go
@@ -10,10 +10,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sealdice-core/utils"
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/sacOO7/gowebsocket"
 )
@@ -588,18 +588,7 @@ func textSplit(input string) []string {
 		}
 	}
 
-	maxLen := 5000 // 以utf-8计算，1666个汉字
-	var splits []string
-
-	var l, r int
-	for l, r = 0, maxLen; r < len(input); l, r = r, r+maxLen {
-		for !utf8.RuneStart(input[r]) {
-			r--
-		}
-		splits = append(splits, input[l:r])
-	}
-	splits = append(splits, input[l:])
-
+	splits := utils.SplitLongText(input, 2000)
 	splits = append(splits, poke...)
 
 	return splits

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"fmt"
 	"path/filepath"
+	"sealdice-core/utils"
 )
 
 type HTTPSimpleMessage struct {
@@ -27,11 +28,14 @@ func (pa *PlatformAdapterHTTP) DoRelogin() bool {
 func (pa *PlatformAdapterHTTP) SetEnable(_ bool) {}
 
 func (pa *PlatformAdapterHTTP) SendToPerson(_ *MsgContext, uid string, text string, _ string) {
-	pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, text})
+	sp := utils.SplitLongText(text, 300)
+	for _, sub := range sp {
+		pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, sub})
+	}
 }
 
 func (pa *PlatformAdapterHTTP) SendToGroup(_ *MsgContext, uid string, text string, _ string) {
-	pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, text})
+	pa.SendToPerson(nil, uid, text, "")
 }
 
 func (pa *PlatformAdapterHTTP) SendFileToPerson(ctx *MsgContext, uid string, path string, flag string) {

--- a/utils/split_text.go
+++ b/utils/split_text.go
@@ -6,12 +6,14 @@ import (
 )
 
 func splitFirst(s string, maxLen int) (first string, rest string) {
-	if len(s) <= maxLen { // 不足上限不切分
+	// 去除首尾空白
+	s = strings.TrimSpace(s)
+
+	// 不足上限不切分
+	if len(s) <= maxLen {
 		return s, ""
 	}
 
-	// 去除首尾空白
-	s = strings.TrimSpace(s)
 	// 确保子串长度不大于 maxLen 且完整切分 UTF-8 字符
 	r := maxLen
 	for (!utf8.RuneStart(s[r])) && r > 0 {

--- a/utils/split_text.go
+++ b/utils/split_text.go
@@ -1,14 +1,12 @@
 package utils
 
 import (
+	"regexp"
 	"strings"
 	"unicode/utf8"
 )
 
 func splitFirst(s string, maxLen int) (first string, rest string) {
-	// 去除首尾空白
-	s = strings.TrimSpace(s)
-
 	// 不足上限不切分
 	if len(s) <= maxLen {
 		return s, ""
@@ -21,9 +19,10 @@ func splitFirst(s string, maxLen int) (first string, rest string) {
 	}
 
 	// 如果有连续换行符, 直接切分
-	idxTwoNL := strings.Index(s[0:r], "\n\n")
-	if idxTwoNL >= 0 {
-		return s[0:idxTwoNL], s[idxTwoNL+2:]
+	multiNL := regexp.MustCompile(`\n{2,}`)
+	idxMultiNL := multiNL.FindStringIndex(s[0:r])
+	if len(idxMultiNL) == 2 {
+		return s[0:idxMultiNL[0]], s[idxMultiNL[1]:]
 	}
 
 	// 如果切分中有换行符, 以最后一个换行符切分, 增强可读性
@@ -42,7 +41,7 @@ func splitFirst(s string, maxLen int) (first string, rest string) {
 // 确保切分后每个子串长度不大于 maxLen.
 // 优先以 text 中的换行符为切分点, 总长度小于 maxLen 的连续短行不切分.
 //
-// 例外: text 中的一个完全空行 (2 个连续换行符) 强制切分.
+// 例外: text 中的多个连续换行符会被强制切分.
 func SplitLongText(text string, maxLen int) []string {
 	if maxLen <= 0 {
 		return []string{text}
@@ -52,7 +51,9 @@ func SplitLongText(text string, maxLen int) []string {
 
 	for len(text) > 0 {
 		first, rest := splitFirst(text, maxLen)
-		splits = append(splits, first)
+		if len(strings.TrimSpace(first)) > 0 {
+			splits = append(splits, first)
+		}
 		text = rest
 	}
 

--- a/utils/split_text.go
+++ b/utils/split_text.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+func splitFirst(s string, maxLen int) (first string, rest string) {
+	if len(s) <= maxLen { // 不足上限不切分
+		return s, ""
+	}
+
+	// 去除首尾空白
+	s = strings.TrimSpace(s)
+	// 确保子串长度不大于 maxLen 且完整切分 UTF-8 字符
+	r := maxLen
+	for (!utf8.RuneStart(s[r])) && r > 0 {
+		r--
+	}
+
+	// 如果有连续换行符, 直接切分
+	idxTwoNL := strings.Index(s[0:r], "\n\n")
+	if idxTwoNL >= 0 {
+		return s[0:idxTwoNL], s[idxTwoNL+2:]
+	}
+
+	// 如果切分中有换行符, 以最后一个换行符切分, 增强可读性
+	idxNL := strings.LastIndex(s[0:r], "\n")
+	if idxNL >= 0 {
+		return s[0:idxNL], s[idxNL+1:]
+	}
+
+	return s[0:r], s[r:]
+}
+
+// SplitLongText 切分长文本
+//   - text 要切分的文本
+//   - maxLen 子串长度上限(字节数), <=0 时不切分
+//
+// 确保切分后每个子串长度不大于 maxLen.
+// 优先以 text 中的换行符为切分点, 总长度小于 maxLen 的连续短行不切分.
+//
+// 例外: text 中的一个完全空行 (2 个连续换行符) 强制切分.
+func SplitLongText(text string, maxLen int) []string {
+	if maxLen <= 0 {
+		return []string{text}
+	}
+
+	var splits []string
+
+	for len(text) > 0 {
+		first, rest := splitFirst(text, maxLen)
+		splits = append(splits, first)
+		text = rest
+	}
+
+	return splits
+}


### PR DESCRIPTION
阈值减小到2000字节(约667汉字)
并且在指令测试页面加入一个阈值更小(300字节)的切分,以供展示效果

Issue #234