### PR TITLE
fix(official-qq): 修复official qq频道中的一些问题

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -38,6 +38,12 @@ func (i *AtInfo) CopyCtx(ctx *MsgContext) (*MsgContext, bool) {
 				ValueMapTemp:  lockfree.NewHashMap(),
 				UpdatedAtTime: 0,
 			}
+			// 特殊处理 official qq
+			if strings.HasPrefix(i.UserID, "OpenQQCH:") {
+				mctx.Player.Name = "<@!" + strings.TrimPrefix(i.UserID, "OpenQQCH:") + ">"
+			} else if strings.HasPrefix(i.UserID, "OpenQQ-Member-T:") {
+				mctx.Player.Name = i.UserID[len(i.UserID)-4:]
+			}
 		}
 		return mctx, p != nil
 	}

--- a/dice/ext_coc7.go
+++ b/dice/ext_coc7.go
@@ -665,13 +665,24 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 				}
 				ctx1 := ctx
 				ctx2 := ctx
-				if len(cmdArgs.At) == 1 {
-					// 单人
-					ctx2, _ = cmdArgs.At[0].CopyCtx(ctx)
-				}
-				if len(cmdArgs.At) == 2 {
-					ctx1, _ = cmdArgs.At[0].CopyCtx(ctx)
-					ctx2, _ = cmdArgs.At[1].CopyCtx(ctx)
+
+				if cmdArgs.AmIBeMentionedFirst {
+					// 第一个at的是骰子，不计为 at的人
+					if len(cmdArgs.At) == 2 {
+						// 单人
+						ctx2, _ = cmdArgs.At[1].CopyCtx(ctx)
+					} else if len(cmdArgs.At) == 3 {
+						ctx1, _ = cmdArgs.At[1].CopyCtx(ctx)
+						ctx2, _ = cmdArgs.At[2].CopyCtx(ctx)
+					}
+				} else {
+					if len(cmdArgs.At) == 1 {
+						// 单人
+						ctx2, _ = cmdArgs.At[0].CopyCtx(ctx)
+					} else if len(cmdArgs.At) == 2 {
+						ctx1, _ = cmdArgs.At[0].CopyCtx(ctx)
+						ctx2, _ = cmdArgs.At[1].CopyCtx(ctx)
+					}
 				}
 
 				restText := cmdArgs.CleanArgs

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1176,6 +1176,13 @@ func (s *IMSession) commandSolve(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs
 				for index, i := range cmdArgs.At {
 					if i.UserID == ctx.EndPoint.UserID {
 						continue
+					} else if strings.HasPrefix(ctx.EndPoint.UserID, "OpenQQ:") {
+						// 特殊处理 OpenQQ频道
+						uid := strings.TrimPrefix(i.UserID, "OpenQQCH:")
+						diceId := strings.TrimPrefix(ctx.EndPoint.UserID, "OpenQQ:")
+						if uid == diceId {
+							continue
+						}
 					}
 					cur = index
 				}

--- a/dice/utils.go
+++ b/dice/utils.go
@@ -261,6 +261,13 @@ func GetCtxProxyAtPosRaw(ctx *MsgContext, cmdArgs *CmdArgs, pos int, setTempVar 
 	for _, i := range cmdArgs.At {
 		if i.UserID == ctx.EndPoint.UserID {
 			continue
+		} else if strings.HasPrefix(ctx.EndPoint.UserID, "OpenQQ:") {
+			// 特殊处理 OpenQQ频道
+			uid := strings.TrimPrefix(i.UserID, "OpenQQCH:")
+			diceId := strings.TrimPrefix(ctx.EndPoint.UserID, "OpenQQ:")
+			if uid == diceId {
+				continue
+			}
 		}
 
 		if pos != cur {


### PR DESCRIPTION
1. official qq频道无法响应涉及代骰的指令
2. official qq频道，rav 指令识别出错，认为第一个玩家是骰子本身