### PR TITLE
feat(official-qq): 完善官方 qq bot 频道私信部分，并增加 .stm 命令用于恢复私信

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -2160,6 +2160,21 @@ func (d *Dice) registerCoreCommands() {
 		},
 	}
 	d.CmdMap["reply"] = cmdReply
+
+	cmdStm := &CmdItemInfo{
+		Name:      "stm",
+		ShortHelp: ".stm // 触发发送一条频道私信",
+		Help:      "从QQ频道触发发送一条频道私信消息，避免由于超过限制条数未回复，导致与骰子的私信被彻底锁定:\n.stm",
+		Solve: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) CmdExecuteResult {
+			if msg.Platform == "OpenQQCH" &&
+				strings.HasPrefix(msg.GuildID, "OpenQQCH-Guild:") &&
+				strings.HasPrefix(msg.GroupID, "OpenQQCH-Channel:") {
+				ReplyPerson(ctx, msg, DiceFormatTmpl(ctx, "其它:私信恢复"))
+			}
+			return CmdExecuteResult{Matched: true, Solved: true}
+		},
+	}
+	d.CmdMap["stm"] = cmdStm
 }
 
 func getDefaultDicePoints(ctx *MsgContext) int64 {

--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -405,7 +405,7 @@ func AtParse(cmd string, prefix string) (string, []*AtInfo) {
 	switch prefix {
 	case "QQ":
 		re = regexp.MustCompile(`\[CQ:at,qq=(\d+?)]`)
-	case "OpenQQ":
+	case "OpenQQ", "OpenQQCH":
 		re = regexp.MustCompile(`<@!?(\S+?)>`)
 	case "DISCORD":
 		re = regexp.MustCompile(`<@(\d+?)>`)

--- a/dice/config.go
+++ b/dice/config.go
@@ -91,11 +91,11 @@ func (cm *ConfigManager) RegisterPluginConfig(pluginName string, configItems ...
 	//	"int":    true,
 	//	"float":  true,
 	//	"array":  true,
-	//}
+	// }
 
 	// var isValidType = func(t string) bool {
 	//	return allowedTypes[t]
-	//}
+	// }
 
 	// Check if the plugin already exists
 	if existingPlugin, ok := cm.Plugins[pluginName]; ok {
@@ -826,6 +826,9 @@ func setupBaseTextTemplate(d *Dice) {
 			"戳一戳": {
 				{"{核心:骰子名字}咕踊了一下", 1},
 			},
+			"私信恢复": {
+				{"这里是{核心:骰子名字}", 1},
+			},
 		},
 		"日志": {
 			"记录_新建": {
@@ -1434,6 +1437,10 @@ func setupBaseTextTemplate(d *Dice) {
 			},
 			"戳一戳": {
 				SubType: "手机QQ功能",
+			},
+			"私信恢复": {
+				SubType:   "官方QQ协议功能",
+				ExtraText: "使用.stm命令恢复频道私信时的提示语",
 			},
 		},
 		"日志": {

--- a/dice/im_helpers.go
+++ b/dice/im_helpers.go
@@ -110,6 +110,9 @@ func GetPlayerInfoBySender(ctx *MsgContext, msg *Message) (*GroupInfo, *GroupPla
 	if msg.GuildID != "" {
 		group.GuildID = msg.GuildID
 	}
+	if msg.ChannelID != "" {
+		group.ChannelID = msg.ChannelID
+	}
 	if group == nil {
 		return nil, nil
 	}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -590,16 +590,16 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 			}
 			for _, i := range ats {
 				// 特殊处理 OpenQQ 和 OpenQQCH
-				if strings.HasPrefix(i.UserID, "OpenQQ:") ||
+				if i.UserID == tmpUID {
+					amIBeMentioned = true
+					break
+				} else if strings.HasPrefix(i.UserID, "OpenQQ:") ||
 					strings.HasPrefix(i.UserID, "OpenQQCH:") {
 					uid := strings.TrimPrefix(tmpUID, "OpenQQ:")
 					if i.UserID == "OpenQQ:"+uid || i.UserID == "OpenQQCH:"+uid {
 						amIBeMentioned = true
 						break
 					}
-				} else if i.UserID == tmpUID {
-					amIBeMentioned = true
-					break
 				}
 			}
 			if amIBeMentioned {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -595,14 +595,11 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 					uid := strings.TrimPrefix(tmpUID, "OpenQQ:")
 					if i.UserID == "OpenQQ:"+uid || i.UserID == "OpenQQCH:"+uid {
 						amIBeMentioned = true
-						tmpUID = i.UserID
 						break
 					}
-				} else {
-					if i.UserID == tmpUID {
-						amIBeMentioned = true
-						break
-					}
+				} else if i.UserID == tmpUID {
+					amIBeMentioned = true
+					break
 				}
 			}
 			if amIBeMentioned {


### PR DESCRIPTION
1. 完善官方 qq bot 频道私信部分
2. 由于频道中发送超过3条私信且未获得回复时，禁止再次发送私信，而这会让发送超过3条无响应私信的用户一直在等待回复，无法再向骰子发送任何私信。故增加一个 .stm (send to me) 命令，允许在频道中向骰子发送该命令，让骰子主动发送私信打破锁定。