### PR TITLE
fix: 修复 `.sn` 指令中存在的重复 `.sn dnd` 说明

### DIFF
--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -569,10 +569,9 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 				return true
 			})
-			text += `.sn dnd // 自动设置dnd名片
-.sn expr {$t玩家_RAW} HP{hp}/{hpmax} // 自设格式
-.sn none // 设置为空白格式
-.sn off // 取消自动设置`
+			text += ".sn expr {$t玩家_RAW} HP{hp}/{hpmax} // 自设格式\n" +
+				".sn none // 设置为空白格式\n" +
+				".sn off // 取消自动设置"
 			if isShort {
 				return text
 			}


### PR DESCRIPTION
fix #875 