### PR TITLE
fix(IMSession): 私聊的用户被视同 群管理员 权限

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -1415,13 +1415,8 @@ func (d *Dice) registerCoreCommands() {
 		Solve: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) CmdExecuteResult {
 			if ctx.Dice.TextCmdTrustOnly {
 				// 检查master和信任权限
-				refuse := ctx.PrivilegeLevel != 100
-				if refuse {
-					refuse = ctx.PrivilegeLevel != 70
-				}
-
 				// 拒绝无权限访问
-				if refuse {
+				if ctx.PrivilegeLevel < 70 {
 					ReplyToSender(ctx, msg, "你不具备Master权限")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}

--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -684,13 +684,8 @@ func RegisterBuiltinExtFun(self *Dice) {
 		Solve: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) CmdExecuteResult {
 			if ctx.Dice.TextCmdTrustOnly {
 				// 检查master和信任权限
-				refuse := ctx.PrivilegeLevel != 100
-				if refuse {
-					refuse = ctx.PrivilegeLevel != 70
-				}
-
 				// 拒绝无权限访问
-				if refuse {
+				if ctx.PrivilegeLevel < 70 {
 					ReplyToSender(ctx, msg, "你不具备Master权限")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}


### PR DESCRIPTION
对 `fillPrivilege` 稍微进行了重构, 使它能够尽可能利用存在的字段判断权限等级.

Close #635