### PR TITLE
fix: 采用哈希表的方式修正自动保存重复插入未变动的数据

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -2500,6 +2500,7 @@ func (d *Dice) ApplyExtDefaultSettings() {
 }
 
 func (d *Dice) Save(isAuto bool) {
+	timestampNow := time.Now().Unix()
 	if d.LastUpdatedTime != 0 {
 		a, err1 := yaml.Marshal(d)
 		advancedData, err2 := yaml.Marshal(d.AdvancedConfig)
@@ -2551,19 +2552,34 @@ func (d *Dice) Save(isAuto bool) {
 		if g.UpdatedAtTime != 0 {
 			data, err := json.Marshal(g)
 			if err == nil {
-				err := model.GroupInfoSave(d.DBData, g.GroupID, g.UpdatedAtTime, data)
+				// 修改保存时间为当前时间
+				err := model.GroupInfoSave(d.DBData, g.GroupID, timestampNow, data)
 				if err != nil {
 					d.Logger.Warnf("保存群组数据失败 %v : %v", g.GroupID, err.Error())
 				}
 				g.UpdatedAtTime = 0
 			}
 		}
-
+		// Pinenutn: 由于未知原因，这里每次都会大量插入相同没修改的数据，群越多，疑似占用越大
+		// 由于150已经删除了对应的代码，此处不做刨根问底，只研究优化方案
+		// 已经在某骰上测试的：
+		// 方案1：循环中的整体作为一个事务，减少提交（由于木落担心可能会导致一次保存插入失败一条就全部回退，放弃）
+		// 方案2：使用哈希记录实际没有修改的，然后只插入修改过的，这种情况下，会导致第一次启动的时候这里的占用很高（因为第一次还会全量插入），以后就少了
+		// 之前想过要不要把事务分块插入，不会做，摆了:(
 		// TODO: 这里其实还能优化
 		data, _ := json.Marshal(LockFreeMapToMap(g.ValueMap))
-		model.AttrGroupSave(d.DBData, g.GroupID, data)
+		dataHash := GenerateShortHash(data)
+		oldHash, ok := d.SaveDatabaseInsertCheckMap.Load(g.GroupID)
+		// 理论上，只要角色卡没修改过，那么就不需要再次入库
+		// 只要我们记录上一次的HashID和本次的HashID，比较ID应该会比插入占用更低？
+		// 实际上，这并没有解决第一次入库会产生大量插入的问题，但总比没有好……
+		// 如果没修改，请不要入库
+		if !ok || dataHash != oldHash {
+			//入库
+			model.AttrGroupSave(d.DBData, g.GroupID, data)
+			d.SaveDatabaseInsertCheckMap.Store(g.GroupID, dataHash)
+		}
 	}
-
 	// 同步绑定的角色卡数据
 	chPrefix := "$:ch-bind-mtime:"
 	chPrefixData := "$:ch-bind-data:"

--- a/dice/config.go
+++ b/dice/config.go
@@ -2585,7 +2585,7 @@ func (d *Dice) Save(isAuto bool) {
 		// 实际上，这并没有解决第一次入库会产生大量插入的问题，但总比没有好……
 		// 如果没修改，请不要入库
 		if !ok || dataHash != oldHash {
-			//入库
+			// 入库
 			model.AttrGroupSave(d.DBData, g.GroupID, data)
 			d.SaveDatabaseInsertCheckMap.Store(g.GroupID, dataHash)
 			allCount++

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -280,6 +280,9 @@ type Dice struct {
 	AdvancedConfig AdvancedConfig `json:"-" yaml:"-"`
 
 	ContainerMode bool `yaml:"-" json:"-"` // 容器模式：禁用内置适配器，不允许使用内置Lagrange和旧的内置Gocq
+
+	// 用于检查是否需要插入到数据库的哈希表 150因为没有对应插入 到时候这个就没用了
+	SaveDatabaseInsertCheckMap *SyncMap[string, string] `json:"-" yaml:"-"`
 }
 
 type CensorMode int

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -282,7 +282,8 @@ type Dice struct {
 	ContainerMode bool `yaml:"-" json:"-"` // 容器模式：禁用内置适配器，不允许使用内置Lagrange和旧的内置Gocq
 
 	// 用于检查是否需要插入到数据库的哈希表 150因为没有对应插入 到时候这个就没用了
-	SaveDatabaseInsertCheckMap *SyncMap[string, string] `json:"-" yaml:"-"`
+	SaveDatabaseInsertCheckMapFlag sync.Once                `json:"-" yaml:"-"`
+	SaveDatabaseInsertCheckMap     *SyncMap[string, string] `json:"-" yaml:"-"`
 }
 
 type CensorMode int

--- a/dice/model/attr.go
+++ b/dice/model/attr.go
@@ -76,3 +76,32 @@ func AttrUserGetAll(db *sqlx.DB, userID string) []byte {
 func AttrUserSave(db *sqlx.DB, userID string, data []byte) {
 	attrSave(db, "attrs_user", userID, data)
 }
+
+// 使用批量 + 事务进行控制
+func attrSaveTX(tx *sqlx.Tx, bucket string, key string, data []byte) {
+	if tx == nil {
+		return
+	}
+
+	nowTimestamp := time.Now().Unix()
+
+	query := `REPLACE INTO ` + bucket + ` (id, updated_at, data) VALUES (:id, :updated_at, :data)`
+	_, err := tx.NamedExec(query, map[string]interface{}{
+		"id":         key,
+		"updated_at": nowTimestamp,
+		"data":       data,
+	})
+	if err != nil {
+		fmt.Println("Failed to execute query:", err)
+		// 根据木落的描述：出错就出错了，不要回滚事务，继续插入即可
+		//_ = tx.Rollback()
+	}
+}
+
+func AttrGroupUserSaveTX(tx *sqlx.Tx, groupID string, userID string, data []byte) {
+	attrSaveTX(tx, "attrs_group_user", fmt.Sprintf("%s-%s", groupID, userID), data)
+}
+
+func AttrGroupSaveTX(tx *sqlx.Tx, groupID string, data []byte) {
+	attrSaveTX(tx, "attrs_group", groupID, data)
+}

--- a/dice/model/attr.go
+++ b/dice/model/attr.go
@@ -93,8 +93,7 @@ func attrSaveTX(tx *sqlx.Tx, bucket string, key string, data []byte) {
 	})
 	if err != nil {
 		fmt.Println("Failed to execute query:", err)
-		// 根据木落的描述：出错就出错了，不要回滚事务，继续插入即可
-		//_ = tx.Rollback()
+		// _ = tx.Rollback()
 	}
 }
 

--- a/dice/model/group_info.go
+++ b/dice/model/group_info.go
@@ -147,3 +147,24 @@ func GroupPlayerInfoSave(db *sqlx.DB, groupID string, playerID string, info *Gro
 	})
 	return err
 }
+
+// GroupPlayerInfoSaveTX 事务保存用户信息
+func GroupPlayerInfoSaveTX(tx *sqlx.Tx, groupID string, playerID string, info *GroupPlayerInfoBase) error {
+	_, err := tx.NamedExec("REPLACE INTO group_player_info (name, updated_at, last_command_time, auto_set_name_template, dice_side_num, group_id, user_id) VALUES (:name, :updated_at, :last_command_time, :auto_set_name_template, :dice_side_num, :group_id, :user_id)", map[string]interface{}{
+		"name":                   info.Name,
+		"updated_at":             info.UpdatedAtTime,
+		"last_command_time":      info.LastCommandTime,
+		"auto_set_name_template": info.AutoSetNameTemplate,
+		"dice_side_num":          info.DiceSideNum,
+		"group_id":               groupID,
+		"user_id":                playerID,
+	})
+	return err
+}
+
+// GroupInfoSaveTX 事务保存群组信息
+func GroupInfoSaveTX(tx *sqlx.Tx, groupID string, updatedAt int64, data []byte) error {
+	// INSERT OR REPLACE 语句可以根据是否已存在对应记录自动插入或更新记录
+	_, err := tx.Exec("INSERT OR REPLACE INTO group_info (id, updated_at, data) VALUES (?, ?, ?)", groupID, updatedAt, data)
+	return err
+}

--- a/dice/utils.go
+++ b/dice/utils.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/fy0/lockfree"
 	"golang.org/x/text/encoding/simplifiedchinese"
 	"golang.org/x/text/transform"
@@ -340,6 +342,18 @@ func LockFreeMapToMap(m lockfree.HashMap) map[string]interface{} {
 	})
 
 	return ret
