### PR TITLE
feat: js插件元数据增加海豹版本约束字段

### DIFF
--- a/dice/dice.go
+++ b/dice/dice.go
@@ -50,6 +50,12 @@ var (
 	APP_CHANNEL = "dev" //nolint:revive
 
 	VERSION_CODE = int64(1004004) //nolint:revive
+
+	VERSION_JSAPI_COMPATIBLE = []*semver.Version{
+		VERSION,
+		semver.MustParse("1.4.4"),
+		semver.MustParse("1.4.3"),
+	}
 )
 
 type CmdExecuteResult struct {

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -844,9 +844,15 @@ func (d *Dice) JsParseMeta(s string, installTime time.Time, rawData []byte, buil
 					continue
 				}
 
-				_, verOK := lo.Find(VERSION_JSAPI_COMPATIBLE, func(v *semver.Version) bool {
-					return vc.Check(v)
-				})
+				var verOK bool
+				// 有特殊符号时，进行严格的版本检查(只检查当前版本)
+				if strings.ContainsAny(v, "~*^<=>") {
+					verOK = vc.Check(VERSION)
+				} else {
+					_, verOK = lo.Find(VERSION_JSAPI_COMPATIBLE, func(v *semver.Version) bool {
+						return vc.Check(v)
+					})
+				}
 
 				if !verOK {
 					errMsg = append(errMsg, fmt.Sprintf("插件「%s」依赖的海豹版本限制在 %s，与海豹版本(%s)的JSAPI不兼容", jsInfo.Name, v, VERSION.String()))

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -846,7 +846,7 @@ func (d *Dice) JsParseMeta(s string, installTime time.Time, rawData []byte, buil
 
 				var verOK bool
 				// 有特殊符号时，进行严格的版本检查(只检查当前版本)
-				if strings.ContainsAny(v, "~*^<=>|") {
+				if strings.ContainsAny(v, "~*^<=>|") || strings.Contains(v, " - ") {
 					verOK = vc.Check(VERSION)
 				} else {
 					_, verOK = lo.Find(VERSION_JSAPI_COMPATIBLE, func(v *semver.Version) bool {

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -846,7 +846,7 @@ func (d *Dice) JsParseMeta(s string, installTime time.Time, rawData []byte, buil
 
 				var verOK bool
 				// 有特殊符号时，进行严格的版本检查(只检查当前版本)
-				if strings.ContainsAny(v, "~*^<=>") {
+				if strings.ContainsAny(v, "~*^<=>|") {
 					verOK = vc.Check(VERSION)
 				} else {
 					_, verOK = lo.Find(VERSION_JSAPI_COMPATIBLE, func(v *semver.Version) bool {

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/samber/lo"
 	"io"
 	"io/fs"
 	"net/http"
@@ -25,6 +24,7 @@ import (
 	fetch "github.com/fy0/gojax/fetch"
 	"github.com/golang-module/carbon"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"gopkg.in/elazarl/goproxy.v1"
 	"gopkg.in/yaml.v3"
 


### PR DESCRIPTION
参考了 #649

![image](https://github.com/sealdice/sealdice-core/assets/1579850/cdf0e668-622d-42ab-9072-31ad5f37b17a)


### 设定此插件需要的海豹兼容版本(推荐)

这项功能用于指定海豹的**插件兼容版本**，你可以理解为最低海豹版本。

插件作者只需在插件 UserScript 部分，填写字段：
```
// @sealVersion 1.4.5
```

这代表插件可以至少在海豹的1.4.5的兼容版本可用，通常来说2.0之前都是被兼容的。

1.4.5的兼容版本，意思是除了1.4.5版本之外，可能是更高的版本。比如1.5.0等，只要原本的插件API不做修改，可以一直兼容。

当失去版本兼容性时，插件会被自动禁用。


### 我需要指定仅有特定海豹版本可以加载我的插件

如果出于某些原因，你不信任海豹官方设定的插件兼容版本，只希望自己的插件运行在特定版本，可以这样写：
```
// @sealVersion =1.4.5
```

这样会将海豹约束在 1.4.5 版本，任何高于或低于此版本的海豹，都不能加载你的插件。

如果你想要制定一个范围，那么可以这样写：
```
// @sealVersion >=1.4.5, <1.5.0
```

或者
```
// @sealVersion >=1.4.*
```

特别注意的是，dev版本和主版本不是一回事，例如说：
```
// @sealVersion >=1.4.5, <1.6.0
```
这个版本号不能被 1.5.0-dev 所加载，如果你希望你的插件在dev和正式版都可用，你可以写：
```
// @sealVersion 1.4.* || 1.4.*-dev
```

更多写法，请参考 semver 标准
