### PR TITLE
fix: 初始部署无法正确给配置项赋予默认值

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -1693,349 +1693,344 @@ func getNumVal(i interface{}) uint {
 
 func (d *Dice) loads() {
 	data, err := os.ReadFile(filepath.Join(d.BaseConfig.DataDir, "serve.yaml"))
-
-	// 配置这块弄得比较屎，有机会换个方案。。。
-	// TODO(Xiangze Li): 不管谁都好 赶紧重写吧, 谁能想起来加了配置还要在这里添一行才能Load出来哇
-	if err == nil { //nolint:nestif
-		dNew := Dice{}
+	dNew := Dice{}
+	if err == nil {
 		err2 := yaml.Unmarshal(data, &dNew)
 		if err2 != nil {
 			d.Logger.Error("serve.yaml parse failed")
 			panic(err2)
 		}
-		d.CommandCompatibleMode = true // 一直为true即可
-		d.ImSession.EndPoints = dNew.ImSession.EndPoints
-		d.CommandPrefix = dNew.CommandPrefix
-		d.DiceMasters = dNew.DiceMasters
-		d.VersionCode = dNew.VersionCode
-		d.MessageDelayRangeStart = dNew.MessageDelayRangeStart
-		d.MessageDelayRangeEnd = dNew.MessageDelayRangeEnd
-		d.WorkInQQChannel = dNew.WorkInQQChannel
-		d.QQChannelLogMessage = dNew.QQChannelLogMessage
-		d.QQChannelAutoOn = dNew.QQChannelAutoOn
-		d.QQEnablePoke = dNew.QQEnablePoke
-		d.TextCmdTrustOnly = dNew.TextCmdTrustOnly
-		d.IgnoreUnaddressedBotCmd = dNew.IgnoreUnaddressedBotCmd
-		d.UILogLimit = dNew.UILogLimit
-		d.FriendAddComment = dNew.FriendAddComment
-		d.AutoReloginEnable = dNew.AutoReloginEnable
-		d.NoticeIDs = dNew.NoticeIDs
-		d.ExtDefaultSettings = dNew.ExtDefaultSettings
-		d.CustomReplyConfigEnable = dNew.CustomReplyConfigEnable
-		d.RefuseGroupInvite = dNew.RefuseGroupInvite
-		d.DefaultCocRuleIndex = dNew.DefaultCocRuleIndex
-		d.UpgradeWindowID = dNew.UpgradeWindowID
-		d.UpgradeEndpointID = dNew.UpgradeEndpointID
-		d.BotExtFreeSwitch = dNew.BotExtFreeSwitch
-		d.RateLimitEnabled = dNew.RateLimitEnabled
-		d.TrustOnlyMode = dNew.TrustOnlyMode
-		d.AliveNoticeEnable = dNew.AliveNoticeEnable
-		d.AliveNoticeValue = dNew.AliveNoticeValue
-		d.ReplyDebugMode = dNew.ReplyDebugMode
-		d.LogSizeNoticeCount = dNew.LogSizeNoticeCount
-		d.LogSizeNoticeEnable = dNew.LogSizeNoticeEnable
-		d.PlayerNameWrapEnable = dNew.PlayerNameWrapEnable
-		d.MailEnable = dNew.MailEnable
-		d.MailFrom = dNew.MailFrom
-		d.MailPassword = dNew.MailPassword
-		d.MailSMTP = dNew.MailSMTP
-		d.JsEnable = dNew.JsEnable
-		d.DisabledJsScripts = dNew.DisabledJsScripts
-		d.NewsMark = dNew.NewsMark
-
-		d.EnableCensor = dNew.EnableCensor
-		d.CensorMode = dNew.CensorMode
-		d.CensorThresholds = dNew.CensorThresholds
-		d.CensorHandlers = dNew.CensorHandlers
-		d.CensorScores = dNew.CensorScores
-		d.CensorCaseSensitive = dNew.CensorCaseSensitive
-		d.CensorMatchPinyin = dNew.CensorMatchPinyin
-		d.CensorFilterRegexStr = dNew.CensorFilterRegexStr
-
-		if dNew.BanList != nil {
-			d.BanList.BanBehaviorRefuseReply = dNew.BanList.BanBehaviorRefuseReply
-			d.BanList.BanBehaviorRefuseInvite = dNew.BanList.BanBehaviorRefuseInvite
-			d.BanList.BanBehaviorQuitLastPlace = dNew.BanList.BanBehaviorQuitLastPlace
-			d.BanList.BanBehaviorQuitPlaceImmediately = dNew.BanList.BanBehaviorQuitPlaceImmediately
-			d.BanList.BanBehaviorQuitIfAdmin = dNew.BanList.BanBehaviorQuitIfAdmin
-
-			d.BanList.ScoreReducePerMinute = dNew.BanList.ScoreReducePerMinute
-
-			d.BanList.ThresholdWarn = dNew.BanList.ThresholdWarn
-			d.BanList.ThresholdBan = dNew.BanList.ThresholdBan
-			d.BanList.ScoreGroupMuted = dNew.BanList.ScoreGroupMuted
-			d.BanList.ScoreGroupKicked = dNew.BanList.ScoreGroupKicked
-			d.BanList.ScoreTooManyCommand = dNew.BanList.ScoreTooManyCommand
-
-			d.BanList.JointScorePercentOfGroup = dNew.BanList.JointScorePercentOfGroup
-			d.BanList.JointScorePercentOfInviter = dNew.BanList.JointScorePercentOfInviter
-		}
-
-		d.MaxExecuteTime = dNew.MaxExecuteTime
-		if d.MaxExecuteTime == 0 {
-			d.MaxExecuteTime = 12
-		}
-
-		d.MaxCocCardGen = dNew.MaxCocCardGen
-		if d.MaxCocCardGen == 0 {
-			d.MaxCocCardGen = 5
-		}
-
-		d.PersonalReplenishRateStr = dNew.PersonalReplenishRateStr
-		if d.PersonalReplenishRateStr == "" {
-			d.PersonalReplenishRateStr = "@every 3s"
-			d.PersonalReplenishRate = rate.Every(time.Second * 3)
-		} else {
-			if parsed, errParse := utils.ParseRate(d.PersonalReplenishRateStr); errParse == nil {
-				d.PersonalReplenishRate = parsed
-			} else {
-				d.Logger.Errorf("解析PersonalReplenishRate失败: %v", errParse)
-				d.PersonalReplenishRateStr = "@every 3s"
-				d.PersonalReplenishRate = rate.Every(time.Second * 3)
-			}
-		}
-
-		d.PersonalBurst = dNew.PersonalBurst
-		if d.PersonalBurst == 0 {
-			d.PersonalBurst = 3
-		}
-
-		d.GroupReplenishRateStr = dNew.GroupReplenishRateStr
-		if d.GroupReplenishRateStr == "" {
-			d.GroupReplenishRateStr = "@every 3s"
-			d.GroupReplenishRate = rate.Every(time.Second * 3)
-		} else {
-			if parsed, errParse := utils.ParseRate(d.GroupReplenishRateStr); errParse == nil {
-				d.GroupReplenishRate = parsed
-			} else {
-				d.Logger.Errorf("解析GroupReplenishRate失败: %v", errParse)
-				d.GroupReplenishRateStr = "@every 3s"
-				d.GroupReplenishRate = rate.Every(time.Second * 3)
-			}
-		}
-
-		d.GroupBurst = dNew.GroupBurst
-		if d.GroupBurst == 0 {
-			d.GroupBurst = 3
-		}
-
-		if d.DiceMasters == nil || len(d.DiceMasters) == 0 {
-			d.DiceMasters = []string{"UI:1001"}
-		}
-		var newDiceMasters []string
-		for _, i := range d.DiceMasters {
-			if i != "<平台,如QQ>:<帐号,如QQ号>" {
-				newDiceMasters = append(newDiceMasters, i)
-			}
-		}
-		d.DiceMasters = newDiceMasters
-		// 装载ServiceAt
-		d.ImSession.ServiceAtNew = map[string]*GroupInfo{}
-		_ = model.GroupInfoListGet(d.DBData, func(id string, updatedAt int64, data []byte) {
-			var groupInfo GroupInfo
-			err := json.Unmarshal(data, &groupInfo)
-			if err == nil {
-				groupInfo.GroupID = id
-				groupInfo.UpdatedAtTime = updatedAt
-
-				// 找出其中以群号开头的，这是1.2版本的bug
-				var toDelete []string
-				if groupInfo.DiceIDExistsMap != nil {
-					groupInfo.DiceIDExistsMap.Range(func(key string, value bool) bool {
-						if strings.HasPrefix(key, "QQ-Group:") {
-							toDelete = append(toDelete, key)
-						}
-						return true
-					})
-					for _, i := range toDelete {
-						groupInfo.DiceIDExistsMap.Delete(i)
-					}
-				}
-				d.ImSession.ServiceAtNew[id] = &groupInfo
-			} else {
-				d.Logger.Errorf("加载群信息失败: %s", id)
-			}
-		})
-
-		m := map[string]*ExtInfo{}
-		for _, i := range d.ExtList {
-			m[i.Name] = i
-		}
-
-		// 设置群扩展
-		for _, v := range d.ImSession.ServiceAtNew {
-			var tmp []*ExtInfo
-			for _, i := range v.ActivatedExtList {
-				if m[i.Name] != nil {
-					tmp = append(tmp, m[i.Name])
-				}
-			}
-			v.ActivatedExtList = tmp
-		}
-
-		// 读取群变量
-		for _, g := range d.ImSession.ServiceAtNew {
-			// 群组数据
-			if g.ValueMap == nil {
-				g.ValueMap = lockfree.NewHashMap()
-			}
-
-			data := model.AttrGroupGetAll(d.DBData, g.GroupID)
-			if len(data) != 0 {
-				mapData := make(map[string]*VMValue)
-				err := JSONValueMapUnmarshal(data, &mapData)
-				if err != nil {
-					d.Logger.Error("读取群变量失败: ", err)
-				}
-				for k, v := range mapData {
-					g.ValueMap.Set(k, v)
-				}
-			}
-			if g.DiceIDActiveMap == nil {
-				g.DiceIDActiveMap = new(SyncMap[string, bool])
-			}
-			if g.DiceIDExistsMap == nil {
-				g.DiceIDExistsMap = new(SyncMap[string, bool])
-			}
-			if g.BotList == nil {
-				g.BotList = new(SyncMap[string, bool])
-			}
-		}
-
-		if d.VersionCode != 0 && d.VersionCode < 10000 {
-			d.CustomReplyConfigEnable = false
-		}
-
-		if d.VersionCode != 0 && d.VersionCode < 10001 {
-			d.AliveNoticeValue = "@every 3h"
-		}
-
-		if d.VersionCode != 0 && d.VersionCode < 10003 {
-			d.Logger.Infof("进行配置文件版本升级: %d -> %d", d.VersionCode, 10003)
-			d.LogSizeNoticeCount = 500
-			d.LogSizeNoticeEnable = true
-			d.CustomReplyConfigEnable = true
-		}
-
-		if d.VersionCode != 0 && d.VersionCode < 10004 {
-			d.AutoReloginEnable = false
-		}
-
-		if d.VersionCode != 0 && d.VersionCode < 10005 {
-			d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
-				d.Logger.Info("正在自动升级自定义文案文件")
-				for index, text := range d.TextMapRaw["核心"]["昵称_重置"] {
-					srcText := text[0].(string)
-					srcText = strings.ReplaceAll(srcText, "{$tQQ昵称}", "{$t旧昵称}")
-					srcText = strings.ReplaceAll(srcText, "{$t帐号昵称}", "{$t旧昵称}")
-					d.TextMapRaw["核心"]["昵称_重置"][index][0] = srcText
-				}
-
-				for index, text := range d.TextMapRaw["核心"]["角色管理_删除成功"] {
-					srcText := text[0].(string)
-					srcText = strings.ReplaceAll(srcText, "{$t新角色名}", "{$t角色名}")
-					d.TextMapRaw["核心"]["角色管理_删除成功"][index][0] = srcText
-				}
-
-				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
-				d.GenerateTextMap()
-				d.SaveText()
-			})
-		}
-
-		// 1.2 版本
-		if d.VersionCode != 0 && d.VersionCode < 10200 {
-			d.TextCmdTrustOnly = true
-			d.QQEnablePoke = true
-			d.PlayerNameWrapEnable = true
-
-			isUI1001Master := false
-			for _, i := range d.DiceMasters {
-				if i == "UI:1001" {
-					isUI1001Master = true
-					break
-				}
-			}
-			if !isUI1001Master {
-				d.DiceMasters = append(d.DiceMasters, "UI:1001")
-			}
-
-			d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
-				// 更正写反的部分
-				d.Logger.Info("正在自动升级自定义文案文件")
-				for index := range d.TextMapRaw["COC"]["属性设置_保存提醒"] {
-					srcText := `{ $t当前绑定角色 ? '[√] 已绑卡' : '' }`
-					d.TextMapRaw["COC"]["属性设置_保存提醒"][index][0] = srcText
-				}
-
-				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
-				d.GenerateTextMap()
-				d.SaveText()
-			})
-		}
-
-		// 1.2 版本
-		if d.VersionCode != 0 && d.VersionCode < 10203 {
-			d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
-				// 更正写反的部分
-				d.Logger.Info("正在自动升级自定义文案文件")
-				for index := range d.TextMapRaw["COC"]["属性设置_增减_单项"] {
-					srcText := "{$t属性}: {$t旧值} ➯ {$t新值} ({$t增加或扣除}{$t表达式文本}={$t变化量})"
-					d.TextMapRaw["COC"]["属性设置_增减_单项"][index][0] = srcText
-				}
-
-				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
-				d.GenerateTextMap()
-				d.SaveText()
-			})
-		}
-
-		// 1.3 版本
-		if d.VersionCode != 0 && d.VersionCode < 10300 {
-			d.JsEnable = true
-
-			d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
-				// 更正写反的部分
-				d.Logger.Info("正在自动升级自定义文案文件")
-				for index, text := range d.TextMapRaw["娱乐"]["鸽子理由"] {
-					srcText := text[0].(string)
-					srcText = strings.ReplaceAll(srcText, "在互联网上约到可爱美少女不惜搁置跑团前去约会的{$t玩家}，还不知道这个叫奈亚的妹子隐藏着什么", "空山不见人，但闻咕咕声。 —— {$t玩家}")
-					d.TextMapRaw["娱乐"]["鸽子理由"][index][0] = srcText
-				}
-
-				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
-				d.GenerateTextMap()
-				d.SaveText()
-			})
-		}
-
-		// 设置全局群名缓存和用户名缓存
-		dm := d.Parent
-		now := time.Now().Unix()
-		for k, v := range d.ImSession.ServiceAtNew {
-			dm.GroupNameCache.Set(k, &GroupNameCacheItem{Name: v.GroupName, time: now})
-		}
-
-		d.Logger.Info("serve.yaml loaded")
 	} else {
-		// 这里是没有加载到配置文件，所以写默认设置项
-		d.AutoReloginEnable = false
-		d.WorkInQQChannel = true
-		d.CustomReplyConfigEnable = false
-		d.AliveNoticeValue = "@every 3h"
+		// 不能正确处理变量零值的, 需要在这里给默认值
 		d.Logger.Info("serve.yaml not found")
 
+		dNew.AutoReloginEnable = false
+		dNew.WorkInQQChannel = true
+		dNew.CustomReplyConfigEnable = false
+		dNew.AliveNoticeValue = "@every 3h"
+		dNew.LogSizeNoticeCount = 500
+		dNew.LogSizeNoticeEnable = true
+		dNew.QQEnablePoke = true
+		dNew.TextCmdTrustOnly = true
+		dNew.PlayerNameWrapEnable = true
+		dNew.DiceMasters = []string{"UI:1001"}
+		dNew.JsEnable = true
+		dNew.ImSession = new(IMSession)
+	}
+
+	// 配置这块弄得比较屎，有机会换个方案。。。
+	// TODO(Xiangze Li): 不管谁都好 赶紧重写吧, 谁能想起来加了配置还要在这里添一行才能Load出来哇
+	d.CommandCompatibleMode = true // 一直为true即可
+	d.ImSession.EndPoints = dNew.ImSession.EndPoints
+	d.CommandPrefix = dNew.CommandPrefix
+	d.DiceMasters = dNew.DiceMasters
+	d.VersionCode = dNew.VersionCode
+	d.MessageDelayRangeStart = dNew.MessageDelayRangeStart
+	d.MessageDelayRangeEnd = dNew.MessageDelayRangeEnd
+	d.WorkInQQChannel = dNew.WorkInQQChannel
+	d.QQChannelLogMessage = dNew.QQChannelLogMessage
+	d.QQChannelAutoOn = dNew.QQChannelAutoOn
+	d.QQEnablePoke = dNew.QQEnablePoke
+	d.TextCmdTrustOnly = dNew.TextCmdTrustOnly
+	d.IgnoreUnaddressedBotCmd = dNew.IgnoreUnaddressedBotCmd
+	d.UILogLimit = dNew.UILogLimit
+	d.FriendAddComment = dNew.FriendAddComment
+	d.AutoReloginEnable = dNew.AutoReloginEnable
+	d.NoticeIDs = dNew.NoticeIDs
+	d.ExtDefaultSettings = dNew.ExtDefaultSettings
+	d.CustomReplyConfigEnable = dNew.CustomReplyConfigEnable
+	d.RefuseGroupInvite = dNew.RefuseGroupInvite
+	d.DefaultCocRuleIndex = dNew.DefaultCocRuleIndex
+	d.UpgradeWindowID = dNew.UpgradeWindowID
+	d.UpgradeEndpointID = dNew.UpgradeEndpointID
+	d.BotExtFreeSwitch = dNew.BotExtFreeSwitch
+	d.RateLimitEnabled = dNew.RateLimitEnabled
+	d.TrustOnlyMode = dNew.TrustOnlyMode
+	d.AliveNoticeEnable = dNew.AliveNoticeEnable
+	d.AliveNoticeValue = dNew.AliveNoticeValue
+	d.ReplyDebugMode = dNew.ReplyDebugMode
+	d.LogSizeNoticeCount = dNew.LogSizeNoticeCount
+	d.LogSizeNoticeEnable = dNew.LogSizeNoticeEnable
+	d.PlayerNameWrapEnable = dNew.PlayerNameWrapEnable
+	d.MailEnable = dNew.MailEnable
+	d.MailFrom = dNew.MailFrom
+	d.MailPassword = dNew.MailPassword
+	d.MailSMTP = dNew.MailSMTP
+	d.JsEnable = dNew.JsEnable
+	d.DisabledJsScripts = dNew.DisabledJsScripts
+	d.NewsMark = dNew.NewsMark
+
+	d.EnableCensor = dNew.EnableCensor
+	d.CensorMode = dNew.CensorMode
+	d.CensorThresholds = dNew.CensorThresholds
+	d.CensorHandlers = dNew.CensorHandlers
+	d.CensorScores = dNew.CensorScores
+	d.CensorCaseSensitive = dNew.CensorCaseSensitive
+	d.CensorMatchPinyin = dNew.CensorMatchPinyin
+	d.CensorFilterRegexStr = dNew.CensorFilterRegexStr
+
+	if dNew.BanList != nil {
+		d.BanList.BanBehaviorRefuseReply = dNew.BanList.BanBehaviorRefuseReply
+		d.BanList.BanBehaviorRefuseInvite = dNew.BanList.BanBehaviorRefuseInvite
+		d.BanList.BanBehaviorQuitLastPlace = dNew.BanList.BanBehaviorQuitLastPlace
+		d.BanList.BanBehaviorQuitPlaceImmediately = dNew.BanList.BanBehaviorQuitPlaceImmediately
+		d.BanList.BanBehaviorQuitIfAdmin = dNew.BanList.BanBehaviorQuitIfAdmin
+
+		d.BanList.ScoreReducePerMinute = dNew.BanList.ScoreReducePerMinute
+
+		d.BanList.ThresholdWarn = dNew.BanList.ThresholdWarn
+		d.BanList.ThresholdBan = dNew.BanList.ThresholdBan
+		d.BanList.ScoreGroupMuted = dNew.BanList.ScoreGroupMuted
+		d.BanList.ScoreGroupKicked = dNew.BanList.ScoreGroupKicked
+		d.BanList.ScoreTooManyCommand = dNew.BanList.ScoreTooManyCommand
+
+		d.BanList.JointScorePercentOfGroup = dNew.BanList.JointScorePercentOfGroup
+		d.BanList.JointScorePercentOfInviter = dNew.BanList.JointScorePercentOfInviter
+	}
+
+	d.MaxExecuteTime = dNew.MaxExecuteTime
+	if d.MaxExecuteTime <= 0 {
+		d.MaxExecuteTime = 12
+	}
+
+	d.MaxCocCardGen = dNew.MaxCocCardGen
+	if d.MaxCocCardGen <= 0 {
+		d.MaxCocCardGen = 5
+	}
+
+	d.PersonalReplenishRateStr = dNew.PersonalReplenishRateStr
+	if d.PersonalReplenishRateStr == "" {
+		d.PersonalReplenishRateStr = "@every 3s"
+		d.PersonalReplenishRate = rate.Every(time.Second * 3)
+	} else {
+		if parsed, errParse := utils.ParseRate(d.PersonalReplenishRateStr); errParse == nil {
+			d.PersonalReplenishRate = parsed
+		} else {
+			d.Logger.Errorf("解析PersonalReplenishRate失败: %v", errParse)
+			d.PersonalReplenishRateStr = "@every 3s"
+			d.PersonalReplenishRate = rate.Every(time.Second * 3)
+		}
+	}
+
+	d.PersonalBurst = dNew.PersonalBurst
+	if d.PersonalBurst == 0 {
+		d.PersonalBurst = 3
+	}
+
+	d.GroupReplenishRateStr = dNew.GroupReplenishRateStr
+	if d.GroupReplenishRateStr == "" {
+		d.GroupReplenishRateStr = "@every 3s"
+		d.GroupReplenishRate = rate.Every(time.Second * 3)
+	} else {
+		if parsed, errParse := utils.ParseRate(d.GroupReplenishRateStr); errParse == nil {
+			d.GroupReplenishRate = parsed
+		} else {
+			d.Logger.Errorf("解析GroupReplenishRate失败: %v", errParse)
+			d.GroupReplenishRateStr = "@every 3s"
+			d.GroupReplenishRate = rate.Every(time.Second * 3)
+		}
+	}
+
+	d.GroupBurst = dNew.GroupBurst
+	if d.GroupBurst <= 0 {
+		d.GroupBurst = 3
+	}
+
+	if d.DiceMasters == nil || len(d.DiceMasters) == 0 {
+		d.DiceMasters = []string{"UI:1001"}
+	}
+	var newDiceMasters []string
+	for _, i := range d.DiceMasters {
+		if i != "<平台,如QQ>:<帐号,如QQ号>" {
+			newDiceMasters = append(newDiceMasters, i)
+		}
+	}
+	d.DiceMasters = newDiceMasters
+	// 装载ServiceAt
+	d.ImSession.ServiceAtNew = map[string]*GroupInfo{}
+	_ = model.GroupInfoListGet(d.DBData, func(id string, updatedAt int64, data []byte) {
+		var groupInfo GroupInfo
+		err := json.Unmarshal(data, &groupInfo)
+		if err == nil {
+			groupInfo.GroupID = id
+			groupInfo.UpdatedAtTime = updatedAt
+
+			// 找出其中以群号开头的，这是1.2版本的bug
+			var toDelete []string
+			if groupInfo.DiceIDExistsMap != nil {
+				groupInfo.DiceIDExistsMap.Range(func(key string, value bool) bool {
+					if strings.HasPrefix(key, "QQ-Group:") {
+						toDelete = append(toDelete, key)
+					}
+					return true
+				})
+				for _, i := range toDelete {
+					groupInfo.DiceIDExistsMap.Delete(i)
+				}
+			}
+			d.ImSession.ServiceAtNew[id] = &groupInfo
+		} else {
+			d.Logger.Errorf("加载群信息失败: %s", id)
+		}
+	})
+
+	m := map[string]*ExtInfo{}
+	for _, i := range d.ExtList {
+		m[i.Name] = i
+	}
+
+	// 设置群扩展
+	for _, v := range d.ImSession.ServiceAtNew {
+		var tmp []*ExtInfo
+		for _, i := range v.ActivatedExtList {
+			if m[i.Name] != nil {
+				tmp = append(tmp, m[i.Name])
+			}
+		}
+		v.ActivatedExtList = tmp
+	}
+
+	// 读取群变量
+	for _, g := range d.ImSession.ServiceAtNew {
+		// 群组数据
+		if g.ValueMap == nil {
+			g.ValueMap = lockfree.NewHashMap()
+		}
+
+		data := model.AttrGroupGetAll(d.DBData, g.GroupID)
+		if len(data) != 0 {
+			mapData := make(map[string]*VMValue)
+			err := JSONValueMapUnmarshal(data, &mapData)
+			if err != nil {
+				d.Logger.Error("读取群变量失败: ", err)
+			}
+			for k, v := range mapData {
+				g.ValueMap.Set(k, v)
+			}
+		}
+		if g.DiceIDActiveMap == nil {
+			g.DiceIDActiveMap = new(SyncMap[string, bool])
+		}
+		if g.DiceIDExistsMap == nil {
+			g.DiceIDExistsMap = new(SyncMap[string, bool])
+		}
+		if g.BotList == nil {
+			g.BotList = new(SyncMap[string, bool])
+		}
+	}
+
+	if d.VersionCode != 0 && d.VersionCode < 10000 {
+		d.CustomReplyConfigEnable = false
+	}
+
+	if d.VersionCode != 0 && d.VersionCode < 10001 {
+		d.AliveNoticeValue = "@every 3h"
+	}
+
+	if d.VersionCode != 0 && d.VersionCode < 10003 {
+		d.Logger.Infof("进行配置文件版本升级: %d -> %d", d.VersionCode, 10003)
 		d.LogSizeNoticeCount = 500
 		d.LogSizeNoticeEnable = true
+		d.CustomReplyConfigEnable = true
+	}
 