+}
+
+func GenerateShortHash(input []byte) string {
+	// 计算 xxhash 哈希值
+	hash := xxhash.Sum64(input)
+
+	// 将哈希值转换为 8 位十六进制字符串
+	hashBytes := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		hashBytes[i] = byte(hash >> (56 - 8*i))
+	}
+	return hex.EncodeToString(hashBytes)
 }
 
 var SVGIcon = []byte(`<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><defs><style>.cls-1{fill:#bdccd4;}.cls-2{fill:#fff;}</style></defs><title>icon-s</title><rect class="cls-1" x="6.36" y="7.14" width="498.86" height="498.86" rx="12"/><polygon class="cls-2" points="130.65 58.2 31.9 269.01 183.55 462.82 365.95 427.73 480.24 237.52 336.41 52 130.65 58.2"/><path d="M488.44,230.71,346.28,44.41h0a10.57,10.57,0,0,0-8.87-4.18L133.26,48.62h0a10.61,10.61,0,0,0-9.15,6L22.06,263h0a10.57,10.57,0,0,0,1.14,11.14l150.59,194.6a10.58,10.58,0,0,0,10.53,3.95L373.17,436l1.35-.46a10.59,10.59,0,0,0,5.72-4.71L489.16,242.44a10.6,10.6,0,0,0-.72-11.73ZM186,449.75l-24.1-187.3L385.9,376ZM364.21,107.21,159.67,244,140.55,72.87ZM149.65,248.53l-102.77,12L131.65,87.9ZM392.46,367.38,165.87,252.6l207-138.45,1.2,1.54,18.83,250.94ZM358.79,95.63,178.51,67.86,333,61.44ZM47.71,271.08l103.1-12L173.2,433.22ZM364.32,416l-120,23.36,135.29-49.82Zm38.14-65.88-16.62-219L467.21,238Z"/><polygon class="cls-2" points="157.03 220.4 160.14 249.69 178.19 258.84 374.4 120.32 373.55 108.64 358.48 106.33 157.03 220.4"/><path d="M297.84,193.19h0c-11-3.95-22.25-3.44-29.35,1.3-7.73,3.69-13.91,13-16.18,24.53C249,235.69,255,250.45,266,252.61c9.44,1.87,19.48-6.76,24-20.27,8.76,1.95,17,1,22.68-2.23a15,15,0,0,0,7-7.93C323.42,211.65,313.84,198.92,297.84,193.19Z"/><path d="M221.27,164c-8.94-3.2-18.77-2.18-27.68,2.88l-.08,0a44.16,44.16,0,0,0-19.37,23.68c-7.61,21.25,1.15,43.9,19.53,50.47,8.94,3.2,18.77,2.18,27.68-2.88l.08,0A44.16,44.16,0,0,0,240.8,214.5C248.41,193.25,239.65,170.61,221.27,164Z"/><ellipse class="cls-2" cx="194.6" cy="193" rx="21.33" ry="16.31" transform="translate(-62.71 287.4) rotate(-64.91)"/><circle class="cls-2" cx="225.91" cy="185.74" r="9.96"/><path d="M310.56,113.25a44.14,44.14,0,0,0-30.26,4.47,32.67,32.67,0,0,0-16.76,22.33c-3.78,19.15,11.16,38.29,33.3,42.66a44.15,44.15,0,0,0,30.26-4.47l.08-.05c8.92-5.06,14.84-13,16.68-22.28C347.64,136.76,332.7,117.62,310.56,113.25Z"/><ellipse class="cls-2" cx="286.98" cy="140.6" rx="21.33" ry="16.31" transform="translate(37.95 340.88) rotate(-64.91)"/><circle class="cls-2" cx="320.22" cy="132.25" r="9.96"/><ellipse cx="226.67" cy="154.45" rx="6.5" ry="9.75" transform="translate(-7.12 297.91) rotate(-65.8)"/><ellipse cx="252.33" cy="140.56" rx="9.75" ry="6.5" transform="translate(83.38 374.84) rotate(-83.32)"/></svg>`)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/blevesearch/bleve/v2 v2.3.10
 	github.com/bwmarrin/discordgo v0.28.1
