### PR TITLE
fix: 修复启动时数据库迁移和回收导致的过长启动时间，并对log_items做了特殊处理。同时修复jsReload后插件默认关闭的问题

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -152,6 +152,7 @@ func (group *GroupInfo) ExtActiveBySnapshotOrder(ei *ExtInfo, isFirstTimeLoad bo
 	if isFirstTimeLoad {
 		if !lo.Contains(orderLst, ei.Name) {
 			newLst = append(newLst, ei)
+			group.ExtListSnapshot = append(group.ExtListSnapshot, ei.Name)
 		}
 	}
 

--- a/dice/model/db.go
+++ b/dice/model/db.go
@@ -153,10 +153,6 @@ func SQLiteDBInit(dataDir string) (dataDB *gorm.DB, logsDB *gorm.DB, err error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	// err = dataDB.Exec("VACUUM").Error
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
 	logsDB, err = LogDBInit(dataDir)
 	return
 }
@@ -193,7 +189,6 @@ func LogDBInit(dataDir string) (logsDB *gorm.DB, err error) {
 		}
 	}
 
-	// err = logsDB.Exec("VACUUM").Error
 	if err != nil {
 		return nil, err
 	}
@@ -281,9 +276,5 @@ func SQLiteCensorDBInit(dataDir string) (censorDB *gorm.DB, err error) {
 	if err = censorDB.AutoMigrate(&CensorLog{}); err != nil {
 		return nil, err
 	}
-	// err = censorDB.Exec("VACUUM").Error
-	// if err != nil {
-	// 	return nil, err
-	// }
 	return censorDB, nil
 }

--- a/dice/model/db.go
+++ b/dice/model/db.go
@@ -153,10 +153,10 @@ func SQLiteDBInit(dataDir string) (dataDB *gorm.DB, logsDB *gorm.DB, err error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	err = dataDB.Exec("VACUUM").Error
-	if err != nil {
-		return nil, nil, err
-	}
+	// err = dataDB.Exec("VACUUM").Error
+	// if err != nil {
+	// 	return nil, nil, err
+	// }
 	logsDB, err = LogDBInit(dataDir)
 	return
 }
@@ -172,11 +172,89 @@ func LogDBInit(dataDir string) (logsDB *gorm.DB, err error) {
 	if err = logsDB.AutoMigrate(&LogInfo{}, &LogOneItem{}); err != nil {
 		return nil, err
 	}
-	err = logsDB.Exec("VACUUM").Error
+
+	itemsAutoMigrate := false
+	dialect := logsDB.Dialector.Name()
+	if dialect != "sqlite" {
+		itemsAutoMigrate = true
+	} else {
+		if logsDB.Migrator().HasTable(&LogOneItem{}) {
+			if err = LogItemsSQLiteMigrate(logsDB); err != nil {
+				return nil, err
+			}
+		} else {
+			itemsAutoMigrate = true
+		}
+	}
+
+	if itemsAutoMigrate {
+		if err = logsDB.AutoMigrate(&LogOneItem{}); err != nil {
+			return nil, err
+		}
+	}
+
+	// err = logsDB.Exec("VACUUM").Error
 	if err != nil {
 		return nil, err
 	}
 	return logsDB, nil
+}
+
+func LogItemsSQLiteMigrate(db *gorm.DB) error {
+	// 获取当前列信息
+	var currentColumns []struct {
+		Name string
+		Type string
+	}
+	err := db.Raw("PRAGMA table_info(log_items)").Scan(&currentColumns).Error
+	if err != nil {
+		return err
+	}
+
+	// 获取模型定义的列信息
+	modelColumns, err := db.Migrator().ColumnTypes(&LogOneItem{})
+	if err != nil {
+		return err
+	}
+
+	// 比较列是否有变化
+	needMigrate := false
+	if len(currentColumns) != len(modelColumns) {
+		needMigrate = true
+	} else {
+		columnMap := make(map[string]string)
+		for _, col := range currentColumns {
+			columnMap[col.Name] = col.Type
+		}
+
+		for _, col := range modelColumns {
+			dbType := col.DatabaseTypeName()
+
+			// 特殊处理 is_dice 列,允许 bool 或 numeric 类型
+			if col.Name() == "is_dice" {
+				currentType := columnMap[col.Name()]
+				if currentType != "bool" && currentType != "numeric" {
+					needMigrate = true
+					break
+				}
+				continue
+			}
+
+			if columnMap[col.Name()] != dbType {
+				needMigrate = true
+				break
+			}
+		}
+	}
+
+	// 如果需要迁移则执行
+	if needMigrate {
+		log.Info("现在进行log_items表的迁移，如果数据库较大，会花费较长时间，请耐心等待")
+		log.Info("若是迁移后观察到数据库体积显著膨胀，可以关闭骰子使用 sealdice-core --vacuum 进行数据库整理，这同样会花费较长时间")
+		return db.AutoMigrate()
+	}
+
+	return nil
 }
 
 func SQLiteCensorDBInit(dataDir string) (censorDB *gorm.DB, err error) {
@@ -192,9 +270,9 @@ func SQLiteCensorDBInit(dataDir string) (censorDB *gorm.DB, err error) {
 	if err = censorDB.AutoMigrate(&CensorLog{}); err != nil {
 		return nil, err
 	}
-	err = censorDB.Exec("VACUUM").Error
-	if err != nil {
-		return nil, err
-	}
+	// err = censorDB.Exec("VACUUM").Error
+	// if err != nil {
+	// 	return nil, err
+	// }
 	return censorDB, nil
 }

--- a/dice/model/log.go
+++ b/dice/model/log.go
@@ -26,7 +26,7 @@ type LogOneItem struct {
 	IMUserID       string      `json:"IMUserId" gorm:"column:im_userid"`
 	Time           int64       `json:"time" gorm:"column:time"`
 	Message        string      `json:"message"  gorm:"column:message"`
-	IsDice         bool        `json:"isDice"  gorm:"column:is_dice;type:bool"`
+	IsDice         bool        `json:"isDice"  gorm:"column:is_dice"`
 	CommandID      int64       `json:"commandId"  gorm:"column:command_id"`
 	CommandInfo    interface{} `json:"commandInfo" gorm:"-"`
 	CommandInfoStr string      `json:"-" gorm:"column:command_info"`


### PR DESCRIPTION
Fix #1135

log_items 行为具体解释一下：
如果当前已经存在这个表，且使用sqlite时，会对比现存表和新表，如果发生列的类型或者数量区别，都会调用 AutoMigrate，否则跳过。

特别的，对于 is_bot 这一列，bool 类型和 numeric 类型都算通过