### PR TITLE
style: 正确配置 goimports 依赖分组

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,4 @@ _help_cache
 .DS_Store
 !static/.nomedia
 
-.vscode/
-
 *.private.pem

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,12 @@ linters-settings:
         # Default: true
         skipRecvDeref: false
 
+  goimports:
+    # A comma-separated list of prefixes, which, if set, checks import paths
+    # with the given prefixes are grouped after 3rd-party packages.
+    # Default: ""
+    local-prefixes: sealdice-core
+
   gomnd:
     # List of function patterns to exclude from analysis.
     # Values always ignored: `time.Date`,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "go.useLanguageServer": true,
+  "gopls": {
+    "formatting.local": "sealdice-core",
+  },
+  "go.formatTool": "default",
+}

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -1,19 +1,19 @@
 package api
 
 import (
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"runtime"
 	"sort"
 	"strings"
 	"time"
 
-	"encoding/hex"
-	"encoding/json"
-	"net/http"
-	"sealdice-core/dice"
-
 	"github.com/labstack/echo/v4"
 	"github.com/monaco-io/request"
+
+	"sealdice-core/dice"
 )
 
 const CodeAlreadyExists = 602
@@ -85,8 +85,10 @@ func hello2(c echo.Context) error {
 	return c.JSON(http.StatusOK, nil)
 }
 
-var myDice *dice.Dice
-var dm *dice.DiceManager
+var (
+	myDice *dice.Dice
+	dm     *dice.DiceManager
+)
 
 func doSignInGetSalt(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{

--- a/api/backup.go
+++ b/api/backup.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sealdice-core/dice"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 type backupFileItem struct {

--- a/api/ban.go
+++ b/api/ban.go
@@ -7,11 +7,12 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"sealdice-core/dice"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func banConfigGet(c echo.Context) error {

--- a/api/censor.go
+++ b/api/censor.go
@@ -10,15 +10,16 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sealdice-core/dice"
-	"sealdice-core/dice/censor"
-	"sealdice-core/dice/model"
 	"sort"
 	"strings"
 
 	"github.com/golang-module/carbon"
 	"github.com/labstack/echo/v4"
 	"github.com/pelletier/go-toml/v2"
+
+	"sealdice-core/dice"
+	"sealdice-core/dice/censor"
+	"sealdice-core/dice/model"
 )
 
 func check(c echo.Context) (bool, error) {

--- a/api/conn.go
+++ b/api/conn.go
@@ -4,11 +4,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
 	"sort"
 	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func ImConnections(c echo.Context) error {

--- a/api/custom.go
+++ b/api/custom.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"net/http"
-	"sealdice-core/dice"
 	"strings"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func customText(c echo.Context) error {

--- a/api/deck.go
+++ b/api/deck.go
@@ -6,10 +6,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice"
 	"strings"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func deckList(c echo.Context) error {

--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -4,14 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
-	"sealdice-core/utils"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"golang.org/x/time/rate"
+
+	"sealdice-core/dice"
+	"sealdice-core/utils"
 )
 
 type DiceConfigInfo struct {

--- a/api/group.go
+++ b/api/group.go
@@ -3,12 +3,13 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
-	"sealdice-core/dice/model"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
+	"sealdice-core/dice/model"
 )
 
 func groupList(c echo.Context) error {
@@ -89,7 +90,6 @@ func groupQuit(c echo.Context) error {
 		ExtraText string `yaml:"extraText" json:"extraText"`
 	}{}
 	err := c.Bind(&v)
-
 	if err != nil {
 		return c.String(430, "")
 	}

--- a/api/helpdoc.go
+++ b/api/helpdoc.go
@@ -3,9 +3,10 @@ package api
 import (
 	"mime/multipart"
 	"net/http"
-	"sealdice-core/dice"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func helpDocStatus(c echo.Context) error {

--- a/api/js.go
+++ b/api/js.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice"
 	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func jsExec(c echo.Context) error {

--- a/api/reply.go
+++ b/api/reply.go
@@ -5,10 +5,11 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
-	"sealdice-core/dice"
 	"strings"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func customReplySave(c echo.Context) error {

--- a/api/socks.go
+++ b/api/socks.go
@@ -6,12 +6,13 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sealdice-core/dice"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/armon/go-socks5"
+
+	"sealdice-core/dice"
 )
 
 var privateIPBlocks []*net.IPNet
@@ -50,7 +51,6 @@ func isPrivateIP(ip net.IP) bool {
 
 func getClientIP() ([]string, error) {
 	addrs, err := net.InterfaceAddrs()
-
 	if err != nil {
 		return nil, err
 	}

--- a/api/story_log.go
+++ b/api/story_log.go
@@ -3,10 +3,11 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"sealdice-core/dice"
-	"sealdice-core/dice/model"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
+	"sealdice-core/dice/model"
 )
 
 func storyGetInfo(c echo.Context) error {

--- a/api/utils.go
+++ b/api/utils.go
@@ -2,13 +2,12 @@ package api
 
 import (
 	"bytes"
-	"fmt"
-	"log"
-	"os"
-
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
+	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 
 	"github.com/alexmullins/zip"
@@ -30,7 +29,7 @@ func Error(c *echo.Context, errMsg string, res Response) error {
 }
 
 func Int64ToBytes(i int64) []byte {
-	var buf = make([]byte, 8)
+	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, uint64(i))
 	return buf
 }

--- a/dice/config.go
+++ b/dice/config.go
@@ -7,26 +7,30 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sealdice-core/dice/model"
-	"sealdice-core/utils"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/fy0/lockfree"
 	wr "github.com/mroth/weightedrand"
+	"golang.org/x/time/rate"
 	"gopkg.in/yaml.v3"
+
+	"sealdice-core/dice/model"
+	"sealdice-core/utils"
 )
 
 // type TextTemplateWithWeight = map[string]map[string]uint
-type TextTemplateItem = []interface{} // 实际上是 [](string | int) 类型
-type TextTemplateItemList []TextTemplateItem
+type (
+	TextTemplateItem     = []interface{} // 实际上是 [](string | int) 类型
+	TextTemplateItemList []TextTemplateItem
+)
 
-type TextTemplateWithWeight = map[string][]TextTemplateItem
-type TextTemplateWithWeightDict = map[string]TextTemplateWithWeight
+type (
+	TextTemplateWithWeight     = map[string][]TextTemplateItem
+	TextTemplateWithWeightDict = map[string]TextTemplateWithWeight
+)
 
 // TextTemplateHelpItem 辅助信息，用于UI中，大部分自动生成
 type TextTemplateHelpItem = struct {
@@ -41,8 +45,10 @@ type TextTemplateHelpItem = struct {
 	NotBuiltin      bool               `json:"notBuiltin"`      // 非内置
 	TopOrder        int                `json:"topOrder"`        // 置顶序号，越高越靠前
 }
-type TextTemplateHelpGroup = map[string]*TextTemplateHelpItem
-type TextTemplateWithHelpDict = map[string]TextTemplateHelpGroup
+type (
+	TextTemplateHelpGroup    = map[string]*TextTemplateHelpItem
+	TextTemplateWithHelpDict = map[string]TextTemplateHelpGroup
+)
 
 // const CONFIG_TEXT_TEMPLATE_FILE = "./data/configs/text-template.yaml"
 
@@ -213,7 +219,7 @@ func (cm *ConfigManager) ResetConfigToDefault(pluginName, key string) {
 }
 
 func (cm *ConfigManager) save() error {
-	file, err := os.OpenFile(cm.filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(cm.filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}
@@ -2248,10 +2254,10 @@ func (d *Dice) SaveText() {
 		// ioutil.WriteFile(filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml"), buf, 0644)
 		current, err := os.ReadFile(newFn)
 		if err != nil {
-			_ = os.WriteFile(bakFn, current, 0644)
+			_ = os.WriteFile(bakFn, current, 0o644)
 		}
 
-		_ = os.WriteFile(newFn, buf, 0644)
+		_ = os.WriteFile(newFn, buf, 0o644)
 	}
 }
 
@@ -2323,7 +2329,7 @@ func (d *Dice) Save(isAuto bool) {
 		a, err := yaml.Marshal(d)
 
 		if err == nil {
-			err := os.WriteFile(filepath.Join(d.BaseConfig.DataDir, "serve.yaml"), a, 0644)
+			err := os.WriteFile(filepath.Join(d.BaseConfig.DataDir, "serve.yaml"), a, 0o644)
 			if err == nil {
 				now := time.Now()
 				d.LastSavedTime = &now

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -7,15 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"sealdice-core/dice/censor"
-	"sealdice-core/dice/logger"
-	"sealdice-core/dice/model"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
-	"golang.org/x/time/rate"
 
 	"github.com/dop251/goja_nodejs/eventloop"
 	"github.com/dop251/goja_nodejs/require"
@@ -25,14 +19,25 @@ import (
 	"github.com/robfig/cron/v3"
 	"github.com/tidwall/buntdb"
 	"go.uber.org/zap"
+
 	rand2 "golang.org/x/exp/rand"
+	"golang.org/x/exp/slices"
+	"golang.org/x/time/rate"
+
+	"sealdice-core/dice/censor"
+	"sealdice-core/dice/logger"
+	"sealdice-core/dice/model"
 )
 
-var APPNAME = "SealDice"
-var VERSION = "1.4.3f1 v20240110"
+var (
+	APPNAME = "SealDice"
+	VERSION = "1.4.3f1 v20240110"
+)
 
-var VERSION_CODE = int64(1004003) //nolint:revive
-var APP_BRANCH = ""               //nolint:revive
+var (
+	VERSION_CODE = int64(1004003) //nolint:revive
+	APP_BRANCH   = ""             //nolint:revive
+)
 
 type CmdExecuteResult struct {
 	Matched  bool // 是否是指令
@@ -289,12 +294,12 @@ func (d *Dice) CocExtraRulesAdd(ruleInfo *CocRuleInfo) bool {
 
 func (d *Dice) Init() {
 	d.BaseConfig.DataDir = filepath.Join("./data", d.BaseConfig.Name)
-	_ = os.MkdirAll(d.BaseConfig.DataDir, 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "configs"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extensions"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "log-exports"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extra"), 0755)
-	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "scripts"), 0755)
+	_ = os.MkdirAll(d.BaseConfig.DataDir, 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "configs"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extensions"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "log-exports"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "extra"), 0o755)
+	_ = os.MkdirAll(filepath.Join(d.BaseConfig.DataDir, "scripts"), 0o755)
 
 	d.Cron = cron.New()
 	d.Cron.Start()
@@ -530,7 +535,6 @@ func (d *Dice) ExprTextBase(buffer string, ctx *MsgContext, flags RollExtraFlags
 
 	// 隐藏的内置字符串符号 \x1e
 	val, detail, err := d.ExprEvalBase("\x1e"+buffer+"\x1e", ctx, flags)
-
 	if err != nil {
 		fmt.Println("脚本执行出错: ", buffer, "->", err)
 	}
@@ -727,7 +731,7 @@ func CrashLog() {
 	if r := recover(); r != nil {
 		text := fmt.Sprintf("报错: %v\n堆栈: %v", r, string(debug.Stack()))
 		now := time.Now()
-		_ = os.WriteFile(fmt.Sprintf("崩溃日志_%s.txt", now.Format("20060201_150405")), []byte(text), 0644)
+		_ = os.WriteFile(fmt.Sprintf("崩溃日志_%s.txt", now.Format("20060201_150405")), []byte(text), 0o644)
 		panic(r)
 	}
 }

--- a/dice/dice_backup.go
+++ b/dice/dice_backup.go
@@ -6,13 +6,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice/model"
-	"sealdice-core/utils"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/alexmullins/zip"
+
+	"sealdice-core/dice/model"
+	"sealdice-core/utils"
 )
 
 const BackupDir = "./backups"
@@ -52,7 +53,7 @@ type OneBackupConfig struct {
 }
 
 func (dm *DiceManager) Backup(cfg AllBackupConfig, bakFilename string) (string, error) {
-	_ = os.MkdirAll(BackupDir, 0755)
+	_ = os.MkdirAll(BackupDir, 0o755)
 
 	fzip, err := os.CreateTemp(BackupDir, bakFilename)
 	if err != nil {

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -3,11 +3,12 @@ package dice
 import (
 	"encoding/json"
 	"fmt"
-	"sealdice-core/dice/model"
 	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
+
+	"sealdice-core/dice/model"
 )
 
 type BanRankType int

--- a/dice/dice_censor.go
+++ b/dice/dice_censor.go
@@ -5,12 +5,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice/censor"
-	"sealdice-core/dice/model"
 	"sort"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
+
+	"sealdice-core/dice/censor"
+	"sealdice-core/dice/model"
 )
 
 type CensorManager struct {
@@ -53,7 +54,7 @@ func (cm *CensorManager) Load(_ *Dice) {
 	fileDir := "./data/censor"
 	cm.IsLoading = true
 	cm.Censor.SensitiveKeys = make(map[string]censor.WordInfo)
-	_ = os.MkdirAll(fileDir, 0755)
+	_ = os.MkdirAll(fileDir, 0o755)
 	_ = filepath.Walk(fileDir, func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && (filepath.Ext(path) == ".txt" || filepath.Ext(path) == ".toml") {
 			cm.Parent.Logger.Infof("正在读取敏感词文件：%s\n", path)

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -12,8 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sealdice-core/static"
-	"sealdice-core/utils/crypto"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +25,9 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/elazarl/goproxy.v1"
 	"gopkg.in/yaml.v3"
+
+	"sealdice-core/static"
+	"sealdice-core/utils/crypto"
 )
 
 var (
@@ -152,7 +153,8 @@ func (d *Dice) JsInit() {
 			if d.JsLoadingScript != nil {
 				official = d.JsLoadingScript.Official
 			}
-			return &ExtInfo{Name: name, Author: author, Version: version,
+			return &ExtInfo{
+				Name: name, Author: author, Version: version,
 				GetDescText: GetExtensionDesc,
 				AutoActive:  true,
 				IsJsExt:     true,
@@ -510,7 +512,7 @@ func (d *Dice) JsLoadScripts() {
 
 	// 导出内置脚本数据
 	builtinScripts, _ := fs.ReadDir(static.Scripts, "scripts")
-	_ = os.MkdirAll(builtinPath, 0755)
+	_ = os.MkdirAll(builtinPath, 0o755)
 	for _, script := range builtinScripts {
 		if !script.IsDir() && filepath.Ext(script.Name()) == ".js" {
 			target := filepath.Join(builtinPath, script.Name())
@@ -519,13 +521,13 @@ func (d *Dice) JsLoadScripts() {
 			// 判断是否有更新后的内置脚本
 			_, err := os.Stat(target)
 			if errors.Is(err, os.ErrNotExist) {
-				_ = os.WriteFile(target, data, 0644)
+				_ = os.WriteFile(target, data, 0o644)
 			} else {
 				// 检查同名内置脚本的签名，检查不通过则覆盖
 				scriptData, _ := os.ReadFile(target)
 				if ok, _ := CheckJsSign(scriptData); !ok {
 					d.Logger.Warnf("已存在的内置脚本「%s」未通过校验，进行覆盖", script.Name())
-					_ = os.WriteFile(target, scriptData, 0644)
+					_ = os.WriteFile(target, scriptData, 0o644)
 				}
 			}
 		}
@@ -862,7 +864,7 @@ func (d *Dice) JsUpdate(jsScriptInfo *JsScriptInfo, tempFileName string) error {
 		return fmt.Errorf("new data is empty")
 	}
 	// 更新插件
-	err = os.WriteFile(jsScriptInfo.Filename, newData, 0755)
+	err = os.WriteFile(jsScriptInfo.Filename, newData, 0o755)
 	if err != nil {
 		d.Logger.Errorf("插件“%s”更新时保存文件出错，%s", jsScriptInfo.Name, err.Error())
 		return err

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -11,21 +11,19 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice/constants"
-	"sealdice-core/dice/model"
 	"strings"
 	"time"
 	"unicode"
 
-	"github.com/golang-module/carbon"
-
 	"github.com/fy0/lockfree"
+	"github.com/golang-module/carbon"
 	"go.uber.org/zap"
+
+	"sealdice-core/dice/constants"
+	"sealdice-core/dice/model"
 )
 
-var (
-	ErrGroupCardOverlong = errors.New("群名片长度超过限制")
-)
+var ErrGroupCardOverlong = errors.New("群名片长度超过限制")
 
 const StoryVersion = 101
 
@@ -702,7 +700,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 		AutoActive: true,
 		Official:   true,
 		OnLoad: func() {
-			_ = os.MkdirAll(filepath.Join(self.BaseConfig.DataDir, "log-exports"), 0755)
+			_ = os.MkdirAll(filepath.Join(self.BaseConfig.DataDir, "log-exports"), 0o755)
 		},
 		OnMessageSend: func(ctx *MsgContext, msg *Message, flag string) {
 			// 记录骰子发言
@@ -904,7 +902,7 @@ func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix s
 
 func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (string, error) {
 	dirpath := filepath.Join(ctx.Dice.BaseConfig.DataDir, "log-exports")
-	_ = os.MkdirAll(dirpath, 0755)
+	_ = os.MkdirAll(dirpath, 0o755)
 
 	url, uploadTS, updateTS, _ := model.LogGetUploadInfo(ctx.Dice.DBLogs, groupID, logName)
 	if len(url) > 0 && uploadTS > updateTS {

--- a/dice/im_vars.go
+++ b/dice/im_vars.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"sealdice-core/dice/model"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/fy0/lockfree"
+
+	"sealdice-core/dice/model"
 )
 
 // LoadPlayerGlobalVars 加载个人全局数据

--- a/dice/model/censor_log.go
+++ b/dice/model/censor_log.go
@@ -2,10 +2,11 @@ package model
 
 import (
 	"encoding/json"
-	"sealdice-core/dice/censor"
 	"time"
 
 	"github.com/jmoiron/sqlx"
+
+	"sealdice-core/dice/censor"
 )
 
 type CensorLog struct {

--- a/dice/model/db_utils.go
+++ b/dice/model/db_utils.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sealdice-core/utils/spinner"
 	"sync"
+
+	"sealdice-core/utils/spinner"
 )
 
 func DBCacheDelete() bool {

--- a/dice/platform_adapter_gocq_channel.go
+++ b/dice/platform_adapter_gocq_channel.go
@@ -3,8 +3,9 @@ package dice
 import (
 	"encoding/json"
 	"fmt"
-	"sealdice-core/dice/model"
 	"strings"
+
+	"sealdice-core/dice/model"
 )
 
 type SenderChannel struct {

--- a/dice/platform_adapter_gocq_helper.go
+++ b/dice/platform_adapter_gocq_helper.go
@@ -11,13 +11,14 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/debug"
-	"sealdice-core/utils/procs"
 	"strings"
 	"time"
 
 	"github.com/ShiraazMoollatjie/goluhn"
 	"github.com/acarl005/stripansi"
 	"github.com/google/uuid"
+
+	"sealdice-core/utils/procs"
 )
 
 type deviceFile struct {
@@ -581,7 +582,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 
 	if pa.UseInPackGoCqhttp { //nolint:nestif
 		workDir := gocqGetWorkDir(dice, conn)
-		_ = os.MkdirAll(workDir, 0755)
+		_ = os.MkdirAll(workDir, 0o755)
 
 		qrcodeFile := filepath.Join(workDir, "qrcode.png")
 		deviceFilePath := filepath.Join(workDir, "device.json")
@@ -604,7 +605,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		if _, err := os.Stat(deviceFilePath); errors.Is(err, os.ErrNotExist) {
 			_, deviceInfo, err := GenerateDeviceJSON(dice, loginInfo.Protocol)
 			if err == nil {
-				_ = os.WriteFile(deviceFilePath, deviceInfo, 0644)
+				_ = os.WriteFile(deviceFilePath, deviceInfo, 0o644)
 				dice.Logger.Info("onebot: 成功创建设备文件")
 			}
 		}
@@ -617,7 +618,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 			pa.ConnectURL = fmt.Sprintf("ws://localhost:%d", p)
 			qqid, _ := pa.mustExtractID(conn.UserID)
 			c := GenerateConfig(qqid, p, loginInfo)
-			_ = os.WriteFile(configFilePath, []byte(c), 0644)
+			_ = os.WriteFile(configFilePath, []byte(c), 0o644)
 		}
 
 		if versions, ok := GocqAppVersionMap[loginInfo.AppVersion]; ok {
@@ -625,10 +626,10 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 				// 删除旧协议版本文件
 				_ = os.RemoveAll(versionDirPath)
 				// 创建协议版本文件
-				_ = os.MkdirAll(versionDirPath, 0755)
+				_ = os.MkdirAll(versionDirPath, 0o755)
 				versionFilePath := filepath.Join(versionDirPath, fmt.Sprintf("%d.json", loginInfo.Protocol))
 				jsonData, _ := json.Marshal(targetVersion)
-				_ = os.WriteFile(versionFilePath, jsonData, 0644)
+				_ = os.WriteFile(versionFilePath, jsonData, 0o644)
 			}
 		}
 
@@ -638,7 +639,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		gocqhttpExePath = strings.ReplaceAll(gocqhttpExePath, "\\", "/") // windows平台需要这个替换
 
 		// 随手执行一下
-		_ = os.Chmod(gocqhttpExePath, 0755)
+		_ = os.Chmod(gocqhttpExePath, 0o755)
 
 		dice.Logger.Info("onebot: 正在启动onebot客户端…… ", gocqhttpExePath)
 		p := procs.NewProcess(fmt.Sprintf(`"%s" -faststart`, gocqhttpExePath))

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"fmt"
 	"path/filepath"
+
 	"sealdice-core/utils"
 )
 

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -9,14 +9,15 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
-	"sealdice-core/dice/model"
-	"sealdice-core/utils/procs"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/sacOO7/gowebsocket"
+
+	"sealdice-core/dice/model"
+	"sealdice-core/utils/procs"
 )
 
 /* 定义结构体 */

--- a/dice/platform_adapter_walleq_helper.go
+++ b/dice/platform_adapter_walleq_helper.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"sealdice-core/utils/procs"
 	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/uuid"
+
+	"sealdice-core/utils/procs"
 )
 
 const (
@@ -134,7 +135,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 	pa.WalleQState = WqStateCodeInLogin
 	fmt.Println("WalleQServe begin")
 	workDir := filepath.Join(dice.BaseConfig.DataDir, conn.RelWorkDir)
-	_ = os.MkdirAll(workDir, 0755)
+	_ = os.MkdirAll(workDir, 0o755)
 	log := dice.Logger
 	qrcodeFile := filepath.Join(workDir, "qrcode.png")
 	// deviceFilePath := filepath.Join(workDir, "device.json") // 暂时让他自己写
@@ -165,7 +166,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 		wqc.Onebot.HTTPWebhook = make([]interface{}, 0)
 		b := new(bytes.Buffer)
 		_ = toml.NewEncoder(b).Encode(wqc)
-		_ = os.WriteFile(configFilePath, b.Bytes(), 0644)
+		_ = os.WriteFile(configFilePath, b.Bytes(), 0o644)
 	} else { //nolint
 		// 如果决定使用单进程 wq
 		/*
@@ -187,7 +188,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 	wd, _ := os.Getwd()
 	wqExePath, _ := filepath.Abs(filepath.Join(wd, "walle-q/walle-q"))
 	wqExePath = strings.ReplaceAll(wqExePath, "\\", "/") // windows平台需要这个替换
-	_ = os.Chmod(wqExePath, 0755)
+	_ = os.Chmod(wqExePath, 0o755)
 
 	log.Info("onebot: 正在启动onebot客户端…… ", wqExePath)
 	p := procs.NewProcess(fmt.Sprintf(`"%s"`, wqExePath))
@@ -306,7 +307,7 @@ func (pa *PlatformAdapterWalleQ) SetQQProtocol(protocol int) bool {
 	}
 	b := new(bytes.Buffer)
 	_ = toml.NewEncoder(b).Encode(wqc)
-	_ = os.WriteFile(wd, b.Bytes(), 0644)
+	_ = os.WriteFile(wd, b.Bytes(), 0o644)
 	return true
 }
 

--- a/main.go
+++ b/main.go
@@ -7,28 +7,28 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
-	"sealdice-core/dice/model"
-	"sealdice-core/migrate"
-	"sealdice-core/static"
+	"runtime/debug"
+	"strings"
+	"syscall"
+	"time"
 
-	"go.uber.org/zap"
+	// _ "net/http/pprof"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"go.uber.org/zap"
 
-	"os"
-	"os/exec"
-	"os/signal"
-	"runtime/debug"
 	"sealdice-core/api"
 	"sealdice-core/dice"
-	"strings"
-	"syscall"
-	"time"
-	// _ "net/http/pprof"
+	"sealdice-core/dice/model"
+	"sealdice-core/migrate"
+	"sealdice-core/static"
 )
 
 /**
@@ -69,7 +69,7 @@ func cleanUpCreate(diceManager *dice.DiceManager) func() {
 				defer func() {
 					_ = recover()
 				}()
-				var dbData = d.DBData
+				dbData := d.DBData
 				if dbData != nil {
 					d.DBData = nil
 					_ = dbData.Close()
@@ -80,7 +80,7 @@ func cleanUpCreate(diceManager *dice.DiceManager) func() {
 				defer func() {
 					_ = recover()
 				}()
-				var dbLogs = d.DBLogs
+				dbLogs := d.DBLogs
 				if dbLogs != nil {
 					d.DBLogs = nil
 					_ = dbLogs.Close()
@@ -93,7 +93,7 @@ func cleanUpCreate(diceManager *dice.DiceManager) func() {
 				}()
 				cm := d.CensorManager
 				if cm != nil && cm.DB != nil {
-					var dbCensor = cm.DB
+					dbCensor := cm.DB
 					cm.DB = nil
 					_ = dbCensor.Close()
 				}
@@ -208,7 +208,7 @@ func main() {
 	}
 	dnsHack()
 
-	_ = os.MkdirAll("./data", 0755)
+	_ = os.MkdirAll("./data", 0o755)
 	MainLoggerInit("./data/main.log", true)
 
 	// 提早初始化是为了读取ServiceName
@@ -253,7 +253,7 @@ func main() {
 		if doNext {
 			// 只有不同文件才进行校验
 			// windows平台旧版本到1.4.0流程
-			_ = os.WriteFile("./升级失败指引.txt", []byte("如果升级成功不用理会此文档，直接删除即可。\r\n\r\n如果升级后无法启动，或再次启动后恢复到旧版本，先不要紧张。\r\n你升级前的数据备份在backups目录。\r\n如果无法启动，请删除海豹目录中的\"update\"、\"auto_update.exe\"并手动进行升级。\n如果升级成功但在再次重启后回退版本，同上。\n\n如有其他问题可以加企鹅群询问：524364253 562897832"), 0644)
+			_ = os.WriteFile("./升级失败指引.txt", []byte("如果升级成功不用理会此文档，直接删除即可。\r\n\r\n如果升级后无法启动，或再次启动后恢复到旧版本，先不要紧张。\r\n你升级前的数据备份在backups目录。\r\n如果无法启动，请删除海豹目录中的\"update\"、\"auto_update.exe\"并手动进行升级。\n如果升级成功但在再次重启后回退版本，同上。\n\n如有其他问题可以加企鹅群询问：524364253 562897832"), 0o644)
 			logger.Warn("检测到 auto_update.exe，即将自动退出当前程序并进行升级")
 			logger.Warn("程序目录下会出现“升级日志.log”，这代表升级正在进行中，如果失败了请检查此文件。")
 

--- a/migrate/log_item_fix_type.go
+++ b/migrate/log_item_fix_type.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+
 	"sealdice-core/utils/spinner"
 )
 

--- a/migrate/v131_deprecated_config.go
+++ b/migrate/v131_deprecated_config.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sealdice-core/dice"
 
 	"gopkg.in/yaml.v3"
+
+	"sealdice-core/dice"
 )
 
 type v131DeprecatedConfig struct {
@@ -106,11 +107,11 @@ func V131DeprecatedConfig2CustomText() error {
 			return err
 		}
 		// 先备份
-		err = os.WriteFile(customTextBakPath, customTextData, 0644)
+		err = os.WriteFile(customTextBakPath, customTextData, 0o644)
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(customTextPath, newData, 0644)
+		err = os.WriteFile(customTextPath, newData, 0o644)
 		if err != nil {
 			return err
 		}
@@ -131,7 +132,7 @@ func V131DeprecatedConfig2CustomText() error {
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(confPath, newData2, 0644)
+		err = os.WriteFile(confPath, newData2, 0o644)
 		if err != nil {
 			return err
 		}

--- a/readme.md
+++ b/readme.md
@@ -10,13 +10,23 @@
 
 ## 开发环境搭建
 
-#### 1. golang 开发环境
+### 1. golang 开发环境
 
 编译的 golang 版本为 1.20。使用更新版本时需注意不要使用新版本引入的新函数。
 
-因部分依赖库的需求，可能需要配置国内镜像，个人使用 <https://goproxy.cn/> 镜像
+因部分依赖库的需求，可能需要配置国内镜像，个人使用 <https://goproxy.cn/> 镜像。
 
-本项目使用 golangci-lint 工具进行静态分析。如果你的开发环境还未安装，请参考[这份文档](https://golangci-lint.run/usage/install/#local-installation)。分析器的相关配置位于 `.golangci.yml` 文件中。
+#### 代码格式化
+
+本项目要求所有代码使用 goimports 进行格式化。这一行为已经设定在本项目的编辑器配置文件中。
+
+#### 在本地配置 LINTER
+
+本项目使用 golangci-lint 工具进行静态分析。
+
+此工具对于代码开发**不是**必要的。但是，本项目的 CI 流程中配置了 linter 检查，不符合规范的代码不能被合入。
+
+因此，强烈推荐开发者在本地安装此工具，请参考[这份文档](https://golangci-lint.run/usage/install/#local-installation)。分析器的相关配置位于 `.golangci.yml` 文件中。
 
 你可能需要调整编辑器的相关配置，使用 golangci-lint 为默认的分析工具，并开启自动检查。
 
@@ -25,8 +35,10 @@
 > 1. `go.lintTool` 选择 golangci-lint
 > 2. `go.lintFlags` 添加一项 `--fast`
 > 3. `go.lintOnSave` **不能**选择 file，因为只分析单个文件会导致无法正确解析符号引用
+>
+> 以上配置没有写入项目的统一设置，以允许开发者不本地使用 golangci-lint
 
-#### 2. 拉取代码并配置数据文件
+### 2. 拉取代码并配置数据文件
 
 使用git拉取项目代码
 
@@ -51,7 +63,7 @@ static
    └─assets
 ```
 
-#### 3. 编译运行
+### 3. 编译运行
 
 打开项目，或使用终端访问项目目录，运行：
 

--- a/signature/gen/sign_mods.go
+++ b/signature/gen/sign_mods.go
@@ -5,8 +5,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	sealcrypto "sealdice-core/utils/crypto"
 	"strings"
+
+	sealcrypto "sealdice-core/utils/crypto"
 )
 
 func main() {

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -11,14 +11,15 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice"
-	"sealdice-core/icon"
 	"syscall"
 	"time"
-
+	
 	"github.com/fy0/systray"
 	"github.com/gen2brain/beeep"
 	"github.com/labstack/echo/v4"
+	
+	"sealdice-core/dice"
+	"sealdice-core/icon"
 )
 
 var theDm *dice.DiceManager
@@ -42,6 +43,7 @@ func TestRunning() bool {
 func tempDirWarn() {
 	fmt.Println("当前工作路径为临时目录，因此拒绝继续执行。")
 }
+
 func showMsgBox(title string, message string) {
 	fmt.Println(title, message)
 }

--- a/tray_others.go
+++ b/tray_others.go
@@ -10,10 +10,11 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice"
 	"syscall"
 
 	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
 )
 
 func trayInit(dm *dice.DiceManager) {
@@ -33,6 +34,7 @@ func TestRunning() bool {
 func tempDirWarn() {
 	fmt.Println("当前工作路径为临时目录，因此拒绝继续执行。")
 }
+
 func showMsgBox(title string, message string) {
 	fmt.Println(title, message)
 }

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -11,12 +11,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"sealdice-core/dice"
-	"sealdice-core/icon"
 	"syscall"
 	"time"
 	"unsafe"
-
+	
 	"github.com/fy0/go-autostart"
 	"github.com/fy0/systray"
 	"github.com/gen2brain/beeep"
@@ -24,6 +22,9 @@ import (
 	win "github.com/lxn/win"
 	"github.com/monaco-io/request"
 	"golang.org/x/sys/windows"
+	
+	"sealdice-core/dice"
+	"sealdice-core/icon"
 )
 
 func hideWindow() {
@@ -264,7 +265,7 @@ func showMsgBox(title string, message string) {
 func executeWin(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		//CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+		// CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
 		CreationFlags:    windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NEW_CONSOLE,
 		NoInheritHandles: true,
 	}

--- a/update.go
+++ b/update.go
@@ -13,12 +13,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sealdice-core/dice"
 	"strconv"
 	"syscall"
 	"time"
 
 	"go.uber.org/zap"
+
+	"sealdice-core/dice"
 )
 
 var binPrefix = "https://sealdice.coding.net/p/sealdice/d/sealdice-binaries/git/raw/master"
@@ -63,7 +64,7 @@ func downloadUpdate(dm *dice.DiceManager, log *zap.SugaredLogger) (string, error
 				return "", errors.New("更新: 删除缓存目录(update)失败")
 			}
 
-			_ = os.MkdirAll("./update", 0755)
+			_ = os.MkdirAll("./update", 0o755)
 			fn2 := "./update/update." + ext
 			err = DownloadFile(fn2, fileUrl)
 			if err != nil {
@@ -183,7 +184,6 @@ func DownloadFile(filepath string, url string) error {
 
 	request.Header.Add("Accept-Encoding", "gzip")
 	resp, err := client.Do(request)
-
 	if err != nil {
 		return err
 	}

--- a/update_updater.go
+++ b/update_updater.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"sealdice-core/dice"
 	"strconv"
 	"strings"
 	"sync"
@@ -15,6 +14,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"sealdice-core/dice"
 )
 
 const updaterVersion = "0.1.1"
@@ -78,7 +79,7 @@ func CheckUpdater(dm *dice.DiceManager) error {
 	// 获取updater版本
 	isUpdaterOk := false
 	if exists {
-		err := os.Chmod(fn, 0755)
+		err := os.Chmod(fn, 0o755)
 		if err != nil {
 			logger.Error("设置升级程序执行权限失败", err.Error())
 		}
@@ -104,7 +105,7 @@ func CheckUpdater(dm *dice.DiceManager) error {
 			return errors.New("下载更新程序失败，无可用更新程序")
 		} else {
 			logger.Info("下载更新程序成功")
-			err := os.Chmod(fn, 0755)
+			err := os.Chmod(fn, 0o755)
 			if err != nil {
 				logger.Error("设置升级程序执行权限失败", err.Error())
 			}
@@ -149,7 +150,7 @@ func UpdateByFile(dm *dice.DiceManager, log *zap.SugaredLogger, packName string,
 		log = logger
 	}
 	fn := getUpdaterFn()
-	err := os.Chmod(fn, 0755)
+	err := os.Chmod(fn, 0o755)
 	if err != nil {
 		log.Error("设置升级程序执行权限失败", err.Error())
 	}
@@ -163,7 +164,6 @@ func UpdateByFile(dm *dice.DiceManager, log *zap.SugaredLogger, packName string,
 	args := []string{"--upgrade", packName, "--pid", strconv.Itoa(os.Getpid())}
 	cmd := exec.CommandContext(ctx, fn, args...)
 	out, err := cmd.CombinedOutput()
-
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			log.Info("升级程序: 验证成功，进入下一阶段，即将退出进程")


### PR DESCRIPTION
配置本地模块名 `sealdice-core` 使 goimports 能够正确识别本地依赖
增加编辑器设置 `.vscode/settings.json` 以统一配置
配置 `.golangci.yml` 以检查 goimports 的效果
格式化现有代码

TODO：

- [ ] 增加 GoLand 的编辑器配置，使两边效果一致。 @oissevalt 