### PR TITLE
feat(Backup): 增加可选的额外备份内容

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -588,7 +588,7 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.GET(prefix+"/checkSecurity", checkSecurity)
 
 	e.GET(prefix+"/backup/list", backupGetList)
-	e.POST(prefix+"/backup/do_backup", backupSimple)
+	e.POST(prefix+"/backup/do_backup", backupExec)
 	e.GET(prefix+"/backup/config_get", backupConfigGet)
 	e.POST(prefix+"/backup/config_set", backupConfigSave)
 	e.GET(prefix+"/backup/download", backupDownload)

--- a/api/backup.go
+++ b/api/backup.go
@@ -122,7 +122,7 @@ func backupBatchDelete(c echo.Context) error {
 }
 
 // 快速备份
-func backupSimple(c echo.Context) error {
+func backupExec(c echo.Context) error {
 	if !doAuth(c) {
 		return c.JSON(http.StatusForbidden, nil)
 	}
@@ -132,15 +132,24 @@ func backupSimple(c echo.Context) error {
 		})
 	}
 
-	_, err := dm.BackupSimple()
+	v := struct {
+		Selection uint64 `json:"selection"`
+	}{}
+	err := c.Bind(&v)
+	if err != nil {
+		return Error(&c, err.Error(), Response{})
+	}
+
+	_, err = dm.Backup(dice.BackupSelection(v.Selection), false)
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"success": err == nil,
 	})
 }
 
 type backupConfig struct {
-	AutoBackupEnable bool   `json:"autoBackupEnable"`
-	AutoBackupTime   string `json:"autoBackupTime"`
+	AutoBackupEnable    bool   `json:"autoBackupEnable"`
+	AutoBackupTime      string `json:"autoBackupTime"`
+	AutoBackupSelection uint64 `json:"autoBackupSelection"`
 
 	BackupCleanStrategy  int    `json:"backupCleanStrategy"`
 	BackupCleanKeepCount int    `json:"backupCleanKeepCount"`
@@ -153,6 +162,7 @@ func backupConfigGet(c echo.Context) error {
 	bc := backupConfig{}
 	bc.AutoBackupEnable = dm.AutoBackupEnable
 	bc.AutoBackupTime = dm.AutoBackupTime
+	bc.AutoBackupSelection = uint64(dm.AutoBackupSelection)
 	bc.BackupCleanStrategy = int(dm.BackupCleanStrategy)
 	bc.BackupCleanKeepCount = dm.BackupCleanKeepCount
 	bc.BackupCleanKeepDur = dm.BackupCleanKeepDur.String()
@@ -179,6 +189,7 @@ func backupConfigSave(c echo.Context) error {
 
 	dm.AutoBackupEnable = v.AutoBackupEnable
 	dm.AutoBackupTime = v.AutoBackupTime
+	dm.AutoBackupSelection = dice.BackupSelection(v.AutoBackupSelection)
 
 	if int(dice.BackupCleanStrategyDisabled) <= v.BackupCleanStrategy && v.BackupCleanStrategy <= int(dice.BackupCleanStrategyByTime) {
 		dm.BackupCleanStrategy = dice.BackupCleanStrategy(v.BackupCleanStrategy)

--- a/api/misc.go
+++ b/api/misc.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"sealdice-core/dice"
+
 	"github.com/labstack/echo/v4"
 	cp "github.com/otiai10/copy"
 )
@@ -36,7 +38,7 @@ func upgrade(c echo.Context) error {
 			ret := <-dm.UpdateDownloadedChan
 			if ret == "" {
 				myDice.Save(true)
-				bakFn, _ := myDice.Parent.BackupSimple()
+				bakFn, _ := myDice.Parent.Backup(dice.BackupSelectionAll, false)
 				tmpParent := os.TempDir()
 				tmpPath := path.Join(tmpParent, bakFn)
 				_ = os.MkdirAll(filepath.Join(tmpParent, "backups"), 0644)

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -950,7 +950,7 @@ func (d *Dice) registerCoreCommands() {
 			case "backup":
 				ReplyToSender(ctx, msg, "开始备份数据")
 
-				_, err := ctx.Dice.Parent.BackupSimple()
+				_, err := ctx.Dice.Parent.Backup(ctx.Dice.Parent.AutoBackupSelection, false)
 				if err == nil {
 					ReplyToSender(ctx, msg, "备份成功！请到UI界面(综合设置-备份)处下载备份，或在骰子backup目录下读取")
 				} else {
@@ -1018,7 +1018,7 @@ func (d *Dice) registerCoreCommands() {
 					ctx.Dice.UpgradeEndpointID = ctx.EndPoint.ID
 					ctx.Dice.Save(true)
 
-					bakFn, _ := ctx.Dice.Parent.BackupSimple()
+					bakFn, _ := ctx.Dice.Parent.Backup(BackupSelectionAll, false)
 					tmpPath := path.Join(os.TempDir(), bakFn)
 					_ = os.MkdirAll(tmpPath, 0755)
 					ctx.Dice.Logger.Infof("将备份文件复制到此路径: %s", tmpPath)

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -46,9 +46,11 @@ type DiceManager struct { //nolint:revive
 	AccessTokens   map[string]bool
 	IsReady        bool
 
-	AutoBackupEnable bool
-	AutoBackupTime   string
-	backupEntryID    cron.EntryID
+	AutoBackupEnable    bool
+	AutoBackupTime      string
+	AutoBackupSelection BackupSelection
+	backupEntryID       cron.EntryID
+
 	// 备份自动清理配置
 	BackupCleanStrategy  BackupCleanStrategy // 关闭 / 保留一定数量 / 保留一定时间
 	BackupCleanKeepCount int                 // 保留的数量
@@ -90,8 +92,9 @@ type DiceConfigs struct { //nolint:revive
 	UIPasswordHash string   `yaml:"uiPasswordHash"`
 	AccessTokens   []string `yaml:"accessTokens"`
 
-	AutoBackupEnable bool   `yaml:"autoBackupEnable"`
-	AutoBackupTime   string `yaml:"autoBackupTime"`
+	AutoBackupEnable    bool   `yaml:"autoBackupEnable"`
+	AutoBackupTime      string `yaml:"autoBackupTime"`
+	AutoBackupSelection uint64 `yaml:"autoBackupSelection"`
 
 	BackupClean struct {
 		Strategy  int    `yaml:"strategy"`
@@ -169,6 +172,7 @@ func (dm *DiceManager) LoadDice() {
 
 	dm.AutoBackupTime = dc.AutoBackupTime
 	dm.AutoBackupEnable = dc.AutoBackupEnable
+	dm.AutoBackupSelection = BackupSelection(dc.AutoBackupSelection)
 
 	if dc.AutoBackupTime == "" {
 		// 从旧版升级
@@ -203,6 +207,7 @@ func (dm *DiceManager) Save() {
 	dc.AccessTokens = []string{}
 	dc.AutoBackupTime = dm.AutoBackupTime
 	dc.AutoBackupEnable = dm.AutoBackupEnable
+	dc.AutoBackupSelection = uint64(dm.AutoBackupSelection)
 	dc.BackupClean.Strategy = int(dm.BackupCleanStrategy)
 	dc.BackupClean.KeepCount = dm.BackupCleanKeepCount
 	dc.BackupClean.KeepDur = int64(dm.BackupCleanKeepDur)


### PR DESCRIPTION
# 需要帮助完成前端实现

## `/backup/config_get` & `/backup/config_set`

数据结构中增加一项 `autoBackupSelection`, 类型是 uint64, 为 pow2 组合

## `/backup/do_backup`

增加 body, 格式如下, 字段类型为 uint64:

```json
{
  "selection": 63
}
``` 

## pow2 各 bit 的含义

| 内容 | 值 |
|-----|-----|
| JS(插件和数据库) | 1 |
| 牌堆 | 2 |
| 帮助文档 | 4 |
| 敏感词库 | 8 |
| 人名数据 | 16 |
| 图片资源 | 32 |
--- 

Close #758 