### PR TITLE
refactor: 使用otter缓存替代buntdb，并借助context对除SQLITE以外的数据库进行细粒度缓存

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -231,7 +231,8 @@ func (group *GroupInfo) PlayerGet(db *gorm.DB, id string) *GroupPlayerInfo {
 	}
 	p, exists := group.Players.Load(id)
 	if !exists {
-		p = (*GroupPlayerInfo)(model.GroupPlayerInfoGet(db, group.GroupID, id))
+		basePtr := model.GroupPlayerInfoGet(db, group.GroupID, id)
+		p = (*GroupPlayerInfo)(basePtr)
 		if p != nil {
 			group.Players.Store(id, p)
 		}

--- a/dice/model/database/mysql.go
+++ b/dice/model/database/mysql.go
@@ -18,7 +18,7 @@ func MySQLDBInit(dsn string) (*gorm.DB, error) {
 		return nil, err
 	}
 	// 存疑，MYSQL是否需要使用缓存
-	cacheDB, err := cache.GetBuntCacheDB(db)
+	cacheDB, err := cache.GetOtterCacheDB(db)
 	if err != nil {
 		return nil, err
 	}

--- a/dice/model/database/pgsql.go
+++ b/dice/model/database/pgsql.go
@@ -20,8 +20,8 @@ func PostgresDBInit(dsn string) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	// GetBuntCacheDB 逻辑保持不变
-	cacheDB, err := cache.GetBuntCacheDB(db)
+	// GetOtterCacheDB 逻辑保持不变
+	cacheDB, err := cache.GetOtterCacheDB(db)
 	if err != nil {
 		return nil, err
 	}

--- a/dice/model/database/sqlite.go
+++ b/dice/model/database/sqlite.go
@@ -23,7 +23,7 @@ func SQLiteDBInit(path string, useWAL bool) (*gorm.DB, error) {
 		return nil, err
 	}
 	// Enable Cache Mode
-	db, err = cache.GetBuntCacheDB(db)
+	db, err = cache.GetOtterCacheDB(db)
 	if err != nil {
 		return nil, err
 	}

--- a/dice/model/database/sqlite_cgo.go
+++ b/dice/model/database/sqlite_cgo.go
@@ -20,7 +20,7 @@ func SQLiteDBInit(path string, useWAL bool) (*gorm.DB, error) {
 		return nil, err
 	}
 	// Enable Cache Mode
-	open, err = cache.GetBuntCacheDB(open)
+	open, err = cache.GetOtterCacheDB(open)
 	if err != nil {
 		return nil, err
 	}

--- a/dice/model/db.go
+++ b/dice/model/db.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"os"
 	"sync"
 
@@ -32,8 +33,8 @@ func initEngine() {
 		log.Warn("未配置数据库类型，默认使用: SQLITE数据库")
 		engine = &SQLiteEngine{}
 	}
-
-	errEngineInstance = engine.Init()
+	// TODO: 使用统一管理的context，以确保在程序关闭时，可以正确销毁数据库的context从而优雅退出
+	errEngineInstance = engine.Init(context.Background())
 	if errEngineInstance != nil {
 		log.Error("数据库引擎初始化失败:", errEngineInstance)
 	}

--- a/dice/model/engine_interface.go
+++ b/dice/model/engine_interface.go
@@ -1,13 +1,24 @@
 package model
 
-import "gorm.io/gorm"
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
 
 // DatabaseOperator 本来是单独放了个文件夹的，但是由于现在所有的model都和处理逻辑在一起，如果放在单独文件夹必然会循环依赖
-// 只能放在外面
+// 只能放在外面，或许我们
 type DatabaseOperator interface {
-	Init() error
+	Init(ctx context.Context) error
 	DBCheck()
 	DataDBInit() (*gorm.DB, error)
 	LogDBInit() (*gorm.DB, error)
 	CensorDBInit() (*gorm.DB, error)
 }
+
+// 实现检查 copied from platform
+var (
+	_ DatabaseOperator = (*SQLiteEngine)(nil)
+	_ DatabaseOperator = (*MYSQLEngine)(nil)
+	_ DatabaseOperator = (*PGSQLEngine)(nil)
+)

--- a/dice/model/engine_mysql.go
+++ b/dice/model/engine_mysql.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -14,6 +15,7 @@ import (
 type MYSQLEngine struct {
 	DSN string
 	DB  *gorm.DB
+	ctx context.Context
 }
 
 type LogInfoHookMySQL struct {
@@ -103,7 +105,11 @@ func createIndexForLogOneItem(db *gorm.DB) (err error) {
 	return nil
 }
 
-func (s *MYSQLEngine) Init() error {
+func (s *MYSQLEngine) Init(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("ctx is missing")
+	}
+	s.ctx = ctx
 	s.DSN = os.Getenv("DB_DSN")
 	if s.DSN == "" {
 		return errors.New("DB_DSN is missing")
@@ -123,7 +129,9 @@ func (s *MYSQLEngine) DBCheck() {
 
 // DataDBInit 初始化
 func (s *MYSQLEngine) DataDBInit() (*gorm.DB, error) {
-	err := s.DB.AutoMigrate(
+	dataContext := context.WithValue(s.ctx, "gorm_cache", "data-db::")
+	dataDB := s.DB.WithContext(dataContext)
+	err := dataDB.AutoMigrate(
 		// TODO: 这个的索引有没有必要进行修改
 		&GroupPlayerInfoBase{},
 		&GroupInfo{},
@@ -134,30 +142,33 @@ func (s *MYSQLEngine) DataDBInit() (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return s.DB, nil
+	return dataDB, nil
 }
 
 func (s *MYSQLEngine) LogDBInit() (*gorm.DB, error) {
 	// logs特殊建表
-	if err := s.DB.AutoMigrate(&LogInfoHookMySQL{}, &LogOneItemHookMySQL{}); err != nil {
+	logsContext := context.WithValue(s.ctx, "gorm_cache", "logs-db::")
+	logDB := s.DB.WithContext(logsContext)
+	if err := logDB.AutoMigrate(&LogInfoHookMySQL{}, &LogOneItemHookMySQL{}); err != nil {
 		return nil, err
 	}
 	// logs建立索引
-	err := createIndexForLogInfo(s.DB)
+	err := createIndexForLogInfo(logDB)
 	if err != nil {
 		return nil, err
 	}
-	err = createIndexForLogOneItem(s.DB)
+	err = createIndexForLogOneItem(logDB)
 	if err != nil {
 		return nil, err
 	}
-	return s.DB, nil
+	return logDB, nil
 }
 
 func (s *MYSQLEngine) CensorDBInit() (*gorm.DB, error) {
-	// 创建基本的表结构，并通过标签定义索引
-	if err := s.DB.AutoMigrate(&CensorLog{}); err != nil {
+	censorContext := context.WithValue(s.ctx, "gorm_cache", "censor-db::")
+	censorDB := s.DB.WithContext(censorContext)
+	if err := censorDB.AutoMigrate(&CensorLog{}); err != nil {
 		return nil, err
 	}
-	return s.DB, nil
+	return censorDB, nil
 }

--- a/dice/model/engine_mysql.go
+++ b/dice/model/engine_mysql.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"sealdice-core/dice/model/database"
+	"sealdice-core/dice/model/database/cache"
 	log "sealdice-core/utils/kratos"
 )
 
@@ -129,7 +130,7 @@ func (s *MYSQLEngine) DBCheck() {
 
 // DataDBInit 初始化
 func (s *MYSQLEngine) DataDBInit() (*gorm.DB, error) {
-	dataContext := context.WithValue(s.ctx, "gorm_cache", "data-db::")
+	dataContext := context.WithValue(s.ctx, cache.CacheKey, cache.DataDBCacheKey)
 	dataDB := s.DB.WithContext(dataContext)
 	err := dataDB.AutoMigrate(
 		// TODO: 这个的索引有没有必要进行修改
@@ -147,7 +148,7 @@ func (s *MYSQLEngine) DataDBInit() (*gorm.DB, error) {
 
 func (s *MYSQLEngine) LogDBInit() (*gorm.DB, error) {
 	// logs特殊建表
-	logsContext := context.WithValue(s.ctx, "gorm_cache", "logs-db::")
+	logsContext := context.WithValue(s.ctx, cache.CacheKey, cache.LogsDBCacheKey)
 	logDB := s.DB.WithContext(logsContext)
 	if err := logDB.AutoMigrate(&LogInfoHookMySQL{}, &LogOneItemHookMySQL{}); err != nil {
 		return nil, err
@@ -165,7 +166,7 @@ func (s *MYSQLEngine) LogDBInit() (*gorm.DB, error) {
 }
 
 func (s *MYSQLEngine) CensorDBInit() (*gorm.DB, error) {
-	censorContext := context.WithValue(s.ctx, "gorm_cache", "censor-db::")
+	censorContext := context.WithValue(s.ctx, cache.CacheKey, cache.CensorsDBCacheKey)
 	censorDB := s.DB.WithContext(censorContext)
 	if err := censorDB.AutoMigrate(&CensorLog{}); err != nil {
 		return nil, err

--- a/dice/model/engine_pgsql.go
+++ b/dice/model/engine_pgsql.go
@@ -9,6 +9,7 @@ import (
 	"gorm.io/gorm"
 
 	"sealdice-core/dice/model/database"
+	"sealdice-core/dice/model/database/cache"
 )
 
 type PGSQLEngine struct {
@@ -42,7 +43,7 @@ func (s *PGSQLEngine) DBCheck() {
 // DataDBInit 初始化
 func (s *PGSQLEngine) DataDBInit() (*gorm.DB, error) {
 	// data建表
-	dataContext := context.WithValue(s.ctx, "gorm_cache", "data-db::")
+	dataContext := context.WithValue(s.ctx, cache.CacheKey, cache.DataDBCacheKey)
 	dataDB := s.DB.WithContext(dataContext)
 	err := dataDB.AutoMigrate(
 		&GroupPlayerInfoBase{},
@@ -59,7 +60,7 @@ func (s *PGSQLEngine) DataDBInit() (*gorm.DB, error) {
 
 func (s *PGSQLEngine) LogDBInit() (*gorm.DB, error) {
 	// logs建表
-	logsContext := context.WithValue(s.ctx, "gorm_cache", "logs-db::")
+	logsContext := context.WithValue(s.ctx, cache.CacheKey, cache.LogsDBCacheKey)
 	logDB := s.DB.WithContext(logsContext)
 	if err := logDB.AutoMigrate(&LogInfo{}, &LogOneItem{}); err != nil {
 		return nil, err
@@ -68,7 +69,7 @@ func (s *PGSQLEngine) LogDBInit() (*gorm.DB, error) {
 }
 
 func (s *PGSQLEngine) CensorDBInit() (*gorm.DB, error) {
-	censorContext := context.WithValue(s.ctx, "gorm_cache", "censor-db::")
+	censorContext := context.WithValue(s.ctx, cache.CacheKey, cache.CensorsDBCacheKey)
 	censorDB := s.DB.WithContext(censorContext)
 	// 创建基本的表结构，并通过标签定义索引
 	if err := censorDB.AutoMigrate(&CensorLog{}); err != nil {

--- a/dice/model/engine_sqlite.go
+++ b/dice/model/engine_sqlite.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 
 type SQLiteEngine struct {
 	DataDir string
+	ctx     context.Context
 }
 
 const defaultDataDir = "./data/default"
@@ -33,7 +36,11 @@ CREATE TABLE attrs__temp (
 );
 `
 
-func (s *SQLiteEngine) Init() error {
+func (s *SQLiteEngine) Init(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("ctx is missing")
+	}
+	s.ctx = ctx
 	s.DataDir = os.Getenv("DATADIR")
 	if s.DataDir == "" {
 		log.Debug("未能发现SQLITE定义位置，使用默认data地址")
@@ -122,6 +129,9 @@ func (s *SQLiteEngine) DataDBInit() (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 添加并设置context
+	dataContext := context.WithValue(s.ctx, "gorm_cache", "data-db::")
+	dataDB = dataDB.WithContext(dataContext)
 	// 特殊情况建表语句处置
 	tx := dataDB.Begin()
 	// 检查是否有这个影响的注释
@@ -180,6 +190,9 @@ func (s *SQLiteEngine) LogDBInit() (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 添加并设置context
+	logsContext := context.WithValue(s.ctx, "gorm_cache", "logs-db::")
+	logsDB = logsDB.WithContext(logsContext)
 	// logs建表
 	if err = logsDB.AutoMigrate(&LogInfo{}); err != nil {
 		return nil, err
@@ -203,11 +216,7 @@ func (s *SQLiteEngine) LogDBInit() (*gorm.DB, error) {
 }
 
 func (s *SQLiteEngine) CensorDBInit() (*gorm.DB, error) {
-	dataDir := os.Getenv("DATA_DIR")
-	if dataDir == "" {
-		dataDir = defaultDataDir
-	}
-	path, err := filepath.Abs(filepath.Join(dataDir, "data-censor.db"))
+	path, err := filepath.Abs(filepath.Join(s.DataDir, "data-censor.db"))
 	if err != nil {
 		return nil, err
 	}
@@ -215,6 +224,9 @@ func (s *SQLiteEngine) CensorDBInit() (*gorm.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 添加并设置context
+	censorContext := context.WithValue(s.ctx, "gorm_cache", "censor-db::")
+	censorDB = censorDB.WithContext(censorContext)
 	// 创建基本的表结构，并通过标签定义索引
 	if err = censorDB.AutoMigrate(&CensorLog{}); err != nil {
 		return nil, err

--- a/dice/model/engine_sqlite.go
+++ b/dice/model/engine_sqlite.go
@@ -11,6 +11,7 @@ import (
 	"gorm.io/gorm"
 
 	"sealdice-core/dice/model/database"
+	"sealdice-core/dice/model/database/cache"
 	log "sealdice-core/utils/kratos"
 )
 
@@ -130,7 +131,7 @@ func (s *SQLiteEngine) DataDBInit() (*gorm.DB, error) {
 		return nil, err
 	}
 	// 添加并设置context
-	dataContext := context.WithValue(s.ctx, "gorm_cache", "data-db::")
+	dataContext := context.WithValue(s.ctx, cache.CacheKey, cache.DataDBCacheKey)
 	dataDB = dataDB.WithContext(dataContext)
 	// 特殊情况建表语句处置
 	tx := dataDB.Begin()
@@ -191,7 +192,7 @@ func (s *SQLiteEngine) LogDBInit() (*gorm.DB, error) {
 		return nil, err
 	}
 	// 添加并设置context
-	logsContext := context.WithValue(s.ctx, "gorm_cache", "logs-db::")
+	logsContext := context.WithValue(s.ctx, cache.CacheKey, cache.LogsDBCacheKey)
 	logsDB = logsDB.WithContext(logsContext)
 	// logs建表
 	if err = logsDB.AutoMigrate(&LogInfo{}); err != nil {
@@ -225,7 +226,7 @@ func (s *SQLiteEngine) CensorDBInit() (*gorm.DB, error) {
 		return nil, err
 	}
 	// 添加并设置context
-	censorContext := context.WithValue(s.ctx, "gorm_cache", "censor-db::")
+	censorContext := context.WithValue(s.ctx, cache.CacheKey, cache.CensorsDBCacheKey)
 	censorDB = censorDB.WithContext(censorContext)
 	// 创建基本的表结构，并通过标签定义索引
 	if err = censorDB.AutoMigrate(&CensorLog{}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -117,9 +117,11 @@ require (
 	github.com/blevesearch/zapx/v16 v16.1.8 // indirect
 	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
+	github.com/dolthub/maphash v0.1.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20230808193330-2592e75ae04a // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
 	github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 // indirect
 	github.com/getlantern/errors v0.0.0-20190325191628-abdb3e3e36f7 // indirect
 	github.com/getlantern/golog v0.0.0-20190830074920-4ef2e798c2d7 // indirect
@@ -155,6 +157,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/maypok86/otter v1.2.4 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd h1:QMSNEh9uQkDjyPwu/J541GgSH+4hw+0skJDIj9HJ3mE=
 github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc h1:MKYt39yZJi0Z9xEeRmDX2L4ocE0ETKcHKw6MVL3R+co=
@@ -114,6 +116,8 @@ github.com/fy0/systray v1.2.2 h1:WUF+1ktzx5Ly0VsD8lC3ZXC/6gJS1QYwaDGZcwH/kcE=
 github.com/fy0/systray v1.2.2/go.mod h1:MS9IFfZENC18mgf9sQh6WHIH/DX2KEjGrTSB2KMiuJ0=
 github.com/fyrchik/go-shlex v0.0.0-20210215145004-cd7f49bfd959 h1:vRVfi8lpnfa/kKTyUbIY+NYXJTFJm/At55QPjVUO958=
 github.com/fyrchik/go-shlex v0.0.0-20210215145004-cd7f49bfd959/go.mod h1:YStpgtXPSk15HQrzeLVhEBONprVJFuvdgs43bFidS/A=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/gen2brain/beeep v0.0.0-20230907135156-1a38885a97fc h1:NNgdMgPX3j33uEAoVVxNxillDPnxT0xbGv8uh4CKIAo=
 github.com/gen2brain/beeep v0.0.0-20230907135156-1a38885a97fc/go.mod h1:0W7dI87PvXJ1Sjs0QPvWXKcQmNERY77e8l7GFhZB/s4=
 github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 h1:NRUJuo3v3WGC/g5YiyF790gut6oQr5f3FBI88Wv0dx4=
@@ -279,6 +283,8 @@ github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/maypok86/otter v1.2.4 h1:HhW1Pq6VdJkmWwcZZq19BlEQkHtI8xgsQzBVXJU0nfc=
+github.com/maypok86/otter v1.2.4/go.mod h1:mKLfoI7v1HOmQMwFgX4QkRk23mX6ge3RDvjdHOWG4R4=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
如题，otter缓存: https://github.com/maypok86/otter;

基于对缓存和并发数据结构的研究，Otter 是 Go 最强大的缓存库之一。 Otter还借鉴了其他语言（例如[caffeine](https://github.com/ben-manes/caffeine) ）设计缓存库的经验。

同时，我现在以context创建data,logs,censor的gorm.DB，从而可以在缓存清理时，针对data/logs/censor的不同进行缓存清理，这样能增加缓存命中率。

注：由于sqlite是物理分割的，所以这个优化似乎只对PG和MYSQL有效。

另外针对Init，对应的代码要求传入context，为以后可以使用超时关闭数据库的context做准备(待定，现在反正直接传递了context.Background()）