### PR TITLE
feat(helpdoc): 支持设置默认的搜索分组

### DIFF
--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -870,3 +870,13 @@ func (m *HelpManager) GetHelpItemPage(pageNum, pageSize int, id, group, from, ti
 	}
 	return total, temp[start:]
 }
+
+// SetDefaultHelpGroup 设置群默认搜索分组
+func (group *GroupInfo) SetDefaultHelpGroup(target string) {
+	group.DefaultHelpGroup = target
+}
+
+// ClearDefaultHelpGroup 清空群指定搜索分组
+func (group *GroupInfo) ClearDefaultHelpGroup(target string) {
+	group.DefaultHelpGroup = ""
+}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -105,6 +105,8 @@ type GroupInfo struct {
 	TmpExtList   []string `yaml:"-" json:"tmpExtList"`
 
 	UpdatedAtTime int64 `yaml:"-" json:"-"`
+
+	DefaultHelpGroup string `yaml:"defaultHelpGroup" json:"defaultHelpGroup"` // 当前群默认的帮助文档分组
 }
 
 // ExtActive 开启扩展


### PR DESCRIPTION
1. 增加 `.find --set=<分组>` 命令，用于设置默认搜索分组；
2. 增加 `.find --setshow` 和 `.find --setclr` 命令，分别用于查看和清空；
3. 依然可以通过 `.find #分组` 来指定分组搜索，此时默认分组不生效。