### PR TITLE
fix(#902): .init set 后先攻列表不重新排序

### DIFF
--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -1256,6 +1256,7 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 						break
 					}
 				}
+				sort.Sort(riList)
 
 				VarSetValueStr(ctx, "$t表达式", expr)
 				VarSetValueStr(ctx, "$t目标", name)


### PR DESCRIPTION
Solve #902 
A mirror of #906 as requested by @Xiangze-Li 