### PR TITLE
fix: 修复了当开启'忽略.bot裸指令'时，@其他人进行.bot会进行响应的问题

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -474,8 +474,15 @@ func (d *Dice) registerCoreCommands() {
 			inGroup := msg.MessageType == "group"
 			mentionNotBot := len(cmdArgs.At) > 0 && !cmdArgs.AmIBeMentionedFirst // 喊的不是当前骰子
 
-			if inGroup && ctx.Dice.IgnoreUnaddressedBotCmd && (len(cmdArgs.At) < 1 || mentionNotBot) {
-				return CmdExecuteResult{Matched: true, Solved: false}
+			if inGroup {
+				// 不响应裸指令选项
+				if len(cmdArgs.At) < 1 && ctx.Dice.IgnoreUnaddressedBotCmd {
+					return CmdExecuteResult{Matched: true, Solved: false}
+				}
+				// 不响应at其他人
+				if !cmdArgs.AmIBeMentionedFirst {
+					return CmdExecuteResult{Matched: true, Solved: false}
+				}
 			}
 
 			if len(cmdArgs.Args) > 0 && !cmdArgs.IsArgEqual(1, "about") { //nolint:nestif


### PR DESCRIPTION
如图所示，是一个逻辑问题
![ZTVMS_LD0$KWWBC$Z4@TH8Q](https://github.com/sealdice/sealdice-core/assets/1579850/c6542406-d3e8-4cac-bd4f-5c8712ac8c03)

原本的熔断机制，即 
![image](https://github.com/sealdice/sealdice-core/assets/1579850/71cf8cd1-7338-4caa-b18c-137f803b7467)
与“忽略裸指令”选项绑定在了一起

修复如下
![Q071M)T{CHOGOT}2U2D((79](https://github.com/sealdice/sealdice-core/assets/1579850/fb7c7572-b79c-4a04-943c-525bfc0b8cc9)
