### PR TITLE
imp: TG 适配器忽略关闭时积压的消息

### DIFF
--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -101,7 +101,6 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 			if update.EditedMessage != nil {
 				if int64(update.EditedMessage.Date) < pa.ActiveTime.Unix() {
 					// This message is edited while pa isn't active.
-					// TODO(Oissevalt): 倘若用户在适配器关闭时修改了 log 中的消息，这是否是预期行为?
 					continue
 				}
 

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -19,6 +19,7 @@ type PlatformAdapterTelegram struct {
 	ProxyURL      string           `yaml:"proxyURL" json:"proxyURL"`
 	EndPoint      *EndPointInfo    `yaml:"-" json:"-"`
 	IntentSession *tgbotapi.BotAPI `yaml:"-" json:"-"`
+	ActiveTime    time.Time        `yaml:"-" json:"-"` // 用于区分adapter关闭时堆积的消息，不进入配置文件
 }
 
 func (pa *PlatformAdapterTelegram) GetGroupInfoAsync(groupID string) {
@@ -82,12 +83,15 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 	d := pa.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
-	pa.Session.Parent.Logger.Infof("Telegram 服务连接成功，账号<%s>(%s)", bot.Self.UserName, pa.EndPoint.UserID)
-	updateConfig := tgbotapi.NewUpdate(0)
 
+	pa.Session.Parent.Logger.Infof("Telegram 服务连接成功，账号<%s>(%s)", bot.Self.UserName, pa.EndPoint.UserID)
+
+	updateConfig := tgbotapi.NewUpdate(0)
 	updateConfig.Timeout = 30
 
 	updates := bot.GetUpdatesChan(updateConfig)
+	pa.ActiveTime = time.Now()
+
 	go func() {
 		for update := range updates {
 			if pa.IntentSession == nil {
@@ -95,6 +99,12 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 			}
 
 			if update.EditedMessage != nil {
+				if int64(update.EditedMessage.Date) < pa.ActiveTime.Unix() {
+					// This message is edited while pa isn't active.
+					// TODO(Oissevalt): 倘若用户在适配器关闭时修改了 log 中的消息，这是否是预期行为?
+					continue
+				}
+
 				msg := pa.toStdMessage(update.EditedMessage)
 				mctx := &MsgContext{
 					Session:     pa.Session,
@@ -110,13 +120,21 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 				go pa.Session.OnMessageEdit(mctx, msg)
 				continue
 			}
+
 			if update.Message == nil {
 				continue
 			}
+
 			msgRaw := update.Message
 			if msgRaw.From.IsBot {
 				continue
 			}
+
+			if int64(msgRaw.Date) < pa.ActiveTime.Unix() {
+				// This message is created while pa isn't active; it should be ignored.
+				continue
+			}
+
 			msg := pa.toStdMessage(msgRaw)
 			if msgRaw.NewChatMembers != nil {
 				for _, member := range msgRaw.NewChatMembers {


### PR DESCRIPTION
1. 认为这应该是预期行为
2. 加入 ActiveTime 字段，该字段仅在 Serve 中被更新和读取，没有必要被序列化