### PR TITLE
feat(JS): 插件增加定时任务 api

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -63,6 +63,8 @@ type ConfigItem struct {
 	Deprecated   bool        `json:"deprecated,omitempty" jsbind:"deprecated"`
 
 	Description string `json:"description" jsbind:"description"`
+
+	task *JsScriptTask
 }
 
 type PluginConfig struct {
@@ -185,13 +187,13 @@ func (cm *ConfigManager) UnregisterConfig(pluginName string, keys ...string) {
 	_ = cm.save()
 }
 
-func (cm *ConfigManager) SetConfig(pluginName, key string, value interface{}) {
+func (cm *ConfigManager) SetConfig(pluginName, key string, value interface{}) error {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
 	plugin, ok := cm.Plugins[pluginName]
 	if !ok {
-		return
+		return nil
 	}
 
 	configItem, exists := plugin.Configs[key]
@@ -207,13 +209,24 @@ func (cm *ConfigManager) SetConfig(pluginName, key string, value interface{}) {
 				strarr = append(strarr, strv.(string))
 			}
 			configItem.Value = strarr
+		case "task:cron":
+			fallthrough
+		case "task:daily":
+			val := value.(string)
+			configItem.Value = val
+			// 立即生效
+			task := configItem.task
+			err := task.reset(val)
+			if err != nil {
+				return err
+			}
 		default:
 			configItem.Value = value
 		}
 		plugin.Configs[key] = configItem
 		cm.Plugins[pluginName] = plugin
 	}
-	_ = cm.save()
+	return cm.save()
 }
 
 func (cm *ConfigManager) getConfig(pluginName, key string) *ConfigItem {
@@ -248,6 +261,11 @@ func (cm *ConfigManager) ResetConfigToDefault(pluginName, key string) {
 		fmt.Println("reset config to default", pluginName, key)
 		configItem.Value = configItem.DefaultValue
 		plugin.Configs[key] = configItem
+		if strings.HasPrefix(configItem.Type, "task:") {
+			if configItem.task != nil {
+				_ = configItem.task.reset(configItem.Value.(string))
+			}
+		}
 		cm.Plugins[pluginName] = plugin
 	}
 	_ = cm.save()

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -234,6 +234,7 @@ type Dice struct {
 	JsRequire         *require.RequireModule `yaml:"-" json:"-"`
 	JsLoop            *eventloop.EventLoop   `yaml:"-" json:"-"`
 	JsScriptList      []*JsScriptInfo        `yaml:"-" json:"-"`
+	JsScriptCron      *cron.Cron             `yaml:"-" json:"-"`
 	// 内置脚本摘要表，用于判断内置脚本是否有更新
 	JsBuiltinDigestSet map[string]bool `yaml:"-" json:"-"`
 	// 当前在加载的脚本路径，用于关联 jsScriptInfo 和 ExtInfo

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -24,6 +24,7 @@ import (
 	fetch "github.com/fy0/gojax/fetch"
 	"github.com/golang-module/carbon"
 	"github.com/pkg/errors"
+	"github.com/robfig/cron/v3"
 	"github.com/samber/lo"
 	"gopkg.in/elazarl/goproxy.v1"
 	"gopkg.in/yaml.v3"
@@ -38,6 +39,8 @@ var (
 
 	signRe = regexp.MustCompile(`^// sign\s+([^\r\n]+)?[\r\n]+$`)
 )
+
+var taskTimeRe = regexp.MustCompile(`^([0-9]|1[0-9]|2[0-3]):([0-5][0-9])$`)
 
 type PrinterFunc struct {
 	d        *Dice
@@ -88,6 +91,9 @@ func (d *Dice) JsInit() {
 	printer := &PrinterFunc{d, false, []string{}}
 	d.JsPrinter = printer
 	reg.RegisterNativeModule("console", console.RequireWithPrinter(printer))
+
+	d.JsScriptCron = cron.New()
+	d.JsScriptCron.Start()
 
 	// 初始化
 	loop.Run(func(vm *goja.Runtime) {
@@ -340,6 +346,88 @@ func (d *Dice) JsInit() {
 			}
 			d.ConfigManager.UnregisterConfig(ei.Name, key...)
 		})
+
+		_ = ext.Set("registerTask", func(ei *ExtInfo, taskType string, value string, fn func(taskCtx JsScriptTaskCtx), key string, desc string) *JsScriptTask {
+			if ei.dice == nil {
+				panic(errors.New("请先完成此扩展的注册"))
+			}
+			scriptCron := ei.dice.JsScriptCron
+			if scriptCron == nil {
+				panic(errors.New("插件cron未成功初始化")) // 按理是不会发生的
+			}
+
+			task := JsScriptTask{cron: scriptCron, key: key, task: fn}
+			expr := value
+			if key != "" {
+				config := d.ConfigManager.getConfig(ei.Name, key)
+				if config != nil {
+					expr = config.Value.(string)
+					config.task = &task
+				}
+			}
+
+			switch taskType {
+			case "cron":
+				entryID, err := scriptCron.AddFunc(expr, func() {
+					task.run()
+				})
+				if err != nil {
+					panic("插件注册定时任务失败：" + err.Error())
+				}
+				task.taskType = taskType
+				task.rawValue = expr
+				task.cronExpr = expr
+				task.entryID = &entryID
+				ei.dice.Logger.Infof("插件注册定时任务：cron=%s", expr)
+			case "daily":
+				// 支持每天定时触发，24 小时表示
+				cronExpr, err := parseTaskTime(expr)
+				if err != nil {
+					panic("插件注册定时任务失败：" + err.Error())
+				}
+
+				entryID, err := scriptCron.AddFunc(cronExpr, func() {
+					task.run()
+				})
+				if err != nil {
+					panic("插件注册定时任务失败：" + err.Error())
+				}
+				task.taskType = taskType
+				task.rawValue = expr
+				task.cronExpr = cronExpr
+				task.entryID = &entryID
+				ei.dice.Logger.Infof("插件注册定时任务：daily=%s", expr)
+			default:
+				panic(fmt.Sprintf("错误的任务类型：%s，当前仅支持 cron|daily", taskType))
+			}
+
+			if key != "" {
+				var config *ConfigItem
+				switch taskType {
+				case "cron":
+					config = &ConfigItem{
+						Key:          key,
+						Type:         "task:cron",
+						Value:        expr,
+						DefaultValue: value,
+						Description:  desc,
+						task:         &task,
+					}
+				case "daily":
+					config = &ConfigItem{
+						Key:          key,
+						Type:         "task:daily",
+						Value:        expr,
+						DefaultValue: value,
+						Description:  desc,
+						task:         &task,
+					}
+				}
+				d.ConfigManager.RegisterPluginConfig(ei.Name, config)
+			}
+			return &task
+		})
+
 		// COC规则自定义
 		coc := vm.NewObject()
 		_ = coc.Set("newRule", func() *CocRuleInfo {
@@ -1153,4 +1241,86 @@ func sortJsScripts(jsScripts []*JsScriptInfo) ([]*JsScriptInfo, map[string][]str
 		}
 	}
 	return result, infos
+}
+
+type JsScriptTask struct {
+	taskType string
+	key      string
+	rawValue string
+
+	cron     *cron.Cron
+	cronExpr string
+	task     func(JsScriptTaskCtx)
+	entryID  *cron.EntryID
+}
+
+type JsScriptTaskCtx struct {
+	Now int64  `jsbind:"now"`
+	Key string `jsbind:"key"`
+}
+
+func (t *JsScriptTask) run() {
+	taskCtx := JsScriptTaskCtx{
+		Now: time.Now().Unix(),
+		Key: t.key,
+	}
+	t.task(taskCtx)
+}
+
+func (t *JsScriptTask) On() bool {
+	if t.entryID != nil {
+		return true
+	}
+	entryID, err := t.cron.AddFunc(t.cronExpr, func() {
+		t.run()
+	})
+	if err != nil {
+		return false
+	}
+	t.entryID = &entryID
+	return true
+}
+
+func (t *JsScriptTask) Off() bool {
+	if t.entryID == nil {
+		return true
+	}
+	t.cron.Remove(*t.entryID)
+	t.entryID = nil
+	return true
+}
+
+func (t *JsScriptTask) reset(expr string) error {
+	if t.entryID != nil {
+		t.Off()
+		defer t.On()
+	}
+
+	t.rawValue = expr
+	switch t.taskType {
+	case "cron":
+		t.cronExpr = expr
+	case "daily":
+		cronExpr, err := parseTaskTime(expr)
+		if err != nil {
+			return err
+		}
+		t.cronExpr = cronExpr
+	default:
+		return fmt.Errorf("unknown task type %s", t.taskType)
+	}
+	return nil
+}
+
+// parseTaskTime 将 24 小时时间转换为 cron 表达式
+func parseTaskTime(taskTimeStr string) (string, error) {
+	match := taskTimeRe.MatchString(taskTimeStr)
+	if !match {
+		return "", fmt.Errorf("仅接受 24 小时表示的时间作为每天的执行时间，如 0:05 13:30")
+	}
+	sub := taskTimeRe.FindStringSubmatch(taskTimeStr)
+	hours, _ := strconv.ParseInt(sub[1], 10, 64)
+	minutes, _ := strconv.ParseInt(sub[2], 10, 64)
+	cronExpr := fmt.Sprintf("%d %d * * *", minutes, hours)
+	return cronExpr, nil
 }


### PR DESCRIPTION
新增 API 如下：
```javascript
seal.ext.registerTask(ext, 'cron', '30 8 * * *', (taskCtx) => {});
seal.ext.registerTask(ext, 'daily', '8:00', (taskCtx) => {}); // 24 小时制
```

Close #761