### PR TITLE
fix: 修复 `.init set` 无法添加新单位的问题

### DIFF
--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -1500,11 +1500,16 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 				}
 
 				riList := (RIList{}).LoadByCurGroup(ctx)
+				added := false
 				for _, i := range riList {
 					if i.name == name {
 						i.val = int64(r.MustReadInt())
+						added = true
 						break
 					}
+				}
+				if !added {
+					riList = append(riList, &RIListItem{name, int64(r.MustReadInt()), "", ""})
 				}
 				sort.Sort(riList)
 


### PR DESCRIPTION
fix #1208 