### PR TITLE
fix: 增强重构自动退群逻辑的判定机制

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1406,7 +1406,8 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 		}
 		// 如果在上述所有操作后，发现时间仍然是0，那么必须忽略该值，因为可能是还没初始化的群，不能人家刚进来就走
 		// 注意不能用last.Equal(time.Time{})，因为这里是时间戳的1970-01-01，而Go初始时间是0000-01-01.
-		if last.Unix() == 0 {
+		// 预防性代码：如果last是0000-01-01，那也不应该被退群。
+		if last.Unix() <= 0 {
 			return true
 		}
 		// 如果时间比要退群的时间早


### PR DESCRIPTION
原本代码使用了等于号进行时间判定，判定时间戳为0的情况下不退群。
由于Go代码还有一个初始时间：0000-01-01，担心某些情况下，会有这个时间出现，导致错误退群。

故修改为时间戳小于0，增强代码健壮性。

经测试，0000-01-01的Unix打印后为： -62135596800 < 0 ，故可以安全通过判定。