### PR TITLE
fix: 修复 JS API `seal.ban.getUser()` 空指针时报错的问题

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -84,8 +84,8 @@ func (d *Dice) registerCoreCommands() {
 					return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 				}
 
-				item := d.BanList.GetByID(uid)
-				if item == nil || (item.Rank != BanRankBanned && item.Rank != BanRankTrusted && item.Rank != BanRankWarn) {
+				item, ok := d.BanList.GetByID(uid)
+				if !ok || (item.Rank != BanRankBanned && item.Rank != BanRankTrusted && item.Rank != BanRankWarn) {
 					ReplyToSender(ctx, msg, "找不到用户/群组")
 					break
 				}

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -219,8 +219,8 @@ func (i *BanListInfo) addJointScore(_ string, score int64, place string, reason 
 }
 
 func (i *BanListInfo) NoticeCheckPrepare(uid string) BanRankType {
-	item := i.GetByID(uid)
-	if item != nil {
+	item, ok := i.GetByID(uid)
+	if ok {
 		return item.Rank
 	}
 	return BanRankNormal
@@ -228,8 +228,8 @@ func (i *BanListInfo) NoticeCheckPrepare(uid string) BanRankType {
 
 func (i *BanListInfo) NoticeCheck(uid string, place string, oldRank BanRankType, ctx *MsgContext) BanRankType {
 	log := i.Parent.Logger
-	item := i.GetByID(uid)
-	if item == nil {
+	item, ok := i.GetByID(uid)
+	if !ok {
 		return 0
 	}
 
@@ -342,14 +342,13 @@ func (i *BanListInfo) AddScoreByCensor(uid string, score int64, place string, le
 	}
 }
 
-func (i *BanListInfo) GetByID(uid string) *BanListInfoItem {
-	v, _ := i.Map.Load(uid)
-	return v
+func (i *BanListInfo) GetByID(uid string) (*BanListInfoItem, bool) {
+	return i.Map.Load(uid)
 }
 
 func (i *BanListInfo) SetTrustByID(uid string, place string, reason string) {
-	v := i.GetByID(uid)
-	if v == nil {
+	v, ok := i.GetByID(uid)
+	if !ok {
 		v = &BanListInfoItem{
 			ID:      uid,
 			Reasons: []string{},

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -113,8 +113,8 @@ func (d *Dice) JsInit() {
 			d.BanList.SaveChanged(d)
 		})
 		_ = ban.Set("remove", func(ctx *MsgContext, id string) {
-			item := d.BanList.GetByID(id)
-			if item == nil {
+			_, ok := d.BanList.GetByID(id)
+			if !ok {
 				return
 			}
 			d.BanList.DeleteByID(d, id)
@@ -127,8 +127,13 @@ func (d *Dice) JsInit() {
 			})
 			return list
 		})
-		_ = ban.Set("getUser", func(id string) BanListInfoItem {
-			return *d.BanList.GetByID(id)
+		_ = ban.Set("getUser", func(id string) *BanListInfoItem {
+			i, ok := d.BanList.GetByID(id)
+			if !ok {
+				return nil
+			}
+			cp := *i
+			return &cp
 		})
 
 		ext := vm.NewObject()

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -954,7 +954,8 @@ func (s *IMSession) QuitInactiveGroup(threshold, hint time.Time) {
 			continue
 		}
 		if s.Parent.BanList != nil {
-			if info := s.Parent.BanList.GetByID(grp.GroupID); info != nil {
+			info, ok := s.Parent.BanList.GetByID(grp.GroupID)
+			if ok {
 				if info.Rank > BanRankNormal {
 					continue // 信任等级高于普通的不清理
 				}

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -511,8 +511,8 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 					// 处理被强制拉群的情况
 					uid := group.InviteUserID
-					banInfo := ctx.Dice.BanList.GetByID(uid)
-					if banInfo != nil {
+					banInfo, ok := ctx.Dice.BanList.GetByID(uid)
+					if ok {
 						if banInfo.Rank == BanRankBanned && ctx.Dice.BanList.BanBehaviorRefuseInvite {
 							// 如果是被ban之后拉群，判定为强制拉群
 							if group.EnteredTime > 0 && group.EnteredTime > banInfo.BanTime {
@@ -526,8 +526,8 @@ func (pa *PlatformAdapterGocq) Serve() int {
 					}
 
 					// 强制拉群情况2 - 群在黑名单
-					banInfo = ctx.Dice.BanList.GetByID(groupID)
-					if banInfo != nil {
+					banInfo, ok = ctx.Dice.BanList.GetByID(groupID)
+					if ok {
 						if banInfo.Rank == BanRankBanned {
 							// 如果是被ban之后拉群，判定为强制拉群
 							if group.EnteredTime > 0 && group.EnteredTime > banInfo.BanTime {
@@ -575,8 +575,8 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			tempInviteMap2[msg.GroupID] = uid
 
 			// 邀请人在黑名单上
-			banInfo := ctx.Dice.BanList.GetByID(uid)
-			if banInfo != nil {
+			banInfo, ok := ctx.Dice.BanList.GetByID(uid)
+			if ok {
 				if banInfo.Rank == BanRankBanned && ctx.Dice.BanList.BanBehaviorRefuseInvite {
 					pa.SetGroupAddRequest(msgQQ.Flag, msgQQ.SubType, false, "黑名单")
 					return
@@ -591,8 +591,8 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			}
 
 			// 群在黑名单上
-			banInfo = ctx.Dice.BanList.GetByID(msg.GroupID)
-			if banInfo != nil {
+			banInfo, ok = ctx.Dice.BanList.GetByID(msg.GroupID)
+			if ok {
 				if banInfo.Rank == BanRankBanned {
 					pa.SetGroupAddRequest(msgQQ.Flag, msgQQ.SubType, false, "群黑名单")
 					return
@@ -667,8 +667,8 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			// 检查黑名单
 			extra := ""
 			uid := FormatDiceIDQQ(string(msgQQ.UserID))
-			banInfo := ctx.Dice.BanList.GetByID(uid)
-			if banInfo != nil {
+			banInfo, ok := ctx.Dice.BanList.GetByID(uid)
+			if ok {
 				if banInfo.Rank == BanRankBanned && ctx.Dice.BanList.BanBehaviorRefuseInvite {
 					if willAccept {
 						extra = "。回答正确，但为被禁止用户，准备自动拒绝"
@@ -880,8 +880,8 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 				skip := false
 				skipReason := ""
-				banInfo := ctx.Dice.BanList.GetByID(opUID)
-				if banInfo != nil {
+				banInfo, ok := ctx.Dice.BanList.GetByID(opUID)
+				if ok {
 					if banInfo.Rank == 30 {
 						skip = true
 						skipReason = "信任用户"

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -400,8 +400,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 				if event.UserID == event.Self.UserID {
 					skip := false
 					skipReason := ""
-					banInfo := ctx.Dice.BanList.GetByID(opUID)
-					if banInfo != nil {
+					banInfo, ok := ctx.Dice.BanList.GetByID(opUID)
+					if ok {
 						if banInfo.Rank == 30 {
 							skip = true
 							skipReason = "信任用户"
@@ -506,8 +506,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 				// 检查黑名单
 				extra := ""
 				uid := msg.Sender.UserID
-				banInfo := ctx.Dice.BanList.GetByID(uid)
-				if banInfo != nil {
+				banInfo, ok := ctx.Dice.BanList.GetByID(uid)
+				if ok {
 					if banInfo.Rank == BanRankBanned && ctx.Dice.BanList.BanBehaviorRefuseInvite {
 						if willAccept {
 							extra = "。回答正确，但为被禁止用户，准备自动拒绝"
@@ -560,8 +560,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 				// tempInviteMap2[msg.GroupId] = uid
 
 				// 邀请人在黑名单上
-				banInfo := ctx.Dice.BanList.GetByID(uid)
-				if banInfo != nil {
+				banInfo, ok := ctx.Dice.BanList.GetByID(uid)
+				if ok {
 					if banInfo.Rank == BanRankBanned && ctx.Dice.BanList.BanBehaviorRefuseInvite {
 						pa.SetGroupAddRequest(req.RequestID, event.GroupID, false)
 						return
@@ -574,8 +574,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 					return
 				}
 				// 群在黑名单上
-				banInfo = ctx.Dice.BanList.GetByID(gid)
-				if banInfo != nil {
+				banInfo, ok = ctx.Dice.BanList.GetByID(gid)
+				if ok {
 					if banInfo.Rank == BanRankBanned {
 						pa.SetGroupAddRequest(req.RequestID, event.GroupID, false)
 						return
@@ -639,8 +639,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 
 					// 处理被强制拉群的情况
 					uid := group.InviteUserID
-					banInfo := ctx.Dice.BanList.GetByID(uid)
-					if banInfo != nil {
+					banInfo, ok := ctx.Dice.BanList.GetByID(uid)
+					if ok {
 						if banInfo.Rank == BanRankBanned && ctx.Dice.BanList.BanBehaviorRefuseInvite {
 							// 如果是被ban之后拉群，判定为强制拉群
 							if group.EnteredTime > 0 && group.EnteredTime > banInfo.BanTime {
@@ -654,8 +654,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 					}
 
 					// 强制拉群情况2 - 群在黑名单
-					banInfo = ctx.Dice.BanList.GetByID(groupID)
-					if banInfo != nil {
+					banInfo, ok = ctx.Dice.BanList.GetByID(groupID)
+					if ok {
 						if banInfo.Rank == BanRankBanned {
 							// 如果是被ban之后拉群，判定为强制拉群
 							if group.EnteredTime > 0 && group.EnteredTime > banInfo.BanTime {


### PR DESCRIPTION
imp: 修改 `BanListInfo.GetByID()` 的返回值，现在它还会返回是否存在的 bool 作为第二个返回值