### PR TITLE
feat(JS): JS 插件支持指定依赖以及版本

### DIFF
--- a/dice/dice_jsvm_test.go
+++ b/dice/dice_jsvm_test.go
@@ -1,0 +1,263 @@
+package dice
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSortJsScripts(t *testing.T) {
+	type args struct {
+		jsScripts []*JsScriptInfo
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*JsScriptInfo
+		wantErr bool
+	}{
+		{
+			name: "test only builtins",
+			args: args{
+				jsScripts: []*JsScriptInfo{
+					{
+						Name:    "A",
+						Author:  "sealdice",
+						Builtin: true,
+					},
+					{
+						Name:    "B",
+						Author:  "sealdice",
+						Builtin: true,
+						Depends: []JsScriptDepends{
+							{
+								Author: "sealdice",
+								Name:   "C",
+							},
+						},
+					},
+					{
+						Name:    "C",
+						Author:  "sealdice",
+						Builtin: true,
+						Depends: []JsScriptDepends{
+							{
+								Author: "sealdice",
+								Name:   "A",
+							},
+						},
+					},
+					{
+						Name:    "D",
+						Author:  "sealdice",
+						Builtin: true,
+						Depends: []JsScriptDepends{
+							{
+								Author: "sealdice",
+								Name:   "B",
+							},
+							{
+								Author: "sealdice",
+								Name:   "C",
+							},
+						},
+					},
+				},
+			},
+			want: []*JsScriptInfo{
+				{
+					Name:    "A",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+				{
+					Name:    "C",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+				{
+					Name:    "B",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+				{
+					Name:    "D",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test only not builtins",
+			args: args{
+				jsScripts: []*JsScriptInfo{
+					{
+						Name:    "A",
+						Author:  "JustAnotherID",
+						Builtin: false,
+					},
+					{
+						Name:    "B",
+						Author:  "JustAnotherID",
+						Builtin: false,
+						Depends: []JsScriptDepends{
+							{
+								Author: "JustAnotherID",
+								Name:   "C",
+							},
+						},
+					},
+					{
+						Name:    "C",
+						Author:  "JustAnotherID",
+						Builtin: false,
+						Depends: []JsScriptDepends{
+							{
+								Author: "JustAnotherID",
+								Name:   "A",
+							},
+						},
+					},
+				}},
+			want: []*JsScriptInfo{
+				{
+					Name:    "A",
+					Author:  "JustAnotherID",
+					Builtin: false,
+				},
+				{
+					Name:    "C",
+					Author:  "JustAnotherID",
+					Builtin: false,
+				},
+				{
+					Name:    "B",
+					Author:  "JustAnotherID",
+					Builtin: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test both",
+			args: args{
+				jsScripts: []*JsScriptInfo{
+					{
+						Name:    "A",
+						Author:  "sealdice",
+						Builtin: true,
+					},
+					{
+						Name:    "B",
+						Author:  "JustAnotherID",
+						Builtin: false,
+					},
+					{
+						Name:    "C",
+						Author:  "JustAnotherID",
+						Builtin: false,
+						Depends: []JsScriptDepends{
+							{
+								Author: "sealdice",
+								Name:   "A",
+							},
+						},
+					},
+					{
+						Name:    "D",
+						Author:  "sealdice",
+						Builtin: true,
+					},
+					{
+						Name:    "E",
+						Author:  "sealdice",
+						Builtin: true,
+						Depends: []JsScriptDepends{
+							{
+								Author: "sealdice",
+								Name:   "A",
+							},
+							{
+								Author: "sealdice",
+								Name:   "D",
+							},
+						},
+					},
+				}},
+			want: []*JsScriptInfo{
+				{
+					Name:    "A",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+				{
+					Name:    "D",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+				{
+					Name:    "E",
+					Author:  "sealdice",
+					Builtin: true,
+				},
+				{
+					Name:    "B",
+					Author:  "JustAnotherID",
+					Builtin: false,
+				},
+				{
+					Name:    "C",
+					Author:  "JustAnotherID",
+					Builtin: false,
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sortJsScripts(tt.args.jsScripts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sortJsScripts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !sameScriptInfos(got, tt.want) {
+				t.Errorf("sortJsScripts() got = %v, want %v", showScriptInfos(got), showScriptInfos(tt.want))
+			}
+		})
+	}
+}
+
+func showScriptInfos(jsScripts []*JsScriptInfo) string {
+	var result []string
+	for _, jsScript := range jsScripts {
+		result = append(result, fmt.Sprintf("%s::%s", jsScript.Author, jsScript.Name))
+	}
+	return "[" + strings.Join(result, ", ") + "]"
+}
+
+func sameScriptInfos(a []*JsScriptInfo, b []*JsScriptInfo) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if !sameScriptInfo(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameScriptInfo(a *JsScriptInfo, b *JsScriptInfo) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Author != b.Author {
+		return false
+	}
+	if a.Builtin != b.Builtin {
+		return false
+	}
+	return true
+}

--- a/dice/dice_jsvm_test.go
+++ b/dice/dice_jsvm_test.go
@@ -168,6 +168,12 @@ func TestSortJsScripts(t *testing.T) {
 						Name:    "D",
 						Author:  "sealdice",
 						Builtin: true,
+						Depends: []JsScriptDepends{
+							{
+								Author: "sealdice",
+								Name:   "A",
+							},
+						},
 					},
 					{
 						Name:    "E",

--- a/dice/dice_jsvm_test.go
+++ b/dice/dice_jsvm_test.go
@@ -223,9 +223,9 @@ func TestSortJsScripts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := sortJsScripts(tt.args.jsScripts)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("sortJsScripts() error = %v, wantErr %v", err, tt.wantErr)
+			got, errMap := sortJsScripts(tt.args.jsScripts)
+			if len(errMap) != 0 && !tt.wantErr {
+				t.Errorf("sortJsScripts() errMap = %v", errMap)
 				return
 			}
 			if !sameScriptInfos(got, tt.want) {

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/RoaringBitmap/roaring v1.2.3 // indirect
 	github.com/bits-and-blooms/bitset v1.2.2 // indirect
 	github.com/bits-and-blooms/bloom/v3 v3.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/RoaringBitmap/roaring v1.2.3 h1:yqreLINqIrX22ErkKI0vY47/ivtJr6n+kMhVOVmhWBY=
 github.com/RoaringBitmap/roaring v1.2.3/go.mod h1:plvDsJQpxOC5bw8LRteu/MLWHsHez/3y6cubLI4/1yE=
 github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a h1:NPnGVqpua4c1iEFVdxnBJA9viP5bo2Zp2jfflbcjdto=


### PR DESCRIPTION
支持为 JS 插件指定依赖，并可使用满足 [SemVer 规则](https://semver.org/lang/zh-CN/) 的语法限制依赖版本。
```
// @depends JustAnotherID:A
// @depends JustAnotherID:B:1.2.3  // 指定特定版本
// @depends JustAnotherID:C:^1.2.0 // 兼容版本，详见 SemVer
```
Related sealdice/sealdice-core#608