### PR TITLE
feat: 公骰列表后端基础功能

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -193,7 +193,7 @@ func (cm *ConfigManager) RegisterPluginConfig(pluginName string, configItems ...
 			newKeys[item.Key] = true
 		}
 
-		// Update or add new config items
+		// DiceUpdate or add new config items
 		for _, newItem := range configItems {
 			// if isValidType(newItem.Type) {
 			if existingItem, itemExists := existingPlugin.Configs[newItem.Key]; itemExists {

--- a/dice/config.go
+++ b/dice/config.go
@@ -193,7 +193,7 @@ func (cm *ConfigManager) RegisterPluginConfig(pluginName string, configItems ...
 			newKeys[item.Key] = true
 		}
 
-		// DiceUpdate or add new config items
+		// Update or add new config items
 		for _, newItem := range configItems {
 			// if isValidType(newItem.Type) {
 			if existingItem, itemExists := existingPlugin.Configs[newItem.Key]; itemExists {

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -765,7 +765,7 @@ func (d *Dice) PublicDiceInfoRegister() {
 		return
 	}
 	// 两种可能: 1. 原本ID为空 2. ID 无效，这里会自动变成新的
-	if cfg.ID != pd.Item.ID {
+	if pd.Item.ID != "" && cfg.ID != pd.Item.ID {
 		cfg.ID = pd.Item.ID
 	}
 }
@@ -804,11 +804,7 @@ func (d *Dice) PublicDiceSetupTick() {
 		doTickUpdate()
 	}()
 
-	var err error
-	d.PublicDiceTimerId, err = d.Cron.AddFunc("@every 3min", doTickUpdate)
-	if err != nil {
-		return
-	}
+	d.PublicDiceTimerId, _ = d.Cron.AddFunc("@every 3min", doTickUpdate)
 }
 
 func (d *Dice) PublicDiceSetup() {

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -25,6 +25,7 @@ import (
 	"sealdice-core/dice/logger"
 	"sealdice-core/dice/model"
 	log "sealdice-core/utils/kratos"
+	"sealdice-core/utils/public_dice"
 )
 
 type CmdExecuteResult struct {
@@ -183,11 +184,14 @@ type Dice struct {
 
 	CensorManager *CensorManager `json:"-" yaml:"-"`
 
-	Config Config `json:"-" yaml:"-"`
-
 	AttrsManager *AttrsManager `json:"-" yaml:"-"`
 
+	Config Config `json:"-" yaml:"-"`
+
 	AdvancedConfig AdvancedConfig `json:"-" yaml:"-"`
+
+	PublicDice        *public_dice.PublicDiceClient `json:"-" yaml:"-"`
+	PublicDiceTimerId cron.EntryID                  `json:"-" yaml:"-"`
 
 	ContainerMode bool `yaml:"-" json:"-"` // 容器模式：禁用内置适配器，不允许使用内置Lagrange和旧的内置Gocq
 
@@ -262,6 +266,8 @@ func (d *Dice) Init() {
 	if d.Config.EnableCensor {
 		d.NewCensorManager()
 	}
+
+	go d.PublicDiceSetup()
 
 	// 创建js运行时
 	if d.Config.JsEnable {
@@ -718,4 +724,101 @@ func (d *Dice) ResetQuitInactiveCron() {
 		}))
 		d.Logger.Infof("退群功能已启动，每 %s 执行一次退群判定", duration.String())
 	}
+}
+
+func (d *Dice) PublicDiceEndpointRefresh() {
+	cfg := &d.Config.PublicDiceConfig
+
+	var endpointItems []*public_dice.Endpoint
+	for _, i := range d.ImSession.EndPoints {
+		if !i.IsPublic {
+			continue
+		}
+		endpointItems = append(endpointItems, &public_dice.Endpoint{
+			Platform: i.Platform,
+			UID:      i.UserID,
+			IsOnline: i.State == 1,
+		})
+	}
+
+	_, code := d.PublicDice.EndpointUpdate(&public_dice.EndpointUpdateRequest{
+		DiceID:    cfg.ID,
+		Endpoints: endpointItems,
+	}, GenerateVerificationKeyForPublicDice)
+	if code != 200 {
+		log.Info("[公骰]无法通过服务器校验，不再进行更新")
+		return
+	}
+}
+
+func (d *Dice) PublicDiceInfoRegister() {
+	cfg := &d.Config.PublicDiceConfig
+
+	pd, code := d.PublicDice.Register(&public_dice.RegisterRequest{
+		ID:    cfg.ID,
+		Name:  cfg.Name,
+		Brief: cfg.Brief,
+		Note:  cfg.Note,
+	}, GenerateVerificationKeyForPublicDice)
+	if code != 200 {
+		log.Info("[公骰]无法通过服务器校验，不再进行骰号注册")
+		return
+	}
+	// 两种可能: 1. 原本ID为空 2. ID 无效，这里会自动变成新的
+	if cfg.ID != pd.Item.ID {
+		cfg.ID = pd.Item.ID
+	}
+}
+
+func (d *Dice) PublicDiceSetupTick() {
+	cfg := &d.Config.PublicDiceConfig
+
+	doTickUpdate := func() {
+		if !cfg.Enable {
+			d.Cron.Remove(d.PublicDiceTimerId)
+			return
+		}
+		var tickEndpointItems []*public_dice.TickEndpoint
+		for _, i := range d.ImSession.EndPoints {
+			if !i.IsPublic {
+				continue
+			}
+			tickEndpointItems = append(tickEndpointItems, &public_dice.TickEndpoint{
+				UID:      i.UserID,
+				IsOnline: i.State == 1,
+			})
+		}
+		d.PublicDice.TickUpdate(&public_dice.TickUpdateRequest{
+			ID:        cfg.ID,
+			Endpoints: tickEndpointItems,
+		}, GenerateVerificationKeyForPublicDice)
+	}
+
+	if d.PublicDiceTimerId != 0 {
+		d.Cron.Remove(d.PublicDiceTimerId)
+	}
+
+	go func() {
+		// 20s后进行第一次调用，此后3min进行一次更新
+		time.Sleep(20 * time.Second)
+		doTickUpdate()
+	}()
+
+	var err error
+	d.PublicDiceTimerId, err = d.Cron.AddFunc("@every 3min", doTickUpdate)
+	if err != nil {
+		return
+	}
+}
+
+func (d *Dice) PublicDiceSetup() {
+	d.PublicDice = public_dice.NewClient("https://dice.weizaima.com", "")
+
+	cfg := &d.Config.PublicDiceConfig
+	if !cfg.Enable {
+		return
+	}
+	d.PublicDiceInfoRegister()
+	d.PublicDiceEndpointRefresh()
+	d.PublicDiceSetupTick()
 }

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -746,7 +746,7 @@ func (d *Dice) PublicDiceEndpointRefresh() {
 		Endpoints: endpointItems,
 	}, GenerateVerificationKeyForPublicDice)
 	if code != 200 {
-		log.Info("[公骰]无法通过服务器校验，不再进行更新")
+		log.Warn("[公骰]无法通过服务器校验，不再进行更新")
 		return
 	}
 }
@@ -761,7 +761,7 @@ func (d *Dice) PublicDiceInfoRegister() {
 		Note:  cfg.Note,
 	}, GenerateVerificationKeyForPublicDice)
 	if code != 200 {
-		log.Info("[公骰]无法通过服务器校验，不再进行骰号注册")
+		log.Warn("[公骰]无法通过服务器校验，不再进行骰号注册")
 		return
 	}
 	// 两种可能: 1. 原本ID为空 2. ID 无效，这里会自动变成新的

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -804,7 +804,7 @@ func (d *Dice) PublicDiceSetupTick() {
 		doTickUpdate()
 	}()
 
-	d.PublicDiceTimerId, _ = d.Cron.AddFunc("@every 3min", doTickUpdate)
+	d.PublicDiceTimerId, _ = d.Cron.AddFunc("@every 3m", doTickUpdate)
 }
 
 func (d *Dice) PublicDiceSetup() {

--- a/dice/dice_config.go
+++ b/dice/dice_config.go
@@ -227,7 +227,7 @@ type NewsConfig struct {
 
 type PublicDiceConfig struct {
 	Enable bool   `json:"publicDiceEnable" yaml:"publicDiceEnable"`
-	ID     string `json:"publicDiceID" yaml:"publicDiceID"`
+	ID     string `json:"publicDiceId" yaml:"publicDiceId"`
 	Name   string `json:"publicDiceName" yaml:"publicDiceName"`
 	Brief  string `json:"publicDiceBrief" yaml:"publicDiceBrief"`
 	Note   string `json:"publicDiceNote" yaml:"publicDiceNote"`

--- a/dice/dice_config.go
+++ b/dice/dice_config.go
@@ -41,6 +41,8 @@ type Config struct {
 	NewsConfig `yaml:",inline"`
 	// 敏感词设置
 	CensorConfig `yaml:",inline"`
+	// 公骰设置
+	PublicDiceConfig `yaml:",inline"`
 
 	// 其它设置，包含由于被导出无法从 Dice 上迁移过来的配置项，为了在 DefaultConfig 上统一设置默认值增加此结构
 	DirtyConfig `yaml:",inline"`
@@ -221,6 +223,15 @@ type MailConfig struct {
 
 type NewsConfig struct {
 	NewsMark string `json:"newsMark" yaml:"newsMark"` // 已读新闻的md5
+}
+
+type PublicDiceConfig struct {
+	Enable bool   `json:"publicDiceEnable" yaml:"publicDiceEnable"`
+	ID     string `json:"publicDiceID" yaml:"publicDiceID"`
+	Name   string `json:"publicDiceName" yaml:"publicDiceName"`
+	Brief  string `json:"publicDiceBrief" yaml:"publicDiceBrief"`
+	Note   string `json:"publicDiceNote" yaml:"publicDiceNote"`
+	Avatar string `json:"publicDiceAvatar" yaml:"publicDiceAvatar"`
 }
 
 type CensorConfig struct {

--- a/dice/dice_config_default.go
+++ b/dice/dice_config_default.go
@@ -97,6 +97,9 @@ var DefaultConfig = Config{
 		CensorMatchPinyin:    false,
 		CensorFilterRegexStr: "",
 	},
+	PublicDiceConfig{
+		Enable: false,
+	},
 	DirtyConfig{
 		DeckList: nil,
 		CommandPrefix: []string{

--- a/dice/verify.go
+++ b/dice/verify.go
@@ -73,7 +73,7 @@ func GenerateVerificationCode(platform string, userID string, username string, u
 	}
 }
 
-type payload2 struct {
+type payloadPublicDice struct {
 	Version string `msgpack:"version,omitempty"`
 	Sign    []byte `msgpack:"sign,omitempty"`
 }
@@ -95,7 +95,7 @@ func GenerateVerificationKeyForPublicDice(data any) string {
 		sign = h.Sum(nil)
 	}
 
-	d := payload2{
+	d := payloadPublicDice{
 		Version: VERSION.String(),
 		Sign:    sign,
 	}

--- a/utils/public_dice/sdk.go
+++ b/utils/public_dice/sdk.go
@@ -1,0 +1,165 @@
+package public_dice
+
+import (
+	"github.com/monaco-io/request"
+)
+
+// PublicDiceClient SDK客户端
+type PublicDiceClient struct {
+	baseURL string
+	token   string
+}
+
+// NewClient 创建新的SDK客户端
+func NewClient(baseURL string, token string) *PublicDiceClient {
+	return &PublicDiceClient{
+		baseURL: baseURL,
+		token:   token,
+	}
+}
+
+// doReq 发送HTTP请求
+func doReq[T any](c *PublicDiceClient, method string, path string, data any, params map[string]string) (*T, int) {
+	req := request.Client{
+		URL:    c.baseURL + path,
+		Method: method,
+		JSON:   data,
+		Query:  params,
+	}
+
+	var result T
+	resp := req.Send()
+	resp.Scan(&result)
+
+	return &result, resp.Code()
+}
+
+// Endpoint 公骰终端信息
+type Endpoint struct {
+	Platform  string `json:"platform" msgpack:",omitempty"`
+	UID       string `json:"uid" msgpack:",omitempty"`
+	InviteURL string `json:"inviteUrl" msgpack:",omitempty"`
+	IsOnline  bool   `json:"isOnline" msgpack:",omitempty"`
+
+	ID           string `json:"id" msgpack:",omitempty"`
+	CreatedAt    string `json:"createdAt" msgpack:",omitempty"`
+	UpdatedAt    string `json:"updatedAt" msgpack:",omitempty"`
+	LastTickTime int64  `json:"lastTickTime" msgpack:",omitempty"`
+}
+
+// DiceInfo 公骰信息
+type DiceInfo struct {
+	ID                string      `json:"id" msgpack:",omitempty"`
+	CreatedAt         string      `json:"createdAt" msgpack:",omitempty"`
+	UpdatedAt         string      `json:"updatedAt" msgpack:",omitempty"`
+	Name              string      `json:"name" msgpack:",omitempty"`
+	Brief             string      `json:"brief" msgpack:",omitempty"`
+	Note              string      `json:"note" msgpack:",omitempty"`
+	Avatar            string      `json:"avatar" msgpack:",omitempty"`
+	Version           string      `json:"version" msgpack:",omitempty"`
+	IsOfficialVersion bool        `json:"isOfficialVersion" msgpack:",omitempty"`
+	UpdateTickCount   int         `json:"updateTickCount" msgpack:",omitempty"`
+	LastTickTime      int64       `json:"lastTickTime" msgpack:",omitempty"`
+	Endpoints         []*Endpoint `json:"endpoints" msgpack:",omitempty"`
+}
+
+// ListResponse 公骰列表响应
+type ListResponse struct {
+	Items []*DiceInfo `json:"items"`
+}
+
+// ListGet 获取公骰列表
+func (c *PublicDiceClient) ListGet(keyFunc func(data any) string) (*ListResponse, int) {
+	if keyFunc != nil {
+		data := keyFunc(nil)
+		return doReq[ListResponse](c, "GET", "/dice/api/public-dice/list", data, nil)
+	}
+	return doReq[ListResponse](c, "GET", "/dice/api/public-dice/list", nil, nil)
+}
+
+// RegisterRequest 注册公骰请求
+type RegisterRequest struct {
+	ID     string `json:"ID,omitempty" msgpack:",omitempty"`
+	Name   string `json:"name,omitempty" msgpack:",omitempty"` // 15字
+	Brief  string `json:"brief,omitempty" msgpack:",omitempty"`
+	Note   string `json:"note,omitempty" msgpack:",omitempty"`
+	Avatar string `json:"avatar,omitempty" msgpack:",omitempty"` // 头像？还是用另一个api进行注册比较好？可以省略
+	Key    string `json:"key,omitempty" msgpack:",omitempty"`
+}
+
+// RegisterResponse 注册公骰响应
+type RegisterResponse struct {
+	Item DiceInfo `json:"item"`
+}
+
+// Register 注册公骰
+func (c *PublicDiceClient) Register(req *RegisterRequest, keyFunc func(data any) string) (*RegisterResponse, int) {
+	if keyFunc != nil {
+		req.Key = keyFunc(req)
+	}
+	return doReq[RegisterResponse](c, "POST", "/dice/api/public-dice/register", req, nil)
+}
+
+// DiceUpdateRequest 更新公骰请求
+type DiceUpdateRequest struct {
+	ID    string `json:"id" msgpack:",omitempty"`
+	Name  string `json:"name" msgpack:",omitempty"`
+	Brief string `json:"brief" msgpack:",omitempty"`
+	Note  string `json:"note" msgpack:",omitempty"`
+	Key   string `json:"key" msgpack:",omitempty"`
+}
+
+// DiceUpdateResponse 更新公骰响应
+type DiceUpdateResponse struct {
+	Updated int `json:"updated"`
+}
+
+// DiceUpdate 更新公骰
+func (c *PublicDiceClient) DiceUpdate(req *DiceUpdateRequest, keyFunc func(data any) string) (*DiceUpdateResponse, int) {
+	if keyFunc != nil {
+		req.Key = keyFunc(req)
+	}
+	return doReq[DiceUpdateResponse](c, "POST", "/dice/api/public-dice/register?update=1", req, nil)
+}
+
+// EndpointUpdateRequest 更新公骰SNS账号信息请求
+type EndpointUpdateRequest struct {
+	DiceID    string      `json:"diceId" msgpack:",omitempty"`
+	Key       string      `json:"key" msgpack:",omitempty"`
+	Endpoints []*Endpoint `json:"endpoints" msgpack:",omitempty"`
+}
+
+// EndpointUpdateResponse 更新公骰SNS账号信息响应
+type EndpointUpdateResponse struct{}
+
+// EndpointUpdate 更新公骰SNS账号信息
+func (c *PublicDiceClient) EndpointUpdate(req *EndpointUpdateRequest, keyFunc func(data any) string) (*EndpointUpdateResponse, int) {
+	if keyFunc != nil {
+		req.Key = keyFunc(req)
+	}
+	return doReq[EndpointUpdateResponse](c, "POST", "/dice/api/public-dice/endpoint-update", req, nil)
+}
+
+// TickUpdateRequest 更新公骰心跳请求
+type TickUpdateRequest struct {
+	ID        string          `json:"ID" msgpack:",omitempty"`
+	Key       string          `json:"key" msgpack:",omitempty"`
+	Endpoints []*TickEndpoint `json:"Endpoints" msgpack:",omitempty"`
+}
+
+// TickEndpoint 公骰心跳端点信息
+type TickEndpoint struct {
+	UID      string `json:"uid" msgpack:",omitempty"`
+	IsOnline bool   `json:"isOnline" msgpack:",omitempty"`
+}
+
+// TickUpdateResponse 更新公骰心跳响应
+type TickUpdateResponse struct{}
+
+// TickUpdate 更新公骰心跳
+func (c *PublicDiceClient) TickUpdate(req *TickUpdateRequest, keyFunc func(data any) string) (*TickUpdateResponse, int) {
+	if keyFunc != nil {
+		req.Key = keyFunc(req)
+	}
+	return doReq[TickUpdateResponse](c, "POST", "/dice/api/public-dice/tick-update", req, nil)
+}


### PR DESCRIPTION
目前通过这种方式使用：
在serve.yaml中，将publicDiceEnable设置为true
```yaml
publicDiceEnable: true
publicDiceId: ""
publicDiceName: ""
publicDiceBrief: ""
publicDiceNote: ""
publicDiceAvatar: ""
```

配置中的publicDiceId会在第一次启动后获得，相当于一个密钥。

同时在同一个文件靠上方的endPoints中，将你想要进行公开登记账号的isPublic设置为true，例如：
```
    endPoints:
        - baseInfo:
            id: b0a2972b-2d8e-4241-805e-7a62beeaf5de
            nickname: 木落的测试机器人
            state: 1
            userId: KOOK:12345
            enable: true
            isPublic: true
```

这样这个号就会出现在公骰列表，未标记的号不会出现。
启动后20s后会进行一次上报，之后每3分钟进行一次刷新。服务器一般来说刷新间隔是30s，因此极端情况下目前需要1分钟才能看到账号登记。

骰子关闭之后，没有继续刷新的账号会在一小段时间后被标记为离线，而在大概一小时后从列表中消失。
