### PR TITLE
refactor(JS): 重置JS环境时一并清除加载的规则模板

### DIFF
--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -515,6 +515,9 @@ func (d *Dice) jsClear() {
 	d.CocExtraRules = map[int]*CocRuleInfo{}
 	// 清理脚本列表
 	d.JsScriptList = []*JsScriptInfo{}
+	// 清理规则模板
+	d.GameSystemMap = &SyncMap[string, *GameSystemTemplate]{}
+	d.RegisterBuiltinSystemTemplate()
 	// 关闭js vm
 	if d.JsLoop != nil {
 		d.JsLoop.Stop()

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -20,6 +20,12 @@ func (d *Dice) RegisterBuiltinExt() {
 	RegisterBuiltinExtDnd5e(d)
 	RegisterBuiltinStory(d)
 	RegisterBuiltinExtExp(d)
+
+	d.RegisterBuiltinSystemTemplate()
+}
+
+func (d *Dice) RegisterBuiltinSystemTemplate() {
+	d.GameSystemTemplateAdd(getCoc7CharTemplate())
 }
 
 // RegisterExtension 注册扩展

--- a/dice/ext_coc7.go
+++ b/dice/ext_coc7.go
@@ -260,9 +260,6 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 		maniaMap[n] = i[2]
 	}
 
-	// 初始化规则模板
-	self.GameSystemTemplateAdd(getCoc7CharTemplate())
-
 	helpRc := "" +
 		".ra/rc <属性表达式> // 属性检定指令，当前者小于等于后者，检定通过\n" +
 		".ra <难度><属性> // 如 .ra 困难侦查\n" +


### PR DESCRIPTION
只经过简单测试

Fix #760