### PR TITLE
fix(Doc): 修正偶发情况下，帮助文档的TextMap并发导致的panic闪退问题。

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -336,7 +336,8 @@ func (d *Dice) registerCoreCommands() {
 			hasSecond := len(search.Hits) >= 2
 			best, ok := d.Parent.Help.TextMap.Load(search.Hits[0].ID)
 			if !ok {
-				ReplyToSender(ctx, msg, "加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)的数据出现错误!")
+				d.Logger.Error("加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)的数据出现错误!")
+				ReplyToSender(ctx, msg, "未找到搜索结果，出现数据加载错误!")
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 			others := ""
@@ -344,7 +345,8 @@ func (d *Dice) registerCoreCommands() {
 			for _, i := range search.Hits {
 				t, ok := d.Parent.Help.TextMap.Load(i.ID)
 				if !ok {
-					ReplyToSender(ctx, msg, "加载d.Parent.Help.TextMap.Load(i.ID)的数据出现错误!")
+					d.Logger.Error("加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)的数据出现错误!")
+					ReplyToSender(ctx, msg, "未找到搜索结果，出现数据加载错误!")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 				if t.Group != "" && t.Group != HelpBuiltinGroup {
@@ -468,7 +470,10 @@ func (d *Dice) registerCoreCommands() {
 					// a := d.Parent.ShortHelp.GetContent(search.Hits[0].ID)
 					a, ok := d.Parent.Help.TextMap.Load(search.Hits[0].ID)
 					if !ok {
+						d.Logger.Error("HELPDOC:读取ID对应的信息出现问题")
 						ReplyToSender(ctx, msg, "HELPDOC:读取ID对应的信息出现问题")
+						// 这段代码是从最下面的return那里抄来的，所以我不清楚这两个参数，是否应该都是true
+						return CmdExecuteResult{Matched: true, Solved: true}
 					}
 					content := d.Parent.Help.GetContent(a, 0)
 					ReplyToSender(ctx, msg, fmt.Sprintf("%s:%s\n%s", a.PackageName, a.Title, content))

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -336,7 +336,7 @@ func (d *Dice) registerCoreCommands() {
 			hasSecond := len(search.Hits) >= 2
 			best, ok := d.Parent.Help.TextMap.Load(search.Hits[0].ID)
 			if !ok {
-				d.Logger.Error("加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)的数据出现错误!")
+				d.Logger.Errorf("加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)->(%s)的数据出现错误!", search.Hits[0].ID)
 				ReplyToSender(ctx, msg, "未找到搜索结果，出现数据加载错误!")
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
@@ -345,7 +345,7 @@ func (d *Dice) registerCoreCommands() {
 			for _, i := range search.Hits {
 				t, ok := d.Parent.Help.TextMap.Load(i.ID)
 				if !ok {
-					d.Logger.Error("加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)的数据出现错误!")
+					d.Logger.Errorf("加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)->(%s)的数据出现错误!", search.Hits[0].ID)
 					ReplyToSender(ctx, msg, "未找到搜索结果，出现数据加载错误!")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
@@ -466,13 +466,10 @@ func (d *Dice) registerCoreCommands() {
 			search, _, _, _, err := d.Parent.Help.Search(ctx, cmdArgs.CleanArgs, true, 1, 1, "")
 			if err == nil {
 				if len(search.Hits) > 0 {
-					// 居然会出现 hits[0] 为nil的情况？？
-					// a := d.Parent.ShortHelp.GetContent(search.Hits[0].ID)
 					a, ok := d.Parent.Help.TextMap.Load(search.Hits[0].ID)
 					if !ok {
 						d.Logger.Error("HELPDOC:读取ID对应的信息出现问题")
 						ReplyToSender(ctx, msg, "HELPDOC:读取ID对应的信息出现问题")
-						// 这段代码是从最下面的return那里抄来的，所以我不清楚这两个参数，是否应该都是true
 						return CmdExecuteResult{Matched: true, Solved: true}
 					}
 					content := d.Parent.Help.GetContent(a, 0)

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -268,7 +268,7 @@ func (d *Dice) registerCoreCommands() {
 			}
 
 			if id != "" {
-				text, exists := d.Parent.Help.TextMap[id]
+				text, exists := d.Parent.Help.TextMap.Load(id)
 				if exists {
 					content := d.Parent.Help.GetContent(text, 0)
 					ReplyToSender(ctx, msg, fmt.Sprintf("词条: %s:%s\n%s", text.PackageName, text.Title, content))
@@ -334,11 +334,19 @@ func (d *Dice) registerCoreCommands() {
 			}
 
 			hasSecond := len(search.Hits) >= 2
-			best := d.Parent.Help.TextMap[search.Hits[0].ID]
+			best, ok := d.Parent.Help.TextMap.Load(search.Hits[0].ID)
+			if !ok {
+				ReplyToSender(ctx, msg, "加载d.Parent.Help.TextMap.Load(search.Hits[0].ID)的数据出现错误!")
+				return CmdExecuteResult{Matched: true, Solved: true}
+			}
 			others := ""
 
 			for _, i := range search.Hits {
-				t := d.Parent.Help.TextMap[i.ID]
+				t, ok := d.Parent.Help.TextMap.Load(i.ID)
+				if !ok {
+					ReplyToSender(ctx, msg, "加载d.Parent.Help.TextMap.Load(i.ID)的数据出现错误!")
+					return CmdExecuteResult{Matched: true, Solved: true}
+				}
 				if t.Group != "" && t.Group != HelpBuiltinGroup {
 					others += fmt.Sprintf("[%s][%s]【%s:%s】 匹配度%.2f\n", i.ID, t.Group, t.PackageName, t.Title, i.Score)
 				} else {
@@ -458,7 +466,10 @@ func (d *Dice) registerCoreCommands() {
 				if len(search.Hits) > 0 {
 					// 居然会出现 hits[0] 为nil的情况？？
 					// a := d.Parent.ShortHelp.GetContent(search.Hits[0].ID)
-					a := d.Parent.Help.TextMap[search.Hits[0].ID]
+					a, ok := d.Parent.Help.TextMap.Load(search.Hits[0].ID)
+					if !ok {
+						ReplyToSender(ctx, msg, "HELPDOC:读取ID对应的信息出现问题")
+					}
 					content := d.Parent.Help.GetContent(a, 0)
 					ReplyToSender(ctx, msg, fmt.Sprintf("%s:%s\n%s", a.PackageName, a.Title, content))
 				} else {


### PR DESCRIPTION
曾经在小鸟处遇到过TextMap并发，导致panic的问题。故切换成SyncMap。

注：已经在小鸟处稳定测试无异常

注2：但是现在提交的代码并非从小鸟处直接粘贴的，而是根据原理重新改的，由于电脑不同，未能进行测试。