### PR TITLE
feat: 实现戳一戳转换成CQ码

### DIFF
--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1082,6 +1082,13 @@ func (pa *PlatformAdapterGocq) Serve() int {
 					}
 				}
 			}()
+
+			if string(msgQQ.UserID) == string(msgQQ.SelfID) {
+				// 自己戳自己，防止循环触发
+				return
+			}
+			msg.Message = "[CQ:poke,qq=" + string(msgQQ.TargetID) + "]"
+			session.Execute(ep, msg, false)
 			return
 		}
 


### PR DESCRIPTION
通过将戳一戳转换成CQ码，可以在**自定义回复**和**插件非指令消息处理**中匹配到对任何人的戳一戳消息
- 测试框架：`napcat-v4.7.13`, onebotv11正向连接
- 还未解决的问题：`msg.Sender.Nickname`在日志中显示为空字符串，影响不大，应该？