### PR TITLE
perf(Log): `log-exports` 文件名使用时间戳替换随机数

### DIFF
--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -942,7 +942,14 @@ func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (string, 
 	}
 
 	// 本地进行一个zip留档，以防万一
-	fzip, _ := os.CreateTemp(dirpath, FilenameReplace(groupID+"_"+logName)+".*.zip")
+	fzip, _ := os.OpenFile(
+		filepath.Join(dirpath, FilenameReplace(fmt.Sprintf(
+			"%s_%s.%s.zip",
+			groupID, logName, time.Now().Format("060102150405"),
+		))),
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+		0o600,
+	)
 	writer := zip.NewWriter(fzip)
 
 	text := ""


### PR DESCRIPTION
目的是使字典顺序与导出时间顺序一致

Issue #512