### PR TITLE
fix(dnd5e): 修正rc代骰，以及死亡豁免文案等问题

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -37,6 +37,7 @@ type AtInfo struct {
 func (i *AtInfo) CopyCtx(ctx *MsgContext) (*MsgContext, bool) {
 	c1 := *ctx
 	mctx := &c1 // 复制一个ctx，用于其他用途
+	mctx.vm = nil
 	if ctx.Group != nil {
 		p := ctx.Group.PlayerGet(ctx.Dice.DBData, i.UserID)
 		if p != nil {

--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -877,15 +877,15 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
-				detail := r.vm.GetDetailText()
+				exprToShow := fmt.Sprintf("[%s]", expr)
 				if d20 == 20 {
 					deathSavingStable(mctx)
 					VarSetValueInt64(mctx, "hp", 1)
 					suffix := DiceFormatTmpl(mctx, "DND:死亡豁免_D20_附加语")
-					ReplyToSender(mctx, msg, fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), detail, d20, suffix))
+					ReplyToSender(mctx, msg, fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), exprToShow, d20, suffix))
 				} else if d20 == 1 {
 					suffix := DiceFormatTmpl(mctx, "DND:死亡豁免_D1_附加语")
-					text := fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), detail, d20, suffix)
+					text := fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), exprToShow, d20, suffix)
 					a, b := deathSaving(mctx, 0, 2)
 					exText := deathSavingResultCheck(mctx, a, b)
 					if exText != "" {
@@ -895,7 +895,7 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 					ReplyToSender(mctx, msg, text)
 				} else if d20 >= 10 {
 					suffix := DiceFormatTmpl(mctx, "DND:死亡豁免_成功_附加语")
-					text := fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), detail, d20, suffix)
+					text := fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), exprToShow, d20, suffix)
 					a, b := deathSaving(mctx, 1, 0)
 					exText := deathSavingResultCheck(mctx, a, b)
 					if exText != "" {
@@ -905,7 +905,7 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 					ReplyToSender(mctx, msg, text)
 				} else {
 					suffix := DiceFormatTmpl(mctx, "DND:死亡豁免_失败_附加语")
-					text := fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), detail, d20, suffix)
+					text := fmt.Sprintf(`%s的死亡豁免检定: %s=%d %s`, getPlayerNameTempFunc(mctx), exprToShow, d20, suffix)
 					a, b := deathSaving(mctx, 0, 1)
 					exText := deathSavingResultCheck(mctx, a, b)
 					if exText != "" {

--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -877,7 +877,13 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
+				detail := r.vm.GetDetailText()
 				exprToShow := fmt.Sprintf("[%s]", expr)
+				if detail != r.ToString() {
+					s := r.ToString()
+					exprToShow, _ = strings.CutPrefix(detail, s)
+				}
+
 				if d20 == 20 {
 					deathSavingStable(mctx)
 					VarSetValueInt64(mctx, "hp", 1)

--- a/dice/ext_dnd5e_template.go
+++ b/dice/ext_dnd5e_template.go
@@ -114,6 +114,8 @@ var _dnd5eTmpl = &GameSystemTemplate{
 		"熟练": 2,
 	},
 	DefaultsComputed: map[string]string{
+		"pp": "10 + 察觉",
+
 		"力量调整值": "abilityModifier('力量')",
 		"体质调整值": "abilityModifier('体质')",
 		"敏捷调整值": "abilityModifier('敏捷')",

--- a/dice/ext_exp.go
+++ b/dice/ext_exp.go
@@ -227,9 +227,12 @@ func cmdStGetItemsForExport(mctx *MsgContext, tmpl *GameSystemTemplate, stInfo *
 				items = append(items, text)
 			} else {
 				if v.TypeId == ds.VMTypeComputedValue {
-					items = append(items, fmt.Sprintf("&%s:%s", k, v.ToString()))
+					// 我认为上游的 computed 类型的 repr 在这种情况下比较矛盾，因为计算类型需要使用赋值语句来创建
+					// repr 从设定上来讲是 value，单独的value不足以表示一个 computed，所以这里自己切一下vStr
+					vStr := v.ToString()
+					items = append(items, fmt.Sprintf("&%s:%s", k, vStr[2:len(vStr)-1]))
 				} else {
-					items = append(items, fmt.Sprintf("%s:%s", k, v.ToString()))
+					items = append(items, fmt.Sprintf("%s:%s", k, v.ToRepr()))
 				}
 			}
 		}

--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -1047,9 +1047,12 @@ func RegisterBuiltinExtFun(self *Dice) {
 			ctx.Eval(tmpl.PreloadCode, nil)
 
 			val := cmdArgs.GetArgN(1)
+			xx := DiceFormat(ctx, val)
+			fmt.Println("wwww", xx)
+
 			if val != "" {
 				ctx.Player.TempValueAlias = nil // 防止dnd的hp被转为“生命值”
-				r, _, err := DiceExprTextBase(ctx, cmdArgs.CleanArgs, RollExtraFlags{DisableBlock: false})
+				r, _, err := DiceExprTextBase(ctx, cmdArgs.CleanArgs, RollExtraFlags{DisableBlock: false, V2Only: true})
 
 				if err == nil {
 					text := r.ToString()

--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -1045,10 +1045,7 @@ func RegisterBuiltinExtFun(self *Dice) {
 
 			tmpl := ctx.Group.GetCharTemplate(ctx.Dice)
 			ctx.Eval(tmpl.PreloadCode, nil)
-
 			val := cmdArgs.GetArgN(1)
-			xx := DiceFormat(ctx, val)
-			fmt.Println("wwww", xx)
 
 			if val != "" {
 				ctx.Player.TempValueAlias = nil // 防止dnd的hp被转为“生命值”

--- a/dice/game_system_template.go
+++ b/dice/game_system_template.go
@@ -67,7 +67,7 @@ type GameSystemTemplate struct {
 	TextMap         *TextTemplateWithWeightDict `yaml:"textMap" json:"textMap"` // UI文本
 	TextMapHelpInfo *TextTemplateWithHelpDict   `yaml:"TextMapHelpInfo" json:"textMapHelpInfo"`
 
-	PreloadCode string `yaml:"preloadCode" json:"preloadCode"` // 预加载代码，js
+	PreloadCode string `yaml:"preloadCode" json:"preloadCode"` // 预加载代码
 	// BasedOn           string                 `yaml:"based-on"`           // 基于规则
 
 	AliasMap *SyncMap[string, string] `yaml:"-" json:"-"` // 别名/同义词
@@ -97,6 +97,8 @@ func (t *GameSystemTemplate) GetDefaultValueEx0(ctx *MsgContext, varname string)
 	// 先计算computed
 	if expr, exists := t.DefaultsComputed[name]; exists {
 		ctx.SystemTemplate = t
+		// 也许有点依赖这个东西？有更好的方式吗？可以更加全局的去加载吗（比如和vm创建伴生加载）？
+		ctx.Eval(t.PreloadCode, nil)
 		r := ctx.Eval(expr, nil)
 
 		if r.vm.Error == nil {

--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -465,7 +465,6 @@ func (ctx *MsgContext) CreateVmIfNotExists() {
 
 			// 从模板取值，模板中的设定是如果取不到获得0
 			// TODO: 目前没有好的方法去复制vm，实际上这个行为应当类似于ds中的函数调用
-			ctx.CreateVmIfNotExists()
 			ctx2 := *ctx
 			ctx2.vm = nil
 			ctx2.CreateVmIfNotExists()


### PR DESCRIPTION
Fix #894

Fix #900

Fix #917

Fix #920
 
Close #893

修正死亡豁免表达式显示
修正seal.format对于dnd5e模板计算属性的错误显示
修正rc代骰问题
增加被察到模板
