### PR TITLE
fix: 修复 JS 中 console 不能使用的问题

### DIFF
--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -57,7 +57,10 @@ func (p *PrinterFunc) RecordEnd() []string {
 	return r
 }
 
-func (p *PrinterFunc) Log(s string) { p.doRecord("log", s); p.d.Logger.Info(s) }
+func (p *PrinterFunc) Log(s string) {
+	p.doRecord("log", s)
+	p.d.Logger.Info(s)
+}
 
 func (p *PrinterFunc) Warn(s string) { p.doRecord("warn", s); p.d.Logger.Warn(s) }
 
@@ -83,7 +86,7 @@ func (d *Dice) JsInit() {
 
 	printer := &PrinterFunc{d, false, []string{}}
 	d.JsPrinter = printer
-	reg.RegisterNativeModule("node:console", console.RequireWithPrinter(printer))
+	reg.RegisterNativeModule("console", console.RequireWithPrinter(printer))
 
 	// 初始化
 	loop.Run(func(vm *goja.Runtime) {


### PR DESCRIPTION
goja 从某一版本开始似乎将 console 分为 `node:console` 和 `console` 两个模组，其中前一个只会在控制台输出固定格式的文本，不会采用定义的 Printer。

closes #616 