### PR TITLE
feat: 添加 master jsclear 指令清除插件存储

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -1137,26 +1137,28 @@ func (d *Dice) registerCoreCommands() {
 					return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 				}
 				// Cannot use sort.Search; requires sorting for binary search.
-				index := -1
-				for i, ext := range ctx.Dice.ExtList {
-					if ext.Name == extName {
-						if !ext.IsJsExt {
+				var ext *ExtInfo
+				for _, e := range ctx.Dice.ExtList {
+					if e.Name == extName {
+						if !e.IsJsExt {
 							ReplyToSender(ctx, msg, fmt.Sprintf("%s是内置模块，为了骰子的正常运行，暂不支持清除", extName))
 							return CmdExecuteResult{Matched: true, Solved: true}
 						}
-						index = i
+						ext = e
 						break
 					}
 				}
-				if index == -1 {
+				if ext == nil {
 					ReplyToSender(ctx, msg, "没有找到插件"+extName)
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
-				if err := ClearExtStorage(ctx.Dice, extName); err != nil {
+				err := ClearExtStorage(ctx.Dice, ext, extName)
+				if err != nil {
 					ctx.Dice.Logger.Errorf("jsclear: %v", err)
 					ReplyToSender(ctx, msg, "清除数据失败，请查看日志")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
+				d.JsReload()
 				ReplyToSender(ctx, msg, fmt.Sprintf("已经清除%s数据，重新加载JS插件", extName))
 				return CmdExecuteResult{Matched: true, Solved: true}
 			default:

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -1152,7 +1152,7 @@ func (d *Dice) registerCoreCommands() {
 					ReplyToSender(ctx, msg, "没有找到插件"+extName)
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
-				if err := ctx.Dice.ClearExtStorage(extName); err != nil {
+				if err := ClearExtStorage(ctx.Dice, extName); err != nil {
 					ctx.Dice.Logger.Errorf("jsclear: %v", err)
 					ReplyToSender(ctx, msg, "清除数据失败，请查看日志")
 					return CmdExecuteResult{Matched: true, Solved: true}

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -1157,7 +1157,6 @@ func (d *Dice) registerCoreCommands() {
 					ReplyToSender(ctx, msg, "清除数据失败，请查看日志")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
-				d.JsReload()
 				ReplyToSender(ctx, msg, fmt.Sprintf("已经清除%s数据，重新加载JS插件", extName))
 				return CmdExecuteResult{Matched: true, Solved: true}
 			default:

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -1136,28 +1136,24 @@ func (d *Dice) registerCoreCommands() {
 				if extName == "" {
 					return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 				}
-				// Cannot use sort.Search; requires sorting for binary search.
-				var ext *ExtInfo
-				for _, e := range ctx.Dice.ExtList {
-					if e.Name == extName {
-						if !e.IsJsExt {
-							ReplyToSender(ctx, msg, fmt.Sprintf("%s是内置模块，为了骰子的正常运行，暂不支持清除", extName))
-							return CmdExecuteResult{Matched: true, Solved: true}
-						}
-						ext = e
-						break
-					}
-				}
+
+				ext := ctx.Dice.ExtFind(extName)
 				if ext == nil {
 					ReplyToSender(ctx, msg, "没有找到插件"+extName)
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
+				if !ext.IsJsExt {
+					ReplyToSender(ctx, msg, fmt.Sprintf("%s是内置模块，为了骰子的正常运行，暂不支持清除", extName))
+					return CmdExecuteResult{Matched: true, Solved: true}
+				}
+
 				err := ClearExtStorage(ctx.Dice, ext, extName)
 				if err != nil {
 					ctx.Dice.Logger.Errorf("jsclear: %v", err)
 					ReplyToSender(ctx, msg, "清除数据失败，请查看日志")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
+
 				d.JsReload()
 				ReplyToSender(ctx, msg, fmt.Sprintf("已经清除%s数据，重新加载JS插件", extName))
 				return CmdExecuteResult{Matched: true, Solved: true}

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -62,7 +62,7 @@ func (d *Dice) GetExtConfigFilePath(extName string, filename string) string {
 // ClearExtStorage stops the JS environment, deletes the extension's
 // storage.db file and restarts the JS environment. It does not return an error
 // if the file does not exist.
-func (d *Dice) ClearExtStorage(name string) error {
+func ClearExtStorage(d *Dice, name string) error {
 	dbPath := filepath.Join(d.BaseConfig.DataDir, "extensions", name, "storage.db")
 	d.JsShutdown()
 	defer d.JsInit()

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -59,8 +59,13 @@ func (d *Dice) GetExtConfigFilePath(extName string, filename string) string {
 	return path.Join(d.GetExtDataDir(extName), filename)
 }
 
+// ClearExtStorage stops the JS environment, deletes the extension's
+// storage.db file and restarts the JS environment. It does not return an error
+// if the file does not exist.
 func (d *Dice) ClearExtStorage(name string) error {
 	dbPath := filepath.Join(d.BaseConfig.DataDir, "extensions", name, "storage.db")
+	d.JsShutdown()
+	defer d.JsInit()
 	err := os.Remove(dbPath)
 	if errors.Is(err, os.ErrNotExist) {
 		err = nil

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 
 	"github.com/dop251/goja"
@@ -56,6 +57,15 @@ func (d *Dice) GetDiceDataPath(name string) string {
 
 func (d *Dice) GetExtConfigFilePath(extName string, filename string) string {
 	return path.Join(d.GetExtDataDir(extName), filename)
+}
+
+func (d *Dice) ClearExtStorage(name string) error {
+	dbPath := filepath.Join(d.BaseConfig.DataDir, "extensions", name, "storage.db")
+	err := os.Remove(dbPath)
+	if errors.Is(err, os.ErrNotExist) {
+		err = nil
+	}
+	return err
 }
 
 func GetExtensionDesc(ei *ExtInfo) string {


### PR DESCRIPTION
- 添加 `func (d *Dice) ClearExtStorage(name string) error`，删除 `data/default/extensions/{name}/storage.db`
- 添加 master jsclear 命令，执行上面的函数，不可删除内置插件数据