### PR TITLE
fix: 修复受邀加入无需审核的群时邀请人显示未知的问题

### DIFF
--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -780,9 +780,13 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 			// 判断进群的人是自己，自动启动
 			gi := SetBotOnAtGroup(ctx, msg.GroupID)
+			// 获取邀请人ID
+			uid := FormatDiceIDQQ(string(msgQQ.OperatorID))
 			if tempInviteMap2[msg.GroupID] != "" {
 				// 设置邀请人
 				gi.InviteUserID = tempInviteMap2[msg.GroupID]
+			} else {
+				gi.InviteUserID = uid
 			}
 			gi.DiceIDExistsMap.Store(ep.UserID, true)
 			gi.EnteredTime = nowTime // 设置入群时间


### PR DESCRIPTION
使用LLOneBot方式搭骰后，骰子受邀加入无需审核的群时，后台群组管理显示邀请人未知，且此时不会触发群受邀通知，而是直接触发成功入群通知
![55b20c530d2e963e6b6b69167adb605f](https://github.com/sealdice/sealdice-core/assets/84258717/3428bfc9-a839-4d42-bfff-94ce86a970e0)
修复后
![d27ed34dd5469179a3b8bcb92680c633](https://github.com/sealdice/sealdice-core/assets/84258717/5679a44d-2774-4ea4-9c37-111b35193099)
