### PR TITLE
fix: 内置客户端在未登录成功前已开始尝试ws正向连接

### DIFF
--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1160,6 +1160,7 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 				_ = recover()
 			}()
 			pa.Socket.Close()
+			pa.diceServing = false
 		}()
 	}
 

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1239,8 +1239,8 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 					UseSignServer:    pa.UseSignServer,
 					SignServerConfig: pa.SignServerConfig,
 				})
+				go ServeQQ(d, c)
 			}
-			go ServeQQ(d, c)
 		} else {
 			go ServeQQ(d, c)
 		}

--- a/main.go
+++ b/main.go
@@ -499,6 +499,7 @@ func diceServe(d *dice.Dice) {
 							dice.LagrangeServe(d, conn, dice.GoCqhttpLoginInfo{
 								IsAsyncRun: true,
 							})
+							return
 						} else {
 							dice.GoCqhttpServe(d, conn, dice.GoCqhttpLoginInfo{
 								Password:         pa.InPackGoCqhttpPassword,

--- a/main.go
+++ b/main.go
@@ -495,7 +495,7 @@ func diceServe(d *dice.Dice) {
 					}
 					if conn.EndPointInfoBase.ProtocolType == "onebot" {
 						pa := conn.Adapter.(*dice.PlatformAdapterGocq)
-						if pa.Implementation == "lagrange" {
+						if pa.BuiltinMode == "lagrange" {
 							dice.LagrangeServe(d, conn, dice.GoCqhttpLoginInfo{
 								IsAsyncRun: true,
 							})


### PR DESCRIPTION
ServeQQ应当由LagrangeServe登录成功后进行调用，而不是还未登录成功就开始尝试ws正向连接。
问题复现：用户在已添加“内置客户端”账号后，重启核心，在内置客户端还未登录成功时，核心已经开始尝试正向连接，导致有时内置客户端登录成功前已经耗尽尝试次数。