### PR TITLE
fix(log): 日志导出zip内部使用纯ASCII文件名,解决编码问题

### DIFF
--- a/dice/constants/constants.go
+++ b/dice/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+// 日志导出时使用的常量
+const (
+	LogExportTxtFilename    = "raw-log.txt"
+	LogExportJsonFilename   = "sealdice-standard-log.json"
+	LogExportReadmeFilename = "README.txt"
+	LogExportReadmeContent  = LogExportTxtFilename + ": 纯文本 Log\n" + LogExportJsonFilename + ": 海豹标准 Log, 粘贴到染色器可格式化\n"
+)

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sealdice-core/dice/constants"
 	"sealdice-core/dice/model"
 	"strings"
 	"time"
@@ -973,15 +974,21 @@ func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (string, 
 		text += fmt.Sprintf("%s(%v) %s\n%s\n\n", i.Nickname, i.IMUserID, timeTxt, i.Message)
 	}
 
-	fileWriter, _ := writer.Create("文本log.txt")
-	_, _ = fileWriter.Write([]byte(text))
+	{
+		wr, _ := writer.Create(constants.LogExportReadmeFilename)
+		_, _ = wr.Write([]byte(constants.LogExportReadmeContent))
+	}
+	{
+		fileWriter, _ := writer.Create(constants.LogExportTxtFilename)
+		_, _ = fileWriter.Write([]byte(text))
+	}
 
 	data, err := json.Marshal(map[string]interface{}{
 		"version": StoryVersion,
 		"items":   lines,
 	})
 	if err == nil {
-		fileWriter2, _ := writer.Create("海豹标准log-粘贴到染色器可格式化.txt")
+		fileWriter2, _ := writer.Create(constants.LogExportJsonFilename)
 		_, _ = fileWriter2.Write(data)
 	}
 


### PR DESCRIPTION
Close #513

效果如图

![IMG_0427](https://github.com/sealdice/sealdice-core/assets/45380560/cf6bb1cf-73bb-4490-b06d-67477a33baa9)
