### PR TITLE
Update cmd_parse.go，NCQQ新CQ码格式兼容

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -563,7 +563,7 @@ func AtParse(cmd string, prefix string) (string, []*AtInfo) {
 	re := regexp.MustCompile("")
 	switch prefix {
 	case "QQ":
-		re = regexp.MustCompile(`\[CQ:at,qq=(\d+?)]`)
+		re = regexp.MustCompile(`\[CQ:at,qq=(\d+)(?:,name=(.*?))?\]`)
 	case "OpenQQ", "OpenQQCH":
 		re = regexp.MustCompile(`<@!?(\S+?)>`)
 	case "DISCORD":


### PR DESCRIPTION
1.7.7ncQQ+9.9.15QQNT的@指令CQ码string返回格式兼容