### PR TITLE
fix: 尝试修正批量入库的无法正确落盘问题

### DIFF
--- a/dice/dice_attrs_manager.go
+++ b/dice/dice_attrs_manager.go
@@ -236,7 +236,7 @@ func (am *AttrsManager) CheckAndFreeUnused() error {
 	var resultList []*service.AttributesBatchUpsertModel
 	am.m.Range(func(key string, value *AttributesItem) bool {
 		lastUsedTime := time.Unix(value.LastUsedTime, 0)
-		if lastUsedTime.Sub(currentTime) > 10*time.Minute {
+		if currentTime.Sub(lastUsedTime) > 10*time.Minute {
 			saveModel, err := value.GetBatchSaveModel()
 			if err != nil {
 				// 打印日志


### PR DESCRIPTION
经过检查，强怀疑和两处错误有关：

1. 清除未释放的数据时，判断逻辑失误。判断是否为未释放的数据时，其时间写反，导致判断永远不生效。
2. DoUpdates行为异常。原本写法下，会每次取表内的数据，将表内的数据更新为表内的数据。GPT表示无法通过调整GORM来解决这个问题，且发现可能关联的，仍然打开的ISSUE如下：https://github.com/go-gorm/gorm/issues/6047
上述两个问题合并，疑似刚好拼凑出了特别情况：数据落盘后并未被正确清理，造成数据卡数据一直驻留在内存中，并在重启后丢失

目前考虑的修复思路为：

修正时间写反的问题，保证判断能正确生效。
将原本的批量逻辑，改为先区分插入和更新，然后分别进行处理，插入采取批量插入，更新采取顺序按条更新。

此处为对应PR。（或许事实上还是没找到原因在哪儿……）