### PR TITLE
feat(helpdoc): helpdoc 支持分组别名

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -434,6 +434,8 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.POST(prefix+"/helpdoc/upload", helpDocUpload)
 	e.POST(prefix+"/helpdoc/delete", helpDocDelete)
 	e.POST(prefix+"/helpdoc/textitem/get_page", helpGetTextItemPage)
+	e.GET(prefix+"/helpdoc/config", helpGetConfig)
+	e.POST(prefix+"/helpdoc/config", helpSetConfig)
 
 	e.GET(prefix+"/story/info", storyGetInfo)
 	e.GET(prefix+"/story/logs", storyGetLogs)

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -192,7 +192,14 @@ func (d *Dice) registerCoreCommands() {
 			)
 			if _group := cmdArgs.GetArgN(1); strings.HasPrefix(_group, "#") {
 				useGroupSearch = true
-				group = strings.TrimPrefix(_group, "#")
+				fakeGroup := strings.TrimPrefix(_group, "#")
+
+				// 转换 group 别名
+				if _g, ok := d.Parent.Help.GroupAliases[fakeGroup]; ok {
+					group = _g
+				} else {
+					group = fakeGroup
+				}
 			}
 
 			var id string

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -203,7 +203,7 @@ func (d *Dice) registerCoreCommands() {
 			}
 			var groupStr string
 			if group != "" {
-				groupStr = "[仅" + group + "]"
+				groupStr = "[搜索分组" + group + "]"
 			}
 
 			var id string
@@ -322,7 +322,7 @@ func (d *Dice) registerCoreCommands() {
 			var bestResult string
 			if showBest {
 				content := d.Parent.Help.GetContent(best, 0)
-				bestResult = fmt.Sprintf("最优先结果:\n词条: %s:%s\n%s\n\n", best.PackageName, best.Title, content)
+				bestResult = fmt.Sprintf("最优先结果%s:\n词条: %s:%s\n%s\n\n", groupStr, best.PackageName, best.Title, content)
 			}
 
 			prefix := d.Parent.Help.GetPrefixText()

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -201,6 +201,10 @@ func (d *Dice) registerCoreCommands() {
 					group = fakeGroup
 				}
 			}
+			var groupStr string
+			if group != "" {
+				groupStr = "[仅" + group + "]"
+			}
 
 			var id string
 			if cmdArgs.GetKwarg("rand") != nil || cmdArgs.GetKwarg("随机") != nil {
@@ -273,14 +277,14 @@ func (d *Dice) registerCoreCommands() {
 			}
 			search, total, pgStart, pgEnd, err := d.Parent.Help.Search(ctx, text, false, numLimit, page, group)
 			if err != nil {
-				ReplyToSender(ctx, msg, "搜索故障: "+err.Error())
+				ReplyToSender(ctx, msg, groupStr+"搜索故障: "+err.Error())
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 			if len(search.Hits) == 0 {
 				if total == 0 {
-					ReplyToSender(ctx, msg, "未找到搜索结果")
+					ReplyToSender(ctx, msg, groupStr+"未找到搜索结果")
 				} else {
-					ReplyToSender(ctx, msg, fmt.Sprintf("找到%d条结果, 但在当前页码并无结果", total))
+					ReplyToSender(ctx, msg, fmt.Sprintf("%s找到%d条结果, 但在当前页码并无结果", groupStr, total))
 				}
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
@@ -327,7 +331,7 @@ func (d *Dice) registerCoreCommands() {
 			// pgStart是下标闭左边界, 加1以获得序号; pgEnd是下标开右边界, 无需调整就是最后一条的序号
 			rplPageNum := fmt.Sprintf("共%d条结果, 当前显示第%d页(第%d条 到 第%d条)\n", total, page, pgStart+1, pgEnd)
 			rplPageHint := "使用\".find <词条> --page=<页码> 查看更多结果\n"
-			ReplyToSender(ctx, msg, prefix+bestResult+rplCurPage+rplDetailHint+rplPageNum+rplPageHint)
+			ReplyToSender(ctx, msg, prefix+groupStr+bestResult+rplCurPage+rplDetailHint+rplPageNum+rplPageHint)
 			return CmdExecuteResult{Matched: true, Solved: true}
 		},
 	}

--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	nanoid "github.com/matoous/go-nanoid/v2"
 
 	"github.com/blevesearch/bleve/v2"
@@ -67,15 +69,24 @@ func (e HelpTextItems) Len() int {
 }
 
 type HelpManager struct {
-	CurID       uint64
-	Index       bleve.Index
-	TextMap     map[string]*HelpTextItem
-	Parent      *DiceManager
-	EngineType  int
-	batch       *bleve.Batch
-	batchNum    int
-	LoadingFn   string
-	HelpDocTree []*HelpDoc
+	CurID        uint64
+	Index        bleve.Index
+	TextMap      map[string]*HelpTextItem
+	Parent       *DiceManager
+	EngineType   int
+	batch        *bleve.Batch
+	batchNum     int
+	LoadingFn    string
+	HelpDocTree  []*HelpDoc
+	GroupAliases map[string]string
+
+	Config *HelpConfig
+}
+
+const HelpConfigFilename = "help_config.yaml"
+
+type HelpConfig struct {
+	Aliases map[string][]string `yaml:"aliases" json:"aliases"`
 }
 
 func (m *HelpManager) GetNextID() string {
@@ -217,6 +228,10 @@ func (m *HelpManager) Load() {
 		if strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
+		if filepath.Base(entry.Name()) == HelpConfigFilename {
+			m.loadHelpConfig()
+			continue
+		}
 		var child HelpDoc
 		child.Key = generateHelpDocKey()
 		child.Name = entry.Name()
@@ -243,6 +258,47 @@ func (m *HelpManager) Load() {
 		m.HelpDocTree = append(m.HelpDocTree, &child)
 	}
 	_ = m.AddItemApply()
+}
+
+func (m *HelpManager) loadHelpConfig() {
+	data, err := os.ReadFile(filepath.Join("./data/helpdoc", HelpConfigFilename))
+	if err != nil {
+		panic(err)
+	}
+	var config HelpConfig
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		panic(err)
+	}
+	m.Config = &config
+	m.refreshHelpGroupAliases(config)
+}
+
+func (m *HelpManager) refreshHelpGroupAliases(config HelpConfig) {
+	// 先清空旧的别名
+	m.GroupAliases = make(map[string]string)
+	for group, aliases := range config.Aliases {
+		if len(aliases) > 0 {
+			for _, alias := range aliases {
+				m.GroupAliases[alias] = group
+			}
+		}
+	}
+}
+
+func (m *HelpManager) SaveHelpConfig(config *HelpConfig) error {
+	m.Config = config
+	m.refreshHelpGroupAliases(*config)
+
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filepath.Join("./data/helpdoc", HelpConfigFilename), data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *HelpManager) loadHelpDoc(group string, path string) bool {


### PR DESCRIPTION
支持配置帮助文档分组的别名，在按组搜索时可映射。如 `DND` 可增加别名 `dnd5e`，增加后 `.find #DND xxx` 与 `.find #dnd5e xxx` 均可限制仅搜索 `DND` 分组下的条目。

ui调整：sealdice/sealdice-ui#110
![image](https://github.com/sealdice/sealdice-core/assets/42864805/7c725531-effe-456f-8bb3-f5adaf50afb4)
![image](https://github.com/sealdice/sealdice-core/assets/42864805/427fb17e-93d6-42b1-b930-a4c892394bb6)
