### PR TITLE
refactor: 删除了dns hack相关代码

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io/fs"
 	"mime"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -207,7 +205,6 @@ func main() {
 	if runtime.GOOS == "android" {
 		fixTimezone()
 	}
-	dnsHack()
 
 	_ = os.MkdirAll("./data", 0o755)
 	MainLoggerInit("./data/main.log", true)
@@ -573,24 +570,6 @@ func uiServe(dm *dice.DiceManager, hideUI bool, useBuiltin bool) {
 //	}
 //	return false
 // }
-
-func dnsHack() {
-	var (
-		dnsResolverIP    = "114.114.114.114:53" // Google DNS resolver.
-		dnsResolverProto = "udp"                // Protocol to use for the DNS resolver
-	)
-	var dialer net.Dialer
-	net.DefaultResolver = &net.Resolver{
-		PreferGo: false,
-		Dial: func(context context.Context, _, _ string) (net.Conn, error) {
-			conn, err := dialer.DialContext(context, dnsResolverProto, dnsResolverIP)
-			if err != nil {
-				return nil, err
-			}
-			return conn, nil
-		},
-	}
-}
 
 func mimePatch() {
 	builtinMimeTypesLower := map[string]string{


### PR DESCRIPTION
这些代码在2年前的4月21日引入，版本是1.0.0
有可能是为了处理部分服务器上域名解析的偏差问题。但是最近接到反馈说存在副作用案例，在一台国外服务器上无法一边连接discord一边连接海豹api上传log。
