### PR TITLE
fix(session): 自动清群发送告别语后等待3秒,避免退群过快导致消息发不出

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -986,6 +986,7 @@ func (s *IMSession) QuitInactiveGroup(threshold, hint time.Time) {
 					GroupID:     grp.GroupID,
 				})
 				ep.Adapter.SendToGroup(msgCtx, grp.GroupID, msgText, "")
+				time.Sleep(3 * time.Second)
 
 				grp.DiceIDExistsMap.Delete(ep.UserID)
 				grp.UpdatedAtTime = time.Now().Unix()


### PR DESCRIPTION
上一个 PR 合太快了，本来想一起处理的（