### PR TITLE
fix: 修复单次触发多条回复时，每次都检查刷屏

### DIFF
--- a/dice/im_helpers.go
+++ b/dice/im_helpers.go
@@ -434,6 +434,11 @@ func spamCheckPerson(ctx *MsgContext, msg *Message) bool {
 		return false
 	}
 
+	// 同一个 ctx 只需检查一次
+	defer func() {
+		ctx.SpamCheckedPerson = true
+	}()
+
 	if ctx.PrivilegeLevel >= 100 {
 		return false
 	}
@@ -469,7 +474,6 @@ func spamCheckPerson(ctx *MsgContext, msg *Message) bool {
 		)
 	}
 
-	ctx.SpamCheckedPerson = true
 	return true
 }
 
@@ -477,6 +481,11 @@ func spamCheckGroup(ctx *MsgContext, msg *Message) bool {
 	if ctx.SpamCheckedGroup {
 		return false
 	}
+
+	// 同一个 ctx 只需检查一次
+	defer func() {
+		ctx.SpamCheckedGroup = true
+	}()
 
 	// Skip privileged groups
 	for _, g := range ctx.Dice.DiceMasters {
@@ -517,7 +526,6 @@ func spamCheckGroup(ctx *MsgContext, msg *Message) bool {
 		)
 	}
 
-	ctx.SpamCheckedGroup = true
 	return true
 }
 

--- a/dice/im_helpers.go
+++ b/dice/im_helpers.go
@@ -11,8 +11,10 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var sealCodeRe = regexp.MustCompile(`\[(img|图|文本|text|语音|voice|视频|video):(.+?)]`)
-var cqCodeRe = regexp.MustCompile(`\[CQ:.+?]`)
+var (
+	sealCodeRe = regexp.MustCompile(`\[(img|图|文本|text|语音|voice|视频|video):(.+?)]`)
+	cqCodeRe   = regexp.MustCompile(`\[CQ:.+?]`)
+)
 
 func IsCurGroupBotOnByID(session *IMSession, ep *EndPointInfo, messageType string, groupID string) bool {
 	a := messageType == "group" &&
@@ -357,9 +359,11 @@ type ByLength []string
 func (s ByLength) Len() int {
 	return len(s)
 }
+
 func (s ByLength) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
+
 func (s ByLength) Less(i, j int) bool {
 	return len(s[i]) > len(s[j])
 }
@@ -426,6 +430,10 @@ func FormatDiceID(ctx *MsgContext, id interface{}, isGroup bool) string {
 }
 
 func spamCheckPerson(ctx *MsgContext, msg *Message) bool {
+	if ctx.SpamCheckedPerson {
+		return false
+	}
+
 	if ctx.PrivilegeLevel >= 100 {
 		return false
 	}
@@ -460,10 +468,16 @@ func spamCheckPerson(ctx *MsgContext, msg *Message) bool {
 			"",
 		)
 	}
+
+	ctx.SpamCheckedPerson = true
 	return true
 }
 
 func spamCheckGroup(ctx *MsgContext, msg *Message) bool {
+	if ctx.SpamCheckedGroup {
+		return false
+	}
+
 	// Skip privileged groups
 	for _, g := range ctx.Dice.DiceMasters {
 		if ctx.Group.GroupID == g {
@@ -503,6 +517,7 @@ func spamCheckGroup(ctx *MsgContext, msg *Message) bool {
 		)
 	}
 
+	ctx.SpamCheckedGroup = true
 	return true
 }
 

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"regexp"
 	"runtime/debug"
-	"sealdice-core/dice/model"
 	"sort"
 	"strings"
 	"time"
+
+	"sealdice-core/dice/model"
 
 	"github.com/dop251/goja"
 	"github.com/fy0/lockfree"
@@ -459,6 +460,8 @@ type MsgContext struct {
 	diceExprOverwrite string                                      // 默认骰表达式覆盖
 	SystemTemplate    *GameSystemTemplate
 	Censored          bool // 已检查过敏感词
+	SpamCheckedGroup  bool
+	SpamCheckedPerson bool
 }
 
 // func (s *IMSession) GroupEnableCheck(ep *EndPointInfo, msg *Message, runInSync bool) {


### PR DESCRIPTION
在 MsgContext 中添加 SpamCheckGroup 和 SpamCheckPerson 两项，在同一上下文中若值为 true，将不会再检查是否刷屏并消耗令牌。