### PR TITLE
fix: 修正CQAT正则会导致AT不生效的问题

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -563,7 +563,7 @@ func AtParse(cmd string, prefix string) (string, []*AtInfo) {
 	re := regexp.MustCompile("")
 	switch prefix {
 	case "QQ":
-		re = regexp.MustCompile(`\[CQ:at,qq=(\d+)(?:,name=(.*?))?\]`)
+		re = regexp.MustCompile(`\[CQ:at,qq=(\d+)(?:,name=(?:.*?))?\]`)
 	case "OpenQQ", "OpenQQCH":
 		re = regexp.MustCompile(`<@!?(\S+?)>`)
 	case "DISCORD":


### PR DESCRIPTION
如题，这能有效的避免你的骰娘变成裸奔骰娘。