### PR TITLE
style: 使用 gofumpts 规范，优化 import 排序

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,6 @@ _help_cache
 .DS_Store
 !static/.nomedia
 
-.vscode/
+# .vscode/
 
 *.private.pem

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -240,7 +240,8 @@ linters:
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     #TooMany - gocyclo # computes and checks the cyclomatic complexity of functions
     #- godot # checks if comments end in a period
-    - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
+    - gofumpt
+    # - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
     #- gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
     - gomodguard # allow and block lists linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations
     - goprintffuncname # checks that printf-like functions are named with f at the end

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "[go]": {
+    "editor.defaultFormatter": "golang.go",
+    "editor.insertSpaces": false,
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  },
+  "go.formatTool": "gofumpt"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,12 @@
     "editor.insertSpaces": false,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
+  },
+  "go.useLanguageServer": true,
+  "gopls": {
+    "formatting.gofumpt": true
   },
   "go.formatTool": "gofumpt"
 }

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -1,15 +1,15 @@
 package api
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"runtime"
 	"sort"
 	"strings"
 	"time"
 
-	"encoding/hex"
-	"encoding/json"
-	"net/http"
 	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
@@ -85,8 +85,10 @@ func hello2(c echo.Context) error {
 	return c.JSON(http.StatusOK, nil)
 }
 
-var myDice *dice.Dice
-var dm *dice.DiceManager
+var (
+	myDice *dice.Dice
+	dm     *dice.DiceManager
+)
 
 func doSignInGetSalt(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{

--- a/api/backup.go
+++ b/api/backup.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sealdice-core/dice"
 	"strings"
 	"time"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )

--- a/api/ban.go
+++ b/api/ban.go
@@ -7,9 +7,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"sealdice-core/dice"
 	"strings"
 	"time"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )

--- a/api/censor.go
+++ b/api/censor.go
@@ -10,11 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strings"
+
 	"sealdice-core/dice"
 	"sealdice-core/dice/censor"
 	"sealdice-core/dice/model"
-	"sort"
-	"strings"
 
 	"github.com/golang-module/carbon"
 	"github.com/labstack/echo/v4"

--- a/api/conn.go
+++ b/api/conn.go
@@ -4,9 +4,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
 	"sort"
 	"time"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )

--- a/api/custom.go
+++ b/api/custom.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"net/http"
-	"sealdice-core/dice"
 	"strings"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )

--- a/api/deck.go
+++ b/api/deck.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice"
 	"strings"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )

--- a/api/dice.go
+++ b/api/dice.go
@@ -52,7 +52,7 @@ func DiceNewVersionUpload(c echo.Context) error {
 		fn += ".tar.gz"
 	}
 
-	f2, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	f2, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}

--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
-	"sealdice-core/utils"
 	"strconv"
 	"strings"
 	"time"
+
+	"sealdice-core/dice"
+	"sealdice-core/utils"
 
 	"github.com/labstack/echo/v4"
 	"golang.org/x/time/rate"

--- a/api/group.go
+++ b/api/group.go
@@ -3,10 +3,11 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
-	"sealdice-core/dice/model"
 	"strings"
 	"time"
+
+	"sealdice-core/dice"
+	"sealdice-core/dice/model"
 
 	"github.com/labstack/echo/v4"
 )
@@ -89,7 +90,6 @@ func groupQuit(c echo.Context) error {
 		ExtraText string `yaml:"extraText" json:"extraText"`
 	}{}
 	err := c.Bind(&v)
-
 	if err != nil {
 		return c.String(430, "")
 	}

--- a/api/helpdoc.go
+++ b/api/helpdoc.go
@@ -3,6 +3,7 @@ package api
 import (
 	"mime/multipart"
 	"net/http"
+
 	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"

--- a/api/js.go
+++ b/api/js.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice"
 	"strings"
+
+	"sealdice-core/dice"
 
 	"github.com/dop251/goja"
 	"github.com/labstack/echo/v4"

--- a/api/misc.go
+++ b/api/misc.go
@@ -33,7 +33,7 @@ func upgrade(c echo.Context) error {
 				bakFn, _ := myDice.Parent.BackupSimple()
 				tmpParent := os.TempDir()
 				tmpPath := path.Join(tmpParent, bakFn)
-				_ = os.MkdirAll(filepath.Join(tmpParent, "backups"), 0644)
+				_ = os.MkdirAll(filepath.Join(tmpParent, "backups"), 0o644)
 				myDice.Logger.Infof("将备份文件复制到此路径: %s", tmpPath)
 				_ = cp.Copy(bakFn, tmpPath)
 

--- a/api/reply.go
+++ b/api/reply.go
@@ -5,8 +5,9 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"sealdice-core/dice"
 	"strings"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )

--- a/api/socks.go
+++ b/api/socks.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sealdice-core/dice"
 	"strconv"
 	"strings"
 	"time"
+
+	"sealdice-core/dice"
 
 	"github.com/armon/go-socks5"
 )