+	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/dop251/goja v0.0.0-20231027120936-b396bb4c349d
 	github.com/dop251/goja_nodejs v0.0.0-20231022114343-5c1f9037c9ab
 	github.com/fy0/go-autostart v0.0.0-20220515100644-a25d81ed766b

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bwmarrin/discordgo v0.28.1 h1:gXsuo2GBO7NbR6uqmrrBDplPUx2T3nzu775q/Rd1aG4=
 github.com/bwmarrin/discordgo v0.28.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.2.0/go.mod h1:9+9sk7u7pGNWYMkh0hdiL++6OeibzJccyQU4p4MedaY=
 github.com/chzyer/readline v1.5.0/go.mod h1:x22KAscuvRqlLoK9CsoYsmxoXZMMFVyOl86cAH8qUic=


### PR DESCRIPTION
原config.go的Save函数，有一个//TODO: 这里其实还能优化。

在某次检查时，我发现：此处的'AttrGroupSave"函数会被大量调用。而AttrGroupSave函数是一个插入语句，这意味着每30秒，就可能有大量插入语句执行。

在诺扣提公骰的数据环境下，每次自动保存将会插入6000+数据。

根据上面的代码，以及和木落的沟通，确认此处缺少检查语句，此处逻辑应当是仅更新的才会被插入。由于并不清楚此处的更新逻辑，且150该代码重构理论该问题已经消失，采用如下方案：

本PR采用了维护一个哈希表的方式，通过每次检查要被保存的数据哈希值是否变动，从而确定是否应该插入，从而部分解决了问题。

部分解决指：
- 没有解决数量较大时，不是批量插入，而是一条一条插入带来的性能问题
- 没有解决仅更新的数据不应当存放在对应结构体