-		// 1.2
-		d.QQEnablePoke = true
+	if d.VersionCode != 0 && d.VersionCode < 10004 {
+		d.AutoReloginEnable = false
+	}
+
+	if d.VersionCode != 0 && d.VersionCode < 10005 {
+		d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
+			d.Logger.Info("正在自动升级自定义文案文件")
+			for index, text := range d.TextMapRaw["核心"]["昵称_重置"] {
+				srcText := text[0].(string)
+				srcText = strings.ReplaceAll(srcText, "{$tQQ昵称}", "{$t旧昵称}")
+				srcText = strings.ReplaceAll(srcText, "{$t帐号昵称}", "{$t旧昵称}")
+				d.TextMapRaw["核心"]["昵称_重置"][index][0] = srcText
+			}
+
+			for index, text := range d.TextMapRaw["核心"]["角色管理_删除成功"] {
+				srcText := text[0].(string)
+				srcText = strings.ReplaceAll(srcText, "{$t新角色名}", "{$t角色名}")
+				d.TextMapRaw["核心"]["角色管理_删除成功"][index][0] = srcText
+			}
+
+			SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
+			d.GenerateTextMap()
+			d.SaveText()
+		})
+	}
+
+	// 1.2 版本
+	if d.VersionCode != 0 && d.VersionCode < 10200 {
 		d.TextCmdTrustOnly = true
+		d.QQEnablePoke = true
 		d.PlayerNameWrapEnable = true
-		d.DiceMasters = []string{"UI:1001"}
 
-		// 1.3
+		isUI1001Master := false
+		for _, i := range d.DiceMasters {
+			if i == "UI:1001" {
+				isUI1001Master = true
+				break
+			}
+		}
+		if !isUI1001Master {
+			d.DiceMasters = append(d.DiceMasters, "UI:1001")
+		}
+
+		d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
+			// 更正写反的部分
+			d.Logger.Info("正在自动升级自定义文案文件")
+			for index := range d.TextMapRaw["COC"]["属性设置_保存提醒"] {
+				srcText := `{ $t当前绑定角色 ? '[√] 已绑卡' : '' }`
+				d.TextMapRaw["COC"]["属性设置_保存提醒"][index][0] = srcText
+			}
+
+			SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
+			d.GenerateTextMap()
+			d.SaveText()
+		})
+	}
+
+	// 1.2 版本
+	if d.VersionCode != 0 && d.VersionCode < 10203 {
+		d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
+			// 更正写反的部分
+			d.Logger.Info("正在自动升级自定义文案文件")
+			for index := range d.TextMapRaw["COC"]["属性设置_增减_单项"] {
+				srcText := "{$t属性}: {$t旧值} ➯ {$t新值} ({$t增加或扣除}{$t表达式文本}={$t变化量})"
+				d.TextMapRaw["COC"]["属性设置_增减_单项"][index][0] = srcText
+			}
+
+			SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
+			d.GenerateTextMap()
+			d.SaveText()
+		})
+	}
+
+	// 1.3 版本
+	if d.VersionCode != 0 && d.VersionCode < 10300 {
 		d.JsEnable = true
+
+		d.RunAfterLoaded = append(d.RunAfterLoaded, func() {
+			// 更正写反的部分
+			d.Logger.Info("正在自动升级自定义文案文件")
+			for index, text := range d.TextMapRaw["娱乐"]["鸽子理由"] {
+				srcText := text[0].(string)
+				srcText = strings.ReplaceAll(srcText, "在互联网上约到可爱美少女不惜搁置跑团前去约会的{$t玩家}，还不知道这个叫奈亚的妹子隐藏着什么", "空山不见人，但闻咕咕声。 —— {$t玩家}")
+				d.TextMapRaw["娱乐"]["鸽子理由"][index][0] = srcText
+			}
+
+			SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
+			d.GenerateTextMap()
+			d.SaveText()
+		})
+	}
+
+	// 设置全局群名缓存和用户名缓存
+	dm := d.Parent
+	now := time.Now().Unix()
+	for k, v := range d.ImSession.ServiceAtNew {
+		dm.GroupNameCache.Set(k, &GroupNameCacheItem{Name: v.GroupName, time: now})
 	}
 
 	_ = model.BanItemList(d.DBData, func(id string, banUpdatedAt int64, data []byte) {

--- a/dice/ext_coc7.go
+++ b/dice/ext_coc7.go
@@ -1461,21 +1461,19 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 		ShortHelp: ".coc (<数量>) // 制卡指令，返回<数量>组人物属性",
 		Solve: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) CmdExecuteResult {
 			n := cmdArgs.GetArgN(1)
-			val, err := strconv.ParseInt(n, 10, 64)
-			if err != nil {
-				// 数量不存在时，视为1次
+			val, _ := strconv.ParseInt(n, 10, 64)
+			if val <= 0 {
 				val = 1
-			}
-			if val > ctx.Dice.MaxCocCardGen {
+			} else if val > ctx.Dice.MaxCocCardGen {
 				val = ctx.Dice.MaxCocCardGen
 			}
-			var i int64
 
 			var ss []string
-			for i = 0; i < val; i++ {
+			for i := int64(0); i < val; i++ {
 				result, _, err := self.ExprText(`力量:{$t1=3d6*5} 敏捷:{$t2=3d6*5} 意志:{$t3=3d6*5}\n体质:{$t4=3d6*5} 外貌:{$t5=3d6*5} 教育:{$t6=(2d6+6)*5}\n体型:{$t7=(2d6+6)*5} 智力:{$t8=(2d6+6)*5}\nHP:{($t4+$t7)/10} 幸运:{$t9=3d6*5} [{$t1+$t2+$t3+$t4+$t5+$t6+$t7+$t8}/{$t1+$t2+$t3+$t4+$t5+$t6+$t7+$t8+$t9}]`, ctx)
 				if err != nil {
-					break
+					self.Logger.Errorf("coc card gen ExprText error at iter%d: %v", i, err)
+					continue
 				}
 				result = strings.ReplaceAll(result, `\n`, "\n")
 				ss = append(ss, result)


### PR DESCRIPTION
进行的修改: load 时, 如果 `serve.yaml` 文件正常, 从文件里读取数据到 `dNew`; 如果文件不正常, 直接赋予 `dNew` 一些配置项初始值. 不论文件状态, 都走一遍从 `dNew` 到当前 `Dice` 的赋值逻辑.
> 之前的逻辑: 如果文件不正常(不存在), 不会进行 `dNew` 到当前 `Dice` 的赋值逻辑.