### PR TITLE
fix: 修复SignInfo空切片的问题

### DIFF
--- a/api/dice_public.go
+++ b/api/dice_public.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"time"
 
 	"sealdice-core/dice"
 
@@ -41,5 +42,7 @@ func dicePublicSet(c echo.Context) error {
 	myDice.PublicDiceInfoRegister()
 	myDice.PublicDiceEndpointRefresh()
 	myDice.PublicDiceSetupTick()
+	myDice.LastUpdatedTime = time.Now().Unix()
+	myDice.Save(false)
 	return Success(&c, Response{})
 }

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -429,21 +429,21 @@ func LagrangeGetSignInfo(dice *Dice) ([]SignInfo, error) {
 	cachePath := filepath.Join(dice.BaseConfig.DataDir, "extra/SignInfo.cache")
 	signInfo, err := lagrangeGetSignInfoFromCloud(cachePath)
 	if err == nil && len(signInfo) > 0 {
-		signInfoGlobal = signInfo
+		signInfoGlobal = append([]SignInfo(nil), signInfo...)
 		return signInfo, nil
 	}
 	dice.Logger.Infof("无法从云端获取SignInfo，即将读取本地缓存数据, 原因: %s", err.Error())
 
 	signInfo, err = lagrangeGetSignInfoFromCache(cachePath)
 	if err == nil && len(signInfo) > 0 {
-		signInfoGlobal = signInfo
+		signInfoGlobal = append([]SignInfo(nil), signInfo...)
 		return signInfo, nil
 	}
 	dice.Logger.Infof("无法从本地缓存获取SignInfo，即将读取内置数据, 原因: %s", err.Error())
 
 	if err = json.Unmarshal([]byte(signInfoJson), &signInfo); err == nil {
 		lagrangeGetSignServerLatency(signInfo)
-		signInfoGlobal = signInfo
+		signInfoGlobal = append([]SignInfo(nil), signInfo...)
 		return signInfo, nil
 	}
 	dice.Logger.Infof("无法从内置数据获取SignInfo，请联系开发者上报问题, 原因: %s", err.Error())

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -429,21 +429,21 @@ func LagrangeGetSignInfo(dice *Dice) ([]SignInfo, error) {
 	cachePath := filepath.Join(dice.BaseConfig.DataDir, "extra/SignInfo.cache")
 	signInfo, err := lagrangeGetSignInfoFromCloud(cachePath)
 	if err == nil && len(signInfo) > 0 {
-		copy(signInfoGlobal, signInfo)
+		signInfoGlobal = signInfo
 		return signInfo, nil
 	}
 	dice.Logger.Infof("无法从云端获取SignInfo，即将读取本地缓存数据, 原因: %s", err.Error())
 
 	signInfo, err = lagrangeGetSignInfoFromCache(cachePath)
 	if err == nil && len(signInfo) > 0 {
-		copy(signInfoGlobal, signInfo)
+		signInfoGlobal = signInfo
 		return signInfo, nil
 	}
 	dice.Logger.Infof("无法从本地缓存获取SignInfo，即将读取内置数据, 原因: %s", err.Error())
 
 	if err = json.Unmarshal([]byte(signInfoJson), &signInfo); err == nil {
 		lagrangeGetSignServerLatency(signInfo)
-		copy(signInfoGlobal, signInfo)
+		signInfoGlobal = signInfo
 		return signInfo, nil
 	}
 	dice.Logger.Infof("无法从内置数据获取SignInfo，请联系开发者上报问题, 原因: %s", err.Error())

--- a/dice/version.go
+++ b/dice/version.go
@@ -21,7 +21,7 @@ var (
 	// APP_CHANNEL 更新频道，stable/dev，在 action 构建时自动注入
 	APP_CHANNEL = "dev" //nolint:revive
 
-	VERSION_CODE = int64(1004100) //nolint:revive
+	VERSION_CODE = int64(1004101) //nolint:revive
 
 	VERSION_JSAPI_COMPATIBLE = []*semver.Version{
 		VERSION,


### PR DESCRIPTION
1、copy函数的dst要提前分配好空间，之前忘了（这个copy函数我根本没用过，看例程漏看了注意项那一行），现在我选择用append

2、升级版本号

3、公骰设置保存至配置文件