### PR TITLE
Revert "fix(Log): 修复了骰点统计报错的问题"

### DIFF
--- a/dice/ext_exp.go
+++ b/dice/ext_exp.go
@@ -293,8 +293,8 @@ func cmdStValueMod(mctx *MsgContext, tmpl *GameSystemTemplate, attrs *Attributes
 		"type":    "mod",
 		"attr":    i.name,
 		"modExpr": i.expr,
-		"valOld":  theOldValue.Value,
-		"valNew":  theNewValue.Value,
+		"valOld":  theOldValue,
+		"valNew":  theNewValue,
 		"isInc":   signText == "增加", // 增加还是扣除
 		"op":      i.op,
 	})


### PR DESCRIPTION
Reverts sealdice/sealdice-core#993

数据存入并无问题，读取时没有使用正确的类型，另行修复