### PR TITLE
fix: 修复简化卡支持引起的 .st san-d6 问题

### DIFF
--- a/dice/ext_exp.go
+++ b/dice/ext_exp.go
@@ -515,12 +515,8 @@ func getCmdStBase() *CmdItemInfo {
 
 					isName := flag == "#"
 					if !isName {
-						// 尝试作为名字处理
-						name = tmpl.GetAlias(name)
-						// 注: 这两句逻辑上是对的，但是chVars.Get()第二个值一直返回true，导致永远判定不了是名字
-						// _, exists := chVars.Get(name)
-						// isName = !exists
-						isName = true // 先调整为true
+						// 先尝试作为名字处理
+						isName = true
 
 						// 如果"-"后面跟的句子进行了计算(骰点、符号、变量)，且不剩余文本，此时为值(如d4)，而不是名字
 						r, _, err := ctx.Dice.ExprEval(val, ctx)
@@ -530,9 +526,11 @@ func getCmdStBase() *CmdItemInfo {
 
 						if isName {
 							// 好像是个名字了，先再看看是不是带默认值的属性
-							if _, _, _, exists := tmpl.GetDefaultValueEx0(mctx, name); exists {
+							valName := tmpl.GetAlias(name)
+							if _, _, _, exists := tmpl.GetDefaultValueEx0(mctx, valName); exists {
 								// 有默认值，不能作为名字
 								isName = false
+								name = valName
 							}
 						}
 					}

--- a/dice/ext_exp.go
+++ b/dice/ext_exp.go
@@ -506,11 +506,12 @@ func getCmdStBase() *CmdItemInfo {
 
 				// 进行简化卡的尝试解析
 				input := cmdArgs.CleanArgs
-				re := regexp.MustCompile(`^(([^\s\-#]{1,25})([-#]))[^\s\d]+\d+`)
+				re := regexp.MustCompile(`^(([^\s\-#]{1,25})([-#]))([^\s\d]+\d+)`)
 				matches := re.FindStringSubmatch(input)
 				if len(matches) > 0 {
 					flag := matches[3]
 					name := matches[2]
+					val := matches[4]
 
 					isName := flag == "#"
 					if !isName {
@@ -520,6 +521,12 @@ func getCmdStBase() *CmdItemInfo {
 						// _, exists := chVars.Get(name)
 						// isName = !exists
 						isName = true // 先调整为true
+
+						// 如果"-"后面跟的句子进行了计算(骰点、符号、变量)，且不剩余文本，此时为值(如d4)，而不是名字
+						r, _, err := ctx.Dice.ExprEval(val, ctx)
+						if err == nil && r.restInput == "" && r.Parser.Calculated {
+							isName = false
+						}
 
 						if isName {
 							// 好像是个名字了，先再看看是不是带默认值的属性


### PR DESCRIPTION
#657 相关，使用的解决方案并非是里面提到的三种，而是与.r的解决方案类似。

自测内容包括：
```
.st san-d6 # 理智 -= 1d6
.st san-1d6 # 理智 -= 1d6
.st san-1 # 理智 -= 1
.st san-力量30  # san 录入力量30
.st san#d2 # san 录入d: 2

.st x:2
.st san-x # san -= 2
.st san-x2 # san 录入 x: 2
.st san-y # san -= 0

.st &x=d100
.st san-x # san -= d100
```