@@ -50,7 +51,6 @@ func isPrivateIP(ip net.IP) bool {
 
 func getClientIP() ([]string, error) {
 	addrs, err := net.InterfaceAddrs()
-
 	if err != nil {
 		return nil, err
 	}

--- a/api/story_log.go
+++ b/api/story_log.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+
 	"sealdice-core/dice"
 	"sealdice-core/dice/model"
 

--- a/api/utils.go
+++ b/api/utils.go
@@ -2,13 +2,12 @@ package api
 
 import (
 	"bytes"
-	"fmt"
-	"log"
-	"os"
-
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
+	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/alexmullins/zip"
@@ -30,7 +29,7 @@ func Error(c *echo.Context, errMsg string, res Response) error {
 }
 
 func Int64ToBytes(i int64) []byte {
-	var buf = make([]byte, 8)
+	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, uint64(i))
 	return buf
 }

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -64,7 +64,7 @@ func (d *Dice) registerCoreCommands() {
 				return arg
 			}
 
-			var val = cmdArgs.GetArgN(1)
+			val := cmdArgs.GetArgN(1)
 			var uid string
 			switch strings.ToLower(val) {
 			case "add":
@@ -128,7 +128,7 @@ func (d *Dice) registerCoreCommands() {
 				}
 				ReplyToSender(ctx, msg, text)
 			case "query":
-				var targetID = cmdArgs.GetArgN(2)
+				targetID := cmdArgs.GetArgN(2)
 				if targetID == "" {
 					ReplyToSender(ctx, msg, "未指定要查询的对象！")
 					break
@@ -140,7 +140,7 @@ func (d *Dice) registerCoreCommands() {
 					break
 				}
 
-				var text = fmt.Sprintf("所查询的<%s>情况：", targetID)
+				text := fmt.Sprintf("所查询的<%s>情况：", targetID)
 				switch v.Rank {
 				case BanRankBanned:
 					text += "禁止(-30)"
@@ -772,7 +772,7 @@ func (d *Dice) registerCoreCommands() {
 		updateCode      = "0000"
 	)
 
-	var masterListHelp = `.master add me // 将自己标记为骰主
+	masterListHelp := `.master add me // 将自己标记为骰主
 .master add @A @B // 将别人标记为骰主
 .master del @A @B @C // 去除骰主标记
 .master unlock <密码(在UI中查看)> // (当Master被人抢占时)清空骰主列表，并使自己成为骰主
@@ -920,7 +920,7 @@ func (d *Dice) registerCoreCommands() {
 					ReplyToSender(ctx, msg, "备份失败！错误已写入日志。可能是磁盘已满所致，建议立即进行处理！")
 				}
 			case "checkupdate":
-				var dm = ctx.Dice.Parent
+				dm := ctx.Dice.Parent
 				if dm.JustForTest {
 					ReplyToSender(ctx, msg, "此指令在展示模式下不可用")
 					return CmdExecuteResult{Matched: true, Solved: true}
@@ -977,7 +977,7 @@ func (d *Dice) registerCoreCommands() {
 
 					bakFn, _ := ctx.Dice.Parent.BackupSimple()
 					tmpPath := path.Join(os.TempDir(), bakFn)
-					_ = os.MkdirAll(tmpPath, 0644)
+					_ = os.MkdirAll(tmpPath, 0o644)
 					ctx.Dice.Logger.Infof("将备份文件复制到此路径: %s", tmpPath)
 					_ = cp.Copy(path.Join(BackupDir, bakFn), tmpPath)
 
@@ -989,7 +989,7 @@ func (d *Dice) registerCoreCommands() {
 				}()
 				dm.UpdateRequestChan <- d
 			case "reboot":
-				var dm = ctx.Dice.Parent
+				dm := ctx.Dice.Parent
 				if dm.JustForTest {
 					ReplyToSender(ctx, msg, "此指令在展示模式下不可用")
 					return CmdExecuteResult{Matched: true, Solved: true}

--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -464,8 +464,10 @@ func AtBuild(uid string) string {
 	return text
 }
 
-var reSpace = regexp.MustCompile(`\s+`)
-var reKeywordParam = regexp.MustCompile(`^--([^\s=]+)(?:=(\S+))?$`)
+var (
+	reSpace        = regexp.MustCompile(`\s+`)
+	reKeywordParam = regexp.MustCompile(`^--([^\s=]+)(?:=(\S+))?$`)
+)
 
 func ArgsParse(rawCmd string) *CmdArgs {
 	args := reSpace.Split(rawCmd, -1)

--- a/dice/config.go
+++ b/dice/config.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sealdice-core/dice/model"
-	"sealdice-core/utils"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"sealdice-core/dice/model"
+	"sealdice-core/utils"
 
 	"golang.org/x/time/rate"
 
@@ -22,11 +23,15 @@ import (
 )
 
 // type TextTemplateWithWeight = map[string]map[string]uint
-type TextTemplateItem = []interface{} // 实际上是 [](string | int) 类型
-type TextTemplateItemList []TextTemplateItem
+type (
+	TextTemplateItem     = []interface{} // 实际上是 [](string | int) 类型
+	TextTemplateItemList []TextTemplateItem
+)
 
-type TextTemplateWithWeight = map[string][]TextTemplateItem
-type TextTemplateWithWeightDict = map[string]TextTemplateWithWeight
+type (
+	TextTemplateWithWeight     = map[string][]TextTemplateItem
+	TextTemplateWithWeightDict = map[string]TextTemplateWithWeight
+)
 
 // TextTemplateHelpItem 辅助信息，用于UI中，大部分自动生成
 type TextTemplateHelpItem = struct {
@@ -41,8 +46,10 @@ type TextTemplateHelpItem = struct {
 	NotBuiltin      bool               `json:"notBuiltin"`      // 非内置
 	TopOrder        int                `json:"topOrder"`        // 置顶序号，越高越靠前
 }
-type TextTemplateHelpGroup = map[string]*TextTemplateHelpItem
-type TextTemplateWithHelpDict = map[string]TextTemplateHelpGroup
+type (
+	TextTemplateHelpGroup    = map[string]*TextTemplateHelpItem
+	TextTemplateWithHelpDict = map[string]TextTemplateHelpGroup
+)
 
 // const CONFIG_TEXT_TEMPLATE_FILE = "./data/configs/text-template.yaml"
 
@@ -213,7 +220,7 @@ func (cm *ConfigManager) ResetConfigToDefault(pluginName, key string) {
 }
 
 func (cm *ConfigManager) save() error {
-	file, err := os.OpenFile(cm.filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(cm.filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
@@ -2248,10 +2255,10 @@ func (d *Dice) SaveText() {
 		// ioutil.WriteFile(filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml"), buf, 0644)
 		current, err := os.ReadFile(newFn)
 		if err != nil {
-			_ = os.WriteFile(bakFn, current, 0644)
+			_ = os.WriteFile(bakFn, current, 0o644)
 		}
 
-		_ = os.WriteFile(newFn, buf, 0644)
+		_ = os.WriteFile(newFn, buf, 0o644)
 	}
 }
 
@@ -2323,7 +2330,7 @@ func (d *Dice) Save(isAuto bool) {
 		a, err := yaml.Marshal(d)
 
 		if err == nil {
-			err := os.WriteFile(filepath.Join(d.BaseConfig.DataDir, "serve.yaml"), a, 0644)
+			err := os.WriteFile(filepath.Join(d.BaseConfig.DataDir, "serve.yaml"), a, 0o644)
 			if err == nil {
 				now := time.Now()
 				d.LastSavedTime = &now

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"sealdice-core/dice/censor"
-	"sealdice-core/dice/logger"
-	"sealdice-core/dice/model"
 	"strconv"
 	"strings"
 	"time"
+
+	"sealdice-core/dice/censor"
+	"sealdice-core/dice/logger"
+	"sealdice-core/dice/model"
 
 	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
@@ -28,11 +29,15 @@ import (
 	rand2 "golang.org/x/exp/rand"
 )
 
-var APPNAME = "SealDice"
-var VERSION = "1.4.3f1 v20240110"
+var (
+	APPNAME = "SealDice"
+	VERSION = "1.4.3f1 v20240110"
+)
 
-var VERSION_CODE = int64(1004003) //nolint:revive
-var APP_BRANCH = ""               //nolint:revive
+var (
+	VERSION_CODE = int64(1004003) //nolint:revive
+	APP_BRANCH   = ""             //nolint:revive
+)
 
 type CmdExecuteResult struct {
 	Matched  bool // 是否是指令
@@ -289,12 +294,12 @@ func (d *Dice) CocExtraRulesAdd(ruleInfo *CocRuleInfo) bool {
 
 func (d *Dice) Init() {
 	d.BaseConfig.DataDir = filepath.Join("./data", d.BaseConfig.Name)
-	_ = os.MkdirAll(d.BaseConfig.DataDir, 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "configs"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extensions"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "log-exports"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extra"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "scripts"), 0755)
+	_ = os.MkdirAll(d.BaseConfig.DataDir, 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "configs"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extensions"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "log-exports"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extra"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "scripts"), 0o755)
 
 	d.Cron = cron.New()
 	d.Cron.Start()
@@ -530,7 +535,6 @@ func (d *Dice) ExprTextBase(buffer string, ctx *MsgContext, flags RollExtraFlags
 
 	// 隐藏的内置字符串符号 \x1e
 	val, detail, err := d.ExprEvalBase("\x1e"+buffer+"\x1e", ctx, flags)
-
 	if err != nil {
 		fmt.Println("脚本执行出错: ", buffer, "->", err)
 	}
@@ -727,7 +731,7 @@ func CrashLog() {
 	if r := recover(); r != nil {
 		text := fmt.Sprintf("报错: %v\n堆栈: %v", r, string(debug.Stack()))
 		now := time.Now()
-		_ = os.WriteFile(fmt.Sprintf("崩溃日志_%s.txt", now.Format("20060201_150405")), []byte(text), 0644)
+		_ = os.WriteFile(fmt.Sprintf("崩溃日志_%s.txt", now.Format("20060201_150405")), []byte(text), 0o644)
 		panic(r)
 	}
 }

--- a/dice/dice_backup.go
+++ b/dice/dice_backup.go
@@ -6,11 +6,12 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice/model"
-	"sealdice-core/utils"
 	"sort"
 	"strings"
 	"time"
+
+	"sealdice-core/dice/model"
+	"sealdice-core/utils"
 
 	"github.com/alexmullins/zip"
 )
@@ -52,7 +53,7 @@ type OneBackupConfig struct {
 }
 
 func (dm *DiceManager) Backup(cfg AllBackupConfig, bakFilename string) (string, error) {
-	_ = os.MkdirAll(BackupDir, 0755)
+	_ = os.MkdirAll(BackupDir, 0o755)
 
 	fzip, err := os.CreateTemp(BackupDir, bakFilename)
 	if err != nil {

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -3,9 +3,10 @@ package dice
 import (
 	"encoding/json"
 	"fmt"
-	"sealdice-core/dice/model"
 	"strings"
 	"time"
+
+	"sealdice-core/dice/model"
 
 	"github.com/robfig/cron/v3"
 )

--- a/dice/dice_censor.go
+++ b/dice/dice_censor.go
@@ -5,10 +5,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice/censor"
-	"sealdice-core/dice/model"
 	"sort"
 	"strings"
+
+	"sealdice-core/dice/censor"
+	"sealdice-core/dice/model"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -53,7 +54,7 @@ func (cm *CensorManager) Load(_ *Dice) {
 	fileDir := "./data/censor"
 	cm.IsLoading = true
 	cm.Censor.SensitiveKeys = make(map[string]censor.WordInfo)
-	_ = os.MkdirAll(fileDir, 0755)
+	_ = os.MkdirAll(fileDir, 0o755)
 	_ = filepath.Walk(fileDir, func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && (filepath.Ext(path) == ".txt" || filepath.Ext(path) == ".toml") {
 			cm.Parent.Logger.Infof("正在读取敏感词文件：%s\n", path)

--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -294,7 +294,7 @@ func (m *HelpManager) SaveHelpConfig(config *HelpConfig) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Join("./data/helpdoc", HelpConfigFilename), data, 0644)
+	err = os.WriteFile(filepath.Join("./data/helpdoc", HelpConfigFilename), data, 0o644)
 	if err != nil {
 		return err
 	}
@@ -742,7 +742,7 @@ func (m *HelpManager) UploadHelpDoc(src io.Reader, group string, name string) er
 	}
 
 	dirPath := filepath.Join("./data/helpdoc", group)
-	err := os.MkdirAll(dirPath, 0755)
+	err := os.MkdirAll(dirPath, 0o755)
 	if err != nil {
 		return err
 	}

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -12,11 +12,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sealdice-core/static"
-	"sealdice-core/utils/crypto"
 	"strconv"
 	"strings"
 	"time"
+
+	"sealdice-core/static"
+	"sealdice-core/utils/crypto"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/console"
@@ -152,7 +153,8 @@ func (d *Dice) JsInit() {
 			if d.JsLoadingScript != nil {
 				official = d.JsLoadingScript.Official
 			}
-			return &ExtInfo{Name: name, Author: author, Version: version,
+			return &ExtInfo{
+				Name: name, Author: author, Version: version,
 				GetDescText: GetExtensionDesc,
 				AutoActive:  true,
 				IsJsExt:     true,
@@ -510,7 +512,7 @@ func (d *Dice) JsLoadScripts() {
 
 	// 导出内置脚本数据
 	builtinScripts, _ := fs.ReadDir(static.Scripts, "scripts")
-	_ = os.MkdirAll(builtinPath, 0755)
+	_ = os.MkdirAll(builtinPath, 0o755)
 	for _, script := range builtinScripts {
 		if !script.IsDir() && filepath.Ext(script.Name()) == ".js" {
 			target := filepath.Join(builtinPath, script.Name())
@@ -519,13 +521,13 @@ func (d *Dice) JsLoadScripts() {
 			// 判断是否有更新后的内置脚本
 			_, err := os.Stat(target)
 			if errors.Is(err, os.ErrNotExist) {
-				_ = os.WriteFile(target, data, 0644)
+				_ = os.WriteFile(target, data, 0o644)
 			} else {
 				// 检查同名内置脚本的签名，检查不通过则覆盖
 				scriptData, _ := os.ReadFile(target)
 				if ok, _ := CheckJsSign(scriptData); !ok {
 					d.Logger.Warnf("已存在的内置脚本「%s」未通过校验，进行覆盖", script.Name())
-					_ = os.WriteFile(target, scriptData, 0644)
+					_ = os.WriteFile(target, scriptData, 0o644)
 				}
 			}
 		}
@@ -862,7 +864,7 @@ func (d *Dice) JsUpdate(jsScriptInfo *JsScriptInfo, tempFileName string) error {
 		return fmt.Errorf("new data is empty")
 	}
 	// 更新插件
-	err = os.WriteFile(jsScriptInfo.Filename, newData, 0755)
+	err = os.WriteFile(jsScriptInfo.Filename, newData, 0o755)
 	if err != nil {
 		d.Logger.Errorf("插件“%s”更新时保存文件出错，%s", jsScriptInfo.Name, err.Error())
 		return err

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -104,7 +104,7 @@ type DiceConfigs struct { //nolint:revive
 
 func (dm *DiceManager) InitHelp() {
 	dm.IsHelpReloading = true
-	_ = os.MkdirAll("./data/helpdoc", 0755)
+	_ = os.MkdirAll("./data/helpdoc", 0o755)
 	dm.Help = new(HelpManager)
 	dm.Help.Parent = dm
 	dm.Help.EngineType = dm.HelpDocEngineType
@@ -120,11 +120,11 @@ func (dm *DiceManager) LoadDice() {
 	dm.UserNameCache = lockfree.NewHashMap()
 	dm.UserIDCache = lockfree.NewHashMap()
 
-	_ = os.MkdirAll(BackupDir, 0755)
-	_ = os.MkdirAll("./data/images", 0755)
-	_ = os.MkdirAll("./data/decks", 0755)
-	_ = os.MkdirAll("./data/names", 0755)
-	_ = os.WriteFile("./data/images/sealdice.png", IconPNG, 0644)
+	_ = os.MkdirAll(BackupDir, 0o755)
+	_ = os.MkdirAll("./data/images", 0o755)
+	_ = os.MkdirAll("./data/decks", 0o755)
+	_ = os.MkdirAll("./data/names", 0o755)
+	_ = os.WriteFile("./data/images/sealdice.png", IconPNG, 0o644)
 
 	// this can be shared by multiple runtimes
 	dm.JsRegistry = new(require.Registry)
@@ -216,7 +216,7 @@ func (dm *DiceManager) Save() {
 
 	data, err := yaml.Marshal(dc)
 	if err == nil {
-		_ = os.WriteFile("./data/dice.yaml", data, 0644)
+		_ = os.WriteFile("./data/dice.yaml", data, 0o644)
 	}
 }
 

--- a/dice/dice_name_generator.go
+++ b/dice/dice_name_generator.go
@@ -16,7 +16,7 @@ type NamesGenerator struct {
 }
 
 func (ng *NamesGenerator) Load() {
-	_ = os.MkdirAll("./data/names", 0755)
+	_ = os.MkdirAll("./data/names", 0o755)
 
 	nameInfo := map[string]map[string][]string{}
 	ng.NamesInfo = nameInfo

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -39,7 +39,7 @@ func (d *Dice) RegisterExtension(extInfo *ExtInfo) {
 
 func (d *Dice) GetExtDataDir(extName string) string {
 	p := path.Join(d.BaseConfig.DataDir, "extensions", extName)
-	_ = os.MkdirAll(p, 0755)
+	_ = os.MkdirAll(p, 0o755)
 	return p
 }
 

--- a/dice/ext_coc7.go
+++ b/dice/ext_coc7.go
@@ -339,7 +339,6 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 					CocDefaultAttrOn: true,
 					DisableBlock:     true,
 				})
-
 				if err != nil {
 					ReplyToSender(mctx, msg, "解析出错: "+restText)
 					return &CmdExecuteResult{Matched: true, Solved: true}
@@ -363,7 +362,6 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 					CocDefaultAttrOn: true,
 					DisableBlock:     true,
 				})
-
 				if err != nil {
 					ReplyToSender(mctx, msg, "解析出错: "+expr2Text)
 					return &CmdExecuteResult{Matched: true, Solved: true}
@@ -393,8 +391,8 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 					detail1 = ""
 				}
 
-				var outcome = r1.Value.(int64)
-				var attrVal = r2.Value.(int64)
+				outcome := r1.Value.(int64)
+				attrVal := r2.Value.(int64)
 
 				successRank, criticalSuccessValue := ResultCheck(mctx, cocRule, outcome, attrVal, difficultyRequire)
 				// 根据难度需求，修改判定值
@@ -696,7 +694,6 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 						CocDefaultAttrOn: true,
 						DisableBlock:     true,
 					})
-
 					if err != nil {
 						ReplyToSender(ctx, msg, "解析出错: "+restText)
 						return &CmdExecuteResult{Matched: true, Solved: true}, 0, "", ""
@@ -1539,7 +1536,6 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 			"dnd5e",
 		},
 		OnLoad: func() {
-
 		},
 		OnCommandReceived: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) {
 			tmpl := getCoc7CharTemplate()

--- a/dice/ext_deck.go
+++ b/dice/ext_deck.go
@@ -1145,7 +1145,7 @@ func (d *Dice) DeckUpdate(deckInfo *DeckInfo, tempFileName string) error {
 		return fmt.Errorf("无法解析获取到的牌堆数据")
 	}
 
-	err = os.WriteFile(deckInfo.Filename, newData, 0755)
+	err = os.WriteFile(deckInfo.Filename, newData, 0o755)
 	if err != nil {
 		d.Logger.Errorf("牌堆“%s”更新时保存文件出错，%s", deckInfo.Name, err.Error())
 		return err

--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -25,9 +25,11 @@ type ByRIListValue []*RIListItem
 func (lst ByRIListValue) Len() int {
 	return len(lst)
 }
+
 func (lst ByRIListValue) Swap(i, j int) {
 	lst[i], lst[j] = lst[j], lst[i]
 }
+
 func (lst ByRIListValue) Less(i, j int) bool {
 	if lst[i].val == lst[j].val {
 		return lst[i].name > lst[j].name
@@ -117,7 +119,7 @@ func setupConfigDND(d *Dice) AttributeConfigs {
 	if err2 != nil {
 		fmt.Println(err2)
 	} else {
-		_ = os.WriteFile(attrConfigFn, buf, 0644)
+		_ = os.WriteFile(attrConfigFn, buf, 0o644)
 	}
 	return defaultVals
 }

--- a/dice/ext_exp.go
+++ b/dice/ext_exp.go
@@ -549,7 +549,6 @@ func getCmdStBase() *CmdItemInfo {
 				}
 
 				r, toSetItems, toModItems, err := cmdStReadOrMod(mctx, tmpl, input)
-
 				if err != nil {
 					dice.Logger.Info(".st 格式错误: ", err.Error())
 					return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}

--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -90,6 +90,7 @@ var guguText = `
 什么跑团？刚分手，别来烦我！{$t玩家}如是说道|蜜瓜包结合实际经历创作
 今天发大水，脑子被水淹了，跑不了团啦！|蜜瓜包结合实际经历创作
 `
+
 var emokloreAttrParent = map[string][]string{
 	"检索":   {"知力"},
 	"洞察":   {"知力"},
@@ -873,8 +874,8 @@ func RegisterBuiltinExtFun(self *Dice) {
 				}
 
 				// 创建pool后产生随机数，使用F-Y洗牌算法以保证随机性和效率
-				var pool = make([]int, roulette.Time)
-				var allNum = make([]int, roulette.Face)
+				pool := make([]int, roulette.Time)
+				allNum := make([]int, roulette.Face)
 				for i := range allNum {
 					allNum[i] = i + 1
 				}
@@ -892,7 +893,7 @@ func RegisterBuiltinExtFun(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 			// Draw mode
-			var isRouletteEmpty = true
+			isRouletteEmpty := true
 			rouletteMap.Range(func(key string, value singleRoulette) bool {
 				isRouletteEmpty = false
 				return false

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -11,11 +11,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice/constants"
-	"sealdice-core/dice/model"
 	"strings"
 	"time"
 	"unicode"
+
+	"sealdice-core/dice/constants"
+	"sealdice-core/dice/model"
 
 	"github.com/golang-module/carbon"
 
@@ -23,9 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	ErrGroupCardOverlong = errors.New("群名片长度超过限制")
-)
+var ErrGroupCardOverlong = errors.New("群名片长度超过限制")
 
 const StoryVersion = 101
 
@@ -702,7 +701,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 		AutoActive: true,
 		Official:   true,
 		OnLoad: func() {
-			_ = os.MkdirAll(filepath.Join(self.BaseConfig.DataDir, "log-exports"), 0755)
+			_ = os.MkdirAll(filepath.Join(self.BaseConfig.DataDir, "log-exports"), 0o755)
 		},
 		OnMessageSend: func(ctx *MsgContext, msg *Message, flag string) {
 			// 记录骰子发言
@@ -904,7 +903,7 @@ func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix s
 
 func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (string, error) {
 	dirpath := filepath.Join(ctx.Dice.BaseConfig.DataDir, "log-exports")
-	_ = os.MkdirAll(dirpath, 0755)
+	_ = os.MkdirAll(dirpath, 0o755)
 
 	url, uploadTS, updateTS, _ := model.LogGetUploadInfo(ctx.Dice.DBLogs, groupID, logName)
 	if len(url) > 0 && uploadTS > updateTS {

--- a/dice/ext_reply_logic.go
+++ b/dice/ext_reply_logic.go
@@ -235,7 +235,7 @@ func (c *ReplyConfig) Save(dice *Dice) {
 	if err != nil {
 		fmt.Println(err)
 	} else {
-		_ = os.WriteFile(attrConfigFn, buf, 0644)
+		_ = os.WriteFile(attrConfigFn, buf, 0o644)
 	}
 }
 

--- a/dice/ext_story.go
+++ b/dice/ext_story.go
@@ -320,7 +320,7 @@ func RegisterBuiltinStory(self *Dice) {
 				if val == "rec" {
 					isRec = true
 				}
-				var author = ""
+				author := ""
 				if val == "author" {
 					author = cmdArgs.GetArgN(2)
 				}

--- a/dice/game_system_template.go
+++ b/dice/game_system_template.go
@@ -118,6 +118,7 @@ func (t *GameSystemTemplate) GetDefaultValueEx(ctx *MsgContext, varname string) 
 	a, _, _, _ := t.GetDefaultValueEx0(ctx, varname)
 	return a
 }
+
 func (t *GameSystemTemplate) getShowAs0(ctx *MsgContext, k string) (*VMValue, error) {
 	// 有showas的情况
 	if expr, exists := t.AttrConfig.ShowAs[k]; exists {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -944,8 +944,10 @@ func (ep *EndPointInfo) TriggerCommand(mctx *MsgContext, msg *Message, cmdArgs *
 }
 
 // 借助类似操作系统信号量的思路来做一个互斥锁
-var muxAutoQuit sync.Mutex
-var groupLeaveNum int
+var (
+	muxAutoQuit   sync.Mutex
+	groupLeaveNum int
+)
 
 // LongTimeQuitInactiveGroup 另一种退群方案,其中minute代表间隔多久执行一次，num代表一次退几个群（每次退群之间有10秒的等待时间）
 func (s *IMSession) LongTimeQuitInactiveGroup(threshold, hint time.Time, roundIntervalMinute int, groupsPerRound int) {

--- a/dice/im_vars.go
+++ b/dice/im_vars.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sealdice-core/dice/model"
 	"strconv"
 	"strings"
 	"time"
+
+	"sealdice-core/dice/model"
 
 	"github.com/fy0/lockfree"
 )

--- a/dice/model/censor_log.go
+++ b/dice/model/censor_log.go
@@ -2,8 +2,9 @@ package model
 
 import (
 	"encoding/json"
-	"sealdice-core/dice/censor"
 	"time"
+
+	"sealdice-core/dice/censor"
 
 	"github.com/jmoiron/sqlx"
 )

--- a/dice/model/db.go
+++ b/dice/model/db.go
@@ -228,7 +228,8 @@ func SQLiteCensorDBInit(dataDir string) (censorDB *sqlx.DB, err error) {
 		return
 	}
 
-	texts := []string{`
+	texts := []string{
+		`
 CREATE TABLE IF NOT EXISTS censor_log
 (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/dice/model/db_utils.go
+++ b/dice/model/db_utils.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sealdice-core/utils/spinner"
 	"sync"
+
+	"sealdice-core/utils/spinner"
 )
 
 func DBCacheDelete() bool {

--- a/dice/model/group_info.go
+++ b/dice/model/group_info.go
@@ -99,7 +99,6 @@ func GroupPlayerInfoGet(db *sqlx.DB, groupID string, playerID string) *GroupPlay
 		"group_id": groupID,
 		"user_id":  playerID,
 	})
-
 	if err != nil {
 		fmt.Printf("error getting group player info: %s", err.Error())
 		return nil
@@ -107,11 +106,11 @@ func GroupPlayerInfoGet(db *sqlx.DB, groupID string, playerID string) *GroupPlay
 
 	defer rows.Close()
 
-	//Name:                stmt.ColumnText(0),
-	//UserId:              playerId,
-	//LastCommandTime:     stmt.ColumnInt64(2),
-	//AutoSetNameTemplate: stmt.ColumnText(3),
-	//DiceSideNum:         int(stmt.ColumnInt64(4)),
+	// Name:                stmt.ColumnText(0),
+	// UserId:              playerId,
+	// LastCommandTime:     stmt.ColumnInt64(2),
+	// AutoSetNameTemplate: stmt.ColumnText(3),
+	// DiceSideNum:         int(stmt.ColumnInt64(4)),
 
 	exists := false
 	for rows.Next() {

--- a/dice/model/log.go
+++ b/dice/model/log.go
@@ -289,7 +289,6 @@ FROM log_items
 WHERE log_id =$1
 ORDER BY time ASC
 LIMIT $2, $3;`, logID, (param.PageNum-1)*param.PageSize, param.PageSize)
-
 	if err != nil {
 		return nil, err
 	}

--- a/dice/platform_adapter_cqcode_helper.go
+++ b/dice/platform_adapter_cqcode_helper.go
@@ -111,6 +111,7 @@ func CQToText(t string, d map[string]string) MessageElement {
 	org += "]"
 	return newText(org)
 }
+
 func getFileName(header http.Header) string {
 	contentDisposition := header.Get("Content-Disposition")
 	if contentDisposition == "" {

--- a/dice/platform_adapter_dingtalk.go
+++ b/dice/platform_adapter_dingtalk.go
@@ -142,7 +142,6 @@ func (pa *PlatformAdapterDingTalk) EditMessage(_ *MsgContext, _, _ string) {}
 func (pa *PlatformAdapterDingTalk) RecallMessage(_ *MsgContext, _ string) {}
 
 func (pa *PlatformAdapterDingTalk) GetGroupInfoAsync(groupID string) {
-
 }
 
 func (pa *PlatformAdapterDingTalk) OnChatReceive(_ *dingtalk.Session, data *chatbot.BotCallbackDataModel) {

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -525,6 +525,7 @@ func FormatDiceIDDiscord(diceDiscord string) string {
 func FormatDiceIDDiscordChannel(diceDiscord string) string {
 	return fmt.Sprintf("DISCORD-CH-Group:%s", diceDiscord)
 }
+
 func FormatDiceIDDiscordGuild(diceDiscord string) string {
 	return fmt.Sprintf("DISCORD-Guild:%s", diceDiscord)
 }

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -595,6 +595,7 @@ func ExtractDodoGroupID(id string) string {
 	}
 	return id
 }
+
 func (pa *PlatformAdapterDodo) QuitGroup(ctx *MsgContext, groupId string) {
 	_, err := pa.Client.SetBotIslandLeave(context.Background(), &model.SetBotLeaveIslandReq{
 		IslandSourceId: ctx.Group.GuildID,

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -271,7 +271,6 @@ func FormatDiceIDQQChGroup(guildID, channelID string) string {
 func tryParseOneBot11ArrayMessage(log *zap.SugaredLogger, message string, writeTo *MessageQQ) error {
 	msgQQType2 := new(MessageQQArray)
 	err := json.Unmarshal([]byte(message), msgQQType2)
-
 	if err != nil {
 		log.Warn("无法解析 onebot11 字段:", message)
 		return err
@@ -421,7 +420,6 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 		msgQQ := new(MessageQQ)
 		err := json.Unmarshal([]byte(message), msgQQ)
-
 		if err != nil {
 			err = tryParseOneBot11ArrayMessage(log, message, msgQQ)
 
@@ -1209,7 +1207,7 @@ func (pa *PlatformAdapterGocq) SetQQProtocol(protocol int) bool {
 			info["protocol"] = protocol
 			data, err := json.Marshal(info)
 			if err == nil {
-				_ = os.WriteFile(deviceFilePath, data, 0644)
+				_ = os.WriteFile(deviceFilePath, data, 0o644)
 				return true
 			}
 		}
@@ -1240,7 +1238,7 @@ func (pa *PlatformAdapterGocq) SetSignServer(signServerConfig *SignServerConfig)
 			}
 			data, err := yaml.Marshal(info)
 			if err == nil {
-				_ = os.WriteFile(configFilePath, data, 0644)
+				_ = os.WriteFile(configFilePath, data, 0o644)
 				return true
 			}
 		}

--- a/dice/platform_adapter_gocq_channel.go
+++ b/dice/platform_adapter_gocq_channel.go
@@ -3,8 +3,9 @@ package dice
 import (
 	"encoding/json"
 	"fmt"
-	"sealdice-core/dice/model"
 	"strings"
+
+	"sealdice-core/dice/model"
 )
 
 type SenderChannel struct {
@@ -137,7 +138,7 @@ func (pa *PlatformAdapterGocq) SendToChannelGroup(ctx *MsgContext, userID string
 		a, _ := json.Marshal(oneBotCommand{
 			Action: "send_guild_channel_msg",
 			Params: GroupMessageParams{
-				//MessageType: "private",
+				// MessageType: "private",
 				GuildID:   lst[0],
 				ChannelID: lst[1],
 				Message:   subText,

--- a/dice/platform_adapter_gocq_helper.go
+++ b/dice/platform_adapter_gocq_helper.go
@@ -11,9 +11,10 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/debug"
-	"sealdice-core/utils/procs"
 	"strings"
 	"time"
+
+	"sealdice-core/utils/procs"
 
 	"github.com/ShiraazMoollatjie/goluhn"
 	"github.com/acarl005/stripansi"
@@ -581,7 +582,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 
 	if pa.UseInPackGoCqhttp { //nolint:nestif
 		workDir := gocqGetWorkDir(dice, conn)
-		_ = os.MkdirAll(workDir, 0755)
+		_ = os.MkdirAll(workDir, 0o755)
 
 		qrcodeFile := filepath.Join(workDir, "qrcode.png")
 		deviceFilePath := filepath.Join(workDir, "device.json")
@@ -604,7 +605,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		if _, err := os.Stat(deviceFilePath); errors.Is(err, os.ErrNotExist) {
 			_, deviceInfo, err := GenerateDeviceJSON(dice, loginInfo.Protocol)
 			if err == nil {
-				_ = os.WriteFile(deviceFilePath, deviceInfo, 0644)
+				_ = os.WriteFile(deviceFilePath, deviceInfo, 0o644)
 				dice.Logger.Info("onebot: 成功创建设备文件")
 			}
 		}
@@ -617,7 +618,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 			pa.ConnectURL = fmt.Sprintf("ws://localhost:%d", p)
 			qqid, _ := pa.mustExtractID(conn.UserID)
 			c := GenerateConfig(qqid, p, loginInfo)
-			_ = os.WriteFile(configFilePath, []byte(c), 0644)
+			_ = os.WriteFile(configFilePath, []byte(c), 0o644)
 		}
 
 		if versions, ok := GocqAppVersionMap[loginInfo.AppVersion]; ok {
@@ -625,10 +626,10 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 				// 删除旧协议版本文件
 				_ = os.RemoveAll(versionDirPath)
 				// 创建协议版本文件
-				_ = os.MkdirAll(versionDirPath, 0755)
+				_ = os.MkdirAll(versionDirPath, 0o755)
 				versionFilePath := filepath.Join(versionDirPath, fmt.Sprintf("%d.json", loginInfo.Protocol))
 				jsonData, _ := json.Marshal(targetVersion)
-				_ = os.WriteFile(versionFilePath, jsonData, 0644)
+				_ = os.WriteFile(versionFilePath, jsonData, 0o644)
 			}
 		}
 
@@ -638,7 +639,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		gocqhttpExePath = strings.ReplaceAll(gocqhttpExePath, "\\", "/") // windows平台需要这个替换
 
 		// 随手执行一下
-		_ = os.Chmod(gocqhttpExePath, 0755)
+		_ = os.Chmod(gocqhttpExePath, 0o755)
 
 		dice.Logger.Info("onebot: 正在启动onebot客户端…… ", gocqhttpExePath)
 		p := procs.NewProcess(fmt.Sprintf(`"%s" -faststart`, gocqhttpExePath))

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"fmt"
 	"path/filepath"
+
 	"sealdice-core/utils"
 )
 

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -173,6 +173,7 @@ func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(msgQQ *dto.WSGroupATMessag
 	}
 	return msg
 }
+
 func (pa *PlatformAdapterOfficialQQ) DoRelogin() bool {
 	pa.CancelFunc()
 	pa.Session.Parent.Logger.Infof("正在启用 official qq 服务")

--- a/dice/platform_adapter_red.go
+++ b/dice/platform_adapter_red.go
@@ -240,8 +240,7 @@ type RedEmojiZplan struct {
 	BytesReserveInfo string `json:"bytesReserveInfo,omitempty"`
 }
 
-type RedThumbPath struct {
-}
+type RedThumbPath struct{}
 
 type RedTextElement struct {
 	Content        string `json:"content,omitempty"`

--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -141,7 +141,6 @@ func (pa *PlatformAdapterSlack) Serve() int {
 	})
 	// Other
 	sh.HandleEvents(se.AppHomeOpened, func(event *sm.Event, client *sm.Client) {
-
 	})
 	// Start
 	pa.Client = client
@@ -243,11 +242,9 @@ func (pa *PlatformAdapterSlack) SetGroupCardName(ctx *MsgContext, name string) {
 }
 
 func (pa *PlatformAdapterSlack) MemberBan(groupId string, userId string, duration int64) {
-
 }
 
 func (pa *PlatformAdapterSlack) MemberKick(groupId string, userId string) {
-
 }
 
 func (pa *PlatformAdapterSlack) GetGroupInfoAsync(groupId string) {
@@ -296,6 +293,7 @@ func FormatDiceIDSlack(id string) string {
 func FormatDiceIDSlackChannel(id string) string {
 	return fmt.Sprintf("SLACK-CH-Group:%s", id)
 }
+
 func FormatDiceIDSlackGuild(id string) string {
 	return fmt.Sprintf("SLACK-Guild:%s", id)
 }

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -439,12 +439,15 @@ type RequestFileDataImpl struct {
 func (r *RequestFileDataImpl) NeedsUpload() bool {
 	return true
 }
+
 func (r *RequestFileDataImpl) UploadData() (string, io.Reader, error) {
 	return r.File, r.Reader, nil
 }
+
 func (r *RequestFileDataImpl) SendData() string {
 	return r.File
 }
+
 func (pa *PlatformAdapterTelegram) SendToChatRaw(uid string, text string) {
 	bot := pa.IntentSession
 	dice := pa.Session.Parent

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -9,12 +9,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
-	"sealdice-core/dice/model"
-	"sealdice-core/utils/procs"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
+
+	"sealdice-core/dice/model"
+	"sealdice-core/utils/procs"
 
 	"github.com/sacOO7/gowebsocket"
 )

--- a/dice/platform_adapter_walleq_helper.go
+++ b/dice/platform_adapter_walleq_helper.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"sealdice-core/utils/procs"
 	"strings"
 	"time"
+
+	"sealdice-core/utils/procs"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/uuid"
@@ -134,7 +135,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 	pa.WalleQState = WqStateCodeInLogin
 	fmt.Println("WalleQServe begin")
 	workDir := filepath.Join(dice.BaseConfig.DataDir, conn.RelWorkDir)
-	_ = os.MkdirAll(workDir, 0755)
+	_ = os.MkdirAll(workDir, 0o755)
 	log := dice.Logger
 	qrcodeFile := filepath.Join(workDir, "qrcode.png")
 	// deviceFilePath := filepath.Join(workDir, "device.json") // 暂时让他自己写
@@ -165,7 +166,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 		wqc.Onebot.HTTPWebhook = make([]interface{}, 0)
 		b := new(bytes.Buffer)
 		_ = toml.NewEncoder(b).Encode(wqc)
-		_ = os.WriteFile(configFilePath, b.Bytes(), 0644)
+		_ = os.WriteFile(configFilePath, b.Bytes(), 0o644)
 	} else { //nolint
 		// 如果决定使用单进程 wq
 		/*
@@ -187,7 +188,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 	wd, _ := os.Getwd()
 	wqExePath, _ := filepath.Abs(filepath.Join(wd, "walle-q/walle-q"))
 	wqExePath = strings.ReplaceAll(wqExePath, "\\", "/") // windows平台需要这个替换
-	_ = os.Chmod(wqExePath, 0755)
+	_ = os.Chmod(wqExePath, 0o755)
 
 	log.Info("onebot: 正在启动onebot客户端…… ", wqExePath)
 	p := procs.NewProcess(fmt.Sprintf(`"%s"`, wqExePath))
@@ -306,7 +307,7 @@ func (pa *PlatformAdapterWalleQ) SetQQProtocol(protocol int) bool {
 	}
 	b := new(bytes.Buffer)
 	_ = toml.NewEncoder(b).Encode(wqc)
-	_ = os.WriteFile(wd, b.Bytes(), 0644)
+	_ = os.WriteFile(wd, b.Bytes(), 0o644)
 	return true
 }
 

--- a/dice/roll.peg.go
+++ b/dice/roll.peg.go
@@ -908,6 +908,7 @@ func Size(size int) func(*DiceRollParser) error {
 		return nil
 	}
 }
+
 func (p *DiceRollParser) Init(options ...func(*DiceRollParser) error) error {
 	var (
 		max                  token32

--- a/dice/utils.go
+++ b/dice/utils.go
@@ -31,8 +31,10 @@ func RemoveSpace(s string) string {
 	return re.ReplaceAllString(s, "")
 }
 
-const letterBytes = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ123456789"
-const letterBytes2 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKMNOPQRSTUVWXYZ1234567890!@#$%^&*()_+=-"
+const (
+	letterBytes  = "abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ123456789"
+	letterBytes2 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKMNOPQRSTUVWXYZ1234567890!@#$%^&*()_+=-"
+)
 
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
@@ -344,14 +346,16 @@ func LockFreeMapToMap(m lockfree.HashMap) map[string]interface{} {
 
 var SVGIcon = []byte(`<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><defs><style>.cls-1{fill:#bdccd4;}.cls-2{fill:#fff;}</style></defs><title>icon-s</title><rect class="cls-1" x="6.36" y="7.14" width="498.86" height="498.86" rx="12"/><polygon class="cls-2" points="130.65 58.2 31.9 269.01 183.55 462.82 365.95 427.73 480.24 237.52 336.41 52 130.65 58.2"/><path d="M488.44,230.71,346.28,44.41h0a10.57,10.57,0,0,0-8.87-4.18L133.26,48.62h0a10.61,10.61,0,0,0-9.15,6L22.06,263h0a10.57,10.57,0,0,0,1.14,11.14l150.59,194.6a10.58,10.58,0,0,0,10.53,3.95L373.17,436l1.35-.46a10.59,10.59,0,0,0,5.72-4.71L489.16,242.44a10.6,10.6,0,0,0-.72-11.73ZM186,449.75l-24.1-187.3L385.9,376ZM364.21,107.21,159.67,244,140.55,72.87ZM149.65,248.53l-102.77,12L131.65,87.9ZM392.46,367.38,165.87,252.6l207-138.45,1.2,1.54,18.83,250.94ZM358.79,95.63,178.51,67.86,333,61.44ZM47.71,271.08l103.1-12L173.2,433.22ZM364.32,416l-120,23.36,135.29-49.82Zm38.14-65.88-16.62-219L467.21,238Z"/><polygon class="cls-2" points="157.03 220.4 160.14 249.69 178.19 258.84 374.4 120.32 373.55 108.64 358.48 106.33 157.03 220.4"/><path d="M297.84,193.19h0c-11-3.95-22.25-3.44-29.35,1.3-7.73,3.69-13.91,13-16.18,24.53C249,235.69,255,250.45,266,252.61c9.44,1.87,19.48-6.76,24-20.27,8.76,1.95,17,1,22.68-2.23a15,15,0,0,0,7-7.93C323.42,211.65,313.84,198.92,297.84,193.19Z"/><path d="M221.27,164c-8.94-3.2-18.77-2.18-27.68,2.88l-.08,0a44.16,44.16,0,0,0-19.37,23.68c-7.61,21.25,1.15,43.9,19.53,50.47,8.94,3.2,18.77,2.18,27.68-2.88l.08,0A44.16,44.16,0,0,0,240.8,214.5C248.41,193.25,239.65,170.61,221.27,164Z"/><ellipse class="cls-2" cx="194.6" cy="193" rx="21.33" ry="16.31" transform="translate(-62.71 287.4) rotate(-64.91)"/><circle class="cls-2" cx="225.91" cy="185.74" r="9.96"/><path d="M310.56,113.25a44.14,44.14,0,0,0-30.26,4.47,32.67,32.67,0,0,0-16.76,22.33c-3.78,19.15,11.16,38.29,33.3,42.66a44.15,44.15,0,0,0,30.26-4.47l.08-.05c8.92-5.06,14.84-13,16.68-22.28C347.64,136.76,332.7,117.62,310.56,113.25Z"/><ellipse class="cls-2" cx="286.98" cy="140.6" rx="21.33" ry="16.31" transform="translate(37.95 340.88) rotate(-64.91)"/><circle class="cls-2" cx="320.22" cy="132.25" r="9.96"/><ellipse cx="226.67" cy="154.45" rx="6.5" ry="9.75" transform="translate(-7.12 297.91) rotate(-65.8)"/><ellipse cx="252.33" cy="140.56" rx="9.75" ry="6.5" transform="translate(83.38 374.84) rotate(-83.32)"/></svg>`)
 
-var HelpMasterInfoDefault = "骰主很神秘，什么都没有说——"
-var HelpMasterLicenseDefault = "请在遵守以下规则前提下使用:\n" +
-	"1. 遵守国家法律法规\n" +
-	"2. 在跑团相关群进行使用\n" +
-	"3. 不要随意踢出、禁言、刷屏\n" +
-	"4. 务必信任骰主，有事留言\n" +
-	"如不同意使用.bot bye使其退群，谢谢。\n" +
-	"祝玩得愉快。"
+var (
+	HelpMasterInfoDefault    = "骰主很神秘，什么都没有说——"
+	HelpMasterLicenseDefault = "请在遵守以下规则前提下使用:\n" +
+		"1. 遵守国家法律法规\n" +
+		"2. 在跑团相关群进行使用\n" +
+		"3. 不要随意踢出、禁言、刷屏\n" +
+		"4. 务必信任骰主，有事留言\n" +
+		"如不同意使用.bot bye使其退群，谢谢。\n" +
+		"祝玩得愉快。"
+)
 
 var SimpleCocSuccessRankToText = map[int]string{
 	-2: "大失败",

--- a/format_go.py
+++ b/format_go.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+
+
+def scan_files(path):
+    gofiles = []
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if file.endswith(".go"):
+                filepath = os.path.join(root, file)
+                gofiles.append(filepath)
+    return gofiles
+
+
+def run_gofumpt(filename):
+    try:
+        formatted = subprocess.check_output(
+            ["gofumpt", filename], stderr=subprocess.STDOUT
+        )
+        with open(filename, "wb") as file:
+            file.write(formatted)
+    except subprocess.CalledProcessError as e:
+        print(f"Subprocess Error: {e.output.decode()}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    gofiles = scan_files(os.getcwd())
+    total = len(gofiles)
+    for index, file in enumerate(gofiles):
+        print(f"Formatting \x1b[33m{file}\x1b[0m... ({index + 1}/{total})")
+        run_gofumpt(file)
+    print(f"All {total} files are formatted!")

--- a/main.go
+++ b/main.go
@@ -7,8 +7,16 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
+	"strings"
+	"syscall"
+	"time"
+
 	"sealdice-core/dice/model"
 	"sealdice-core/migrate"
 	"sealdice-core/static"
@@ -19,15 +27,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
-	"os"
-	"os/exec"
-	"os/signal"
-	"runtime/debug"
 	"sealdice-core/api"
 	"sealdice-core/dice"
-	"strings"
-	"syscall"
-	"time"
 	// _ "net/http/pprof"
 )
 
@@ -69,7 +70,7 @@ func cleanUpCreate(diceManager *dice.DiceManager) func() {
 				defer func() {
 					_ = recover()
 				}()
-				var dbData = d.DBData
+				dbData := d.DBData
 				if dbData != nil {
 					d.DBData = nil
 					_ = dbData.Close()
@@ -80,7 +81,7 @@ func cleanUpCreate(diceManager *dice.DiceManager) func() {
 				defer func() {
 					_ = recover()
 				}()
-				var dbLogs = d.DBLogs
+				dbLogs := d.DBLogs
 				if dbLogs != nil {
 					d.DBLogs = nil
 					_ = dbLogs.Close()
@@ -93,7 +94,7 @@ func cleanUpCreate(diceManager *dice.DiceManager) func() {
 				}()
 				cm := d.CensorManager
 				if cm != nil && cm.DB != nil {
-					var dbCensor = cm.DB
+					dbCensor := cm.DB
 					cm.DB = nil
 					_ = dbCensor.Close()
 				}
@@ -208,7 +209,7 @@ func main() {
 	}
 	dnsHack()
 
-	_ = os.MkdirAll("./data", 0755)
+	_ = os.MkdirAll("./data", 0o755)
 	MainLoggerInit("./data/main.log", true)
 
 	// 提早初始化是为了读取ServiceName
@@ -253,7 +254,7 @@ func main() {
 		if doNext {
 			// 只有不同文件才进行校验
 			// windows平台旧版本到1.4.0流程
-			_ = os.WriteFile("./升级失败指引.txt", []byte("如果升级成功不用理会此文档，直接删除即可。\r\n\r\n如果升级后无法启动，或再次启动后恢复到旧版本，先不要紧张。\r\n你升级前的数据备份在backups目录。\r\n如果无法启动，请删除海豹目录中的\"update\"、\"auto_update.exe\"并手动进行升级。\n如果升级成功但在再次重启后回退版本，同上。\n\n如有其他问题可以加企鹅群询问：524364253 562897832"), 0644)
+			_ = os.WriteFile("./升级失败指引.txt", []byte("如果升级成功不用理会此文档，直接删除即可。\r\n\r\n如果升级后无法启动，或再次启动后恢复到旧版本，先不要紧张。\r\n你升级前的数据备份在backups目录。\r\n如果无法启动，请删除海豹目录中的\"update\"、\"auto_update.exe\"并手动进行升级。\n如果升级成功但在再次重启后回退版本，同上。\n\n如有其他问题可以加企鹅群询问：524364253 562897832"), 0o644)
 			logger.Warn("检测到 auto_update.exe，即将自动退出当前程序并进行升级")
 			logger.Warn("程序目录下会出现“升级日志.log”，这代表升级正在进行中，如果失败了请检查此文件。")
 

--- a/migrate/convert_logs.go
+++ b/migrate/convert_logs.go
@@ -92,7 +92,7 @@ type MsgContext struct {
 }
 
 func BoltDBInit(path string) *bbolt.DB {
-	db, err := bbolt.Open(path, 0644, nil)
+	db, err := bbolt.Open(path, 0o644, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/migrate/convert_serve.go
+++ b/migrate/convert_serve.go
@@ -280,7 +280,7 @@ create table if not exists ban_info
 		fmt.Println("群成员数量", times)
 	}
 
-	_ = os.WriteFile("./data/default/serve.yaml.old", data, 0644)
+	_ = os.WriteFile("./data/default/serve.yaml.old", data, 0o644)
 
 	// 处理attrs部分
 	ctx := CreateFakeCtx()

--- a/migrate/log_item_fix_type.go
+++ b/migrate/log_item_fix_type.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+
 	"sealdice-core/utils/spinner"
 )
 

--- a/migrate/v131_deprecated_config.go
+++ b/migrate/v131_deprecated_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
 	"sealdice-core/dice"
 
 	"gopkg.in/yaml.v3"
@@ -106,11 +107,11 @@ func V131DeprecatedConfig2CustomText() error {
 			return err
 		}
 		// 先备份
-		err = os.WriteFile(customTextBakPath, customTextData, 0644)
+		err = os.WriteFile(customTextBakPath, customTextData, 0o644)
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(customTextPath, newData, 0644)
+		err = os.WriteFile(customTextPath, newData, 0o644)
 		if err != nil {
 			return err
 		}
@@ -131,7 +132,7 @@ func V131DeprecatedConfig2CustomText() error {
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(confPath, newData2, 0644)
+		err = os.WriteFile(confPath, newData2, 0o644)
 		if err != nil {
 			return err
 		}

--- a/migrate/v141_deprecated_config.go
+++ b/migrate/v141_deprecated_config.go
@@ -10,7 +10,7 @@ import (
 
 func V141DeprecatedConfigRename() error {
 	var err error
-	var confp = filepath.Clean("./data/default/serve.yaml")
+	confp := filepath.Clean("./data/default/serve.yaml")
 
 	if _, err = os.Stat(confp); err != nil {
 		// No renaming is needed if config hasn't been created.
@@ -46,7 +46,7 @@ func V141DeprecatedConfigRename() error {
 		return err
 	}
 
-	err = os.WriteFile(confp, modified, 0644)
+	err = os.WriteFile(confp, modified, 0o644)
 	if err != nil {
 		return err
 	}

--- a/signature/gen/sign_mods.go
+++ b/signature/gen/sign_mods.go
@@ -5,8 +5,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	sealcrypto "sealdice-core/utils/crypto"
 	"strings"
+
+	sealcrypto "sealdice-core/utils/crypto"
 )
 
 func main() {
@@ -52,7 +53,7 @@ func signModFile(privateKey string, path, name string, signStrTmpl string) {
 		return
 	}
 	newData := []byte(fmt.Sprintf(signStrTmpl, sign) + string(data))
-	err = os.WriteFile("[signed]"+name, newData, 0644)
+	err = os.WriteFile("[signed]"+name, newData, 0o644)
 	if err != nil {
 		return
 	}

--- a/static/gen/download-fe.go
+++ b/static/gen/download-fe.go
@@ -75,7 +75,7 @@ func unzip(src, dest string) error {
 		}
 	}()
 
-	_ = os.MkdirAll(dest, 0755)
+	_ = os.MkdirAll(dest, 0o755)
 
 	// Closure to address file descriptors issue with all the deferred .Close() methods
 	extractAndWriteFile := func(f *zip.File) error {

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -11,10 +11,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice"
-	"sealdice-core/icon"
 	"syscall"
 	"time"
+
+	"sealdice-core/dice"
+	"sealdice-core/icon"
 
 	"github.com/fy0/systray"
 	"github.com/gen2brain/beeep"
@@ -42,6 +43,7 @@ func TestRunning() bool {
 func tempDirWarn() {
 	fmt.Println("当前工作路径为临时目录，因此拒绝继续执行。")
 }
+
 func showMsgBox(title string, message string) {
 	fmt.Println(title, message)
 }

--- a/tray_others.go
+++ b/tray_others.go
@@ -10,8 +10,9 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice"
 	"syscall"
+
+	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
 )
@@ -33,6 +34,7 @@ func TestRunning() bool {
 func tempDirWarn() {
 	fmt.Println("当前工作路径为临时目录，因此拒绝继续执行。")
 }
+
 func showMsgBox(title string, message string) {
 	fmt.Println(title, message)
 }

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -11,11 +11,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice"
-	"sealdice-core/icon"
 	"syscall"
 	"time"
 	"unsafe"
+
+	"sealdice-core/dice"
+	"sealdice-core/icon"
 
 	"github.com/fy0/go-autostart"
 	"github.com/fy0/systray"
@@ -264,7 +265,7 @@ func showMsgBox(title string, message string) {
 func executeWin(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		//CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+		// CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
 		CreationFlags:    windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NEW_CONSOLE,
 		NoInheritHandles: true,
 	}

--- a/update.go
+++ b/update.go
@@ -13,10 +13,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sealdice-core/dice"
 	"strconv"
 	"syscall"
 	"time"
+
+	"sealdice-core/dice"
 
 	"go.uber.org/zap"
 )
@@ -63,7 +64,7 @@ func downloadUpdate(dm *dice.DiceManager, log *zap.SugaredLogger) (string, error
 				return "", errors.New("更新: 删除缓存目录(update)失败")
 			}
 
-			_ = os.MkdirAll("./update", 0755)
+			_ = os.MkdirAll("./update", 0o755)
 			fn2 := "./update/update." + ext
 			err = DownloadFile(fn2, fileUrl)
 			if err != nil {
@@ -183,7 +184,6 @@ func DownloadFile(filepath string, url string) error {
 
 	request.Header.Add("Accept-Encoding", "gzip")
 	resp, err := client.Do(request)
-
 	if err != nil {
 		return err
 	}

--- a/update_updater.go
+++ b/update_updater.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"sealdice-core/dice"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+
+	"sealdice-core/dice"
 
 	"go.uber.org/zap"
 )
@@ -78,7 +79,7 @@ func CheckUpdater(dm *dice.DiceManager) error {
 	// 获取updater版本
 	isUpdaterOk := false
 	if exists {
-		err := os.Chmod(fn, 0755)
+		err := os.Chmod(fn, 0o755)
 		if err != nil {
 			logger.Error("设置升级程序执行权限失败", err.Error())
 		}
@@ -104,7 +105,7 @@ func CheckUpdater(dm *dice.DiceManager) error {
 			return errors.New("下载更新程序失败，无可用更新程序")
 		} else {
 			logger.Info("下载更新程序成功")
-			err := os.Chmod(fn, 0755)
+			err := os.Chmod(fn, 0o755)
 			if err != nil {
 				logger.Error("设置升级程序执行权限失败", err.Error())
 			}
@@ -149,7 +150,7 @@ func UpdateByFile(dm *dice.DiceManager, log *zap.SugaredLogger, packName string,
 		log = logger
 	}
 	fn := getUpdaterFn()
-	err := os.Chmod(fn, 0755)
+	err := os.Chmod(fn, 0o755)
 	if err != nil {
 		log.Error("设置升级程序执行权限失败", err.Error())
 	}
@@ -163,7 +164,6 @@ func UpdateByFile(dm *dice.DiceManager, log *zap.SugaredLogger, packName string,
 	args := []string{"--upgrade", packName, "--pid", strconv.Itoa(os.Getpid())}
 	cmd := exec.CommandContext(ctx, fn, args...)
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			log.Info("升级程序: 验证成功，进入下一阶段，即将退出进程")


### PR DESCRIPTION
gofumpts 主要包括以下几点：

1. import 按标准库–内部库–外部库排列
2. err 和检查 err 中间不能有空行
3. 八进制数必须使用 0o666 而非 0666 的样式（TODO：我本人不介意，但如果大家觉得丑的话，有人知道怎么禁用这一条吗）
4. 合并连续的 var 声明，函数内部不使用 `var a = ...` 的形式而一律使用 `a := ...`

已经加入 .vscode/settings.json 为 VS Code 启用 gofumpts，GoLand 或许可以添加 File Watcher 或者运行新加入的 format_go.py 脚本。