### PR TITLE
fix: 在解散群聊的时候，同步dismiss的操作去除群账号链接

### DIFF
--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1000,8 +1000,9 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				ctx.Notice(txtErr)
 				return
 			}
-			// TODO：存疑，根据其他地方的描述，这里的ep.UserID等价于v.DiceID，这样使用是否正确有待进一步测试
+			// TODO：存疑，根据DISMISS的代码复制而来
 			group.DiceIDExistsMap.Delete(ep.UserID)
+			group.UpdatedAtTime = time.Now().Unix()
 			log.Info(txt)
 			ctx.Notice(txt)
 			return

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -991,7 +991,6 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			// {"group_id":564808710,"notice_type":"group_decrease","operator_id":2589922907,"post_type":"notice","self_id":2589922907,"sub_type":"leave","time":1651584460,"user_id":2589922907}
 			groupName := dm.TryGetGroupName(msg.GroupID)
 			txt := fmt.Sprintf("离开群组或群解散: <%s>(%s)", groupName, msgQQ.GroupID)
-			txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, msgQQ.GroupID)
 			// 这个就是要删除的部分，离开这个群组=群组退出=删除对应的群聊绑定信息（也就是用户的骰子和这个群聊无关了）
 			// 同时考虑到：QQ群团队发布公告称，由于业务调整，“恢复QQ群”功能将于2023年10月13日起正式下线，届时涉及QQ群相关的恢复功能都将无法使用，可以安心删除群聊对应绑定信息。
 			group, exists := session.ServiceAtNew.Load(msg.GroupID)

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -991,6 +991,17 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			// {"group_id":564808710,"notice_type":"group_decrease","operator_id":2589922907,"post_type":"notice","self_id":2589922907,"sub_type":"leave","time":1651584460,"user_id":2589922907}
 			groupName := dm.TryGetGroupName(msg.GroupID)
 			txt := fmt.Sprintf("离开群组或群解散: <%s>(%s)", groupName, msgQQ.GroupID)
+			txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, msgQQ.GroupID)
+			// 这个就是要删除的部分，离开这个群组=群组退出=删除对应的群聊绑定信息（也就是用户的骰子和这个群聊无关了）
+			// 同时考虑到：QQ群团队发布公告称，由于业务调整，“恢复QQ群”功能将于2023年10月13日起正式下线，届时涉及QQ群相关的恢复功能都将无法使用，可以安心删除群聊对应绑定信息。
+			group, exists := session.ServiceAtNew.Load(msg.GroupID)
+			if !exists {
+				log.Error(txtErr)
+				ctx.Notice(txtErr)
+				return
+			}
+			// TODO：存疑，根据其他地方的描述，这里的ep.UserID等价于v.DiceID，这样使用是否正确有待进一步测试
+			group.DiceIDExistsMap.Delete(ep.UserID)
 			log.Info(txt)
 			ctx.Notice(txt)
 			return

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -996,6 +996,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			// 同时考虑到：QQ群团队发布公告称，由于业务调整，“恢复QQ群”功能将于2023年10月13日起正式下线，届时涉及QQ群相关的恢复功能都将无法使用，可以安心删除群聊对应绑定信息。
 			group, exists := session.ServiceAtNew.Load(msg.GroupID)
 			if !exists {
+				txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, msgQQ.GroupID)
 				log.Error(txtErr)
 				ctx.Notice(txtErr)
 				return


### PR DESCRIPTION
如题。试图解决大量解散群聊但后台不删除的情况。这应当不影响日志相关。

