### PR TITLE
fix: ws正向连接地址与已生成的内置客户端配置不符

### DIFF
--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -78,9 +78,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		// 创建配置文件
 		pa.ConnectURL = ""
 		if file, err := os.Open(configFilePath); err == nil {
-			defer func(file *os.File) {
-				_ = file.Close()
-			}(file)
 			if settings, err := io.ReadAll(file); err == nil {
 				var result map[string]interface{}
 				if err := json.Unmarshal(settings, &result); err == nil {
@@ -89,6 +86,7 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 					}
 				}
 			}
+			_ = file.Close()
 		}
 		if pa.ConnectURL == "" {
 			p, _ := GetRandomFreePort()

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,16 +76,13 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 
 		// 创建配置文件
 		pa.ConnectURL = ""
-		if file, err := os.Open(configFilePath); err == nil {
-			if settings, err := io.ReadAll(file); err == nil {
-				var result map[string]interface{}
-				if err := json.Unmarshal(settings, &result); err == nil {
-					if val, ok := result["Implementations"].([]interface{})[0].(map[string]interface{})["Port"].(float64); ok {
-						pa.ConnectURL = fmt.Sprintf("ws://127.0.0.1:%d", int(val))
-					}
+		if file, err := os.ReadFile(configFilePath); err == nil {
+			var result map[string]interface{}
+			if err := json.Unmarshal(file, &result); err == nil {
+				if val, ok := result["Implementations"].([]interface{})[0].(map[string]interface{})["Port"].(float64); ok {
+					pa.ConnectURL = fmt.Sprintf("ws://127.0.0.1:%d", int(val))
 				}
 			}
-			_ = file.Close()
 		}
 		if pa.ConnectURL == "" {
 			p, _ := GetRandomFreePort()

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -81,7 +81,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 			defer func(file *os.File) {
 				_ = file.Close()
 			}(file)
-
 			decoder := json.NewDecoder(file)
 			var result map[string]interface{}
 			err := decoder.Decode(&result)
@@ -90,7 +89,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 					pa.ConnectURL = fmt.Sprintf("ws://127.0.0.1:%d", int(val))
 				}
 			}
-
 		}
 		if pa.ConnectURL == "" {
 			p, _ := GetRandomFreePort()

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"


### PR DESCRIPTION
bug：内置客户端启动时，ws正向连接地址与内置客户端已写好的配置地址不符，两者无法正常连接
解决方案：每次LagrangeServe时应读取已有配置文件中的Port值，如果用户胡乱更改lagr配置文件导致port读取失败，直接覆写一份新的。