### PR TITLE
feat(JS): 支持JS插件中直接修改群名片

### DIFF
--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -404,6 +404,8 @@ func (d *Dice) JsInit() {
 		})
 		// 1.2新增结束
 
+		_ = vm.Set("setPlayerGroupCard", SetPlayerGroupCardByTemplate)
+
 		// Note: Szzrain 暴露dice对象给js会导致js可以调用dice的所有Export的方法
 		// 这是不安全的, 所有需要用到dice实例的函数都可以以传入ctx作为替代
 		// _ = seal.Set("inst", d)


### PR DESCRIPTION
新增一个 `setPlayerGroupCard` 函数直接将 go 的 `SetPlayerGroupCardByTemplate` 暴露出去。

另：现在已有一个 `applyPlayerGroupCardByTemplate` 函数是通过修改自动设置模板来设置群名片。

没有经过测试。 

Close #543