### PR TITLE
imp(dnd5e): rc 指令中支持使用繁体的`優勢,劣勢`

### DIFF
--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -752,9 +752,11 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 			default:
 				restText := cmdArgs.CleanArgs
-				re := regexp.MustCompile(`^优势|劣势`)
+				re := regexp.MustCompile(`^优势|劣势|優勢|劣勢`)
 				m := re.FindString(restText)
 				if m != "" {
+					m = strings.Replace(m, "優勢", "优势", 1)
+					m = strings.Replace(m, "劣勢", "劣势", 1)
 					restText = strings.TrimSpace(restText[len(m):])
 				}
 				expr := fmt.Sprintf("D20%s + %s", m, restText)


### PR DESCRIPTION
由于未修改 PEG 定义，掷骰表达式中尚不支持 `r d20 優勢`

Issue #551