### PR TITLE
fix: 修正使用sn设置插件内名片模板时，名片模板错误和名片超长时显示设置成功但未成功的问题（增加sn命令default分支内的错误处理）。

### DIFF
--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -695,7 +695,6 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 			default:
 				ok := false
-				last := ctx.Player.AutoSetNameTemplate
 
 				ctx.Dice.GameSystemMap.Range(func(key string, value *GameSystemTemplate) bool {
 					var t NameTemplateItem
@@ -717,8 +716,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 						ok = true
 						return false
 					} else if err != nil {
-						ctx.Player.AutoSetNameTemplate = last
-						ReplyToSender(ctx, msg, fmt.Sprintf("%q模板sn格式错误，已自动还原之前模板", val))
+						ReplyToSender(ctx, msg, fmt.Sprintf("%q模板格式错误或不存在，请更改插件模板设置", val))
 						ok = true
 						return false
 					}

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -695,7 +695,6 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 			default:
 				ok := false
-
 				ctx.Dice.GameSystemMap.Range(func(key string, value *GameSystemTemplate) bool {
 					var t NameTemplateItem
 					var exists bool
@@ -716,7 +715,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 						ok = true
 						return false
 					} else if err != nil {
-						ReplyToSender(ctx, msg, fmt.Sprintf("%q模板格式错误或不存在，请更改插件模板设置", val))
+						ReplyToSender(ctx, msg, "命名模版错误或不存在，请使用.sn help查看使用说明")
 						ok = true
 						return false
 					}


### PR DESCRIPTION
第一次弄，之前把主分支推过来了，后来要修别的时发现不太对劲，就关闭重推了一下。
如题，解决了[#1222](https://github.com/sealdice/sealdice-core/issues/1222)的问题（）
自己测了下应该没啥问题……
然后我发现.nn命令名称超长时也没有报错……以后再说。

![图片](https://github.com/user-attachments/assets/78b1904c-a078-4cbc-b225-4a7503bb9ccb)