### PR TITLE
fix: 修复 DND5e rc 使用技能别名进行检定时会展示原始函数的问题

### DIFF
--- a/dice/ext_dnd5e.go
+++ b/dice/ext_dnd5e.go
@@ -62,18 +62,6 @@ var dndAttrParent = map[string]string{
 
 const NULL_INIT_VAL = math.MaxInt32 // 不使用 MAX_INT64 以保证 JS 环境使用时不会出现潜在问题
 
-func setupConfigDND(_ *Dice) AttributeConfigs {
-	// 如果不存在，新建
-	defaultVals := AttributeConfigs{
-		Alias: map[string][]string{},
-		Order: AttributeOrder{
-			Top:    []string{"力量", "敏捷", "体质", "体型", "魅力", "智力", "感知", "hp", "ac", "熟练"},
-			Others: AttributeOrderOthers{SortBy: "Name"},
-		},
-	}
-	return defaultVals
-}
-
 func getPlayerNameTempFunc(mctx *MsgContext) string {
 	if mctx.Dice.Config.PlayerNameWrapEnable {
 		return fmt.Sprintf("<%s>", mctx.Player.Name)
@@ -95,8 +83,6 @@ func stpFormat(attrName string) string {
 }
 
 func RegisterBuiltinExtDnd5e(self *Dice) {
-	ac := setupConfigDND(self)
-
 	deathSavingStable := func(ctx *MsgContext) {
 		VarDelValue(ctx, "DSS")
 		VarDelValue(ctx, "DSF")
@@ -417,7 +403,7 @@ func RegisterBuiltinExtDnd5e(self *Dice) {
 			// 获取代骰
 			mctx := GetCtxProxyFirst(ctx, cmdArgs)
 			mctx.DelegateText = ctx.DelegateText
-			mctx.Player.TempValueAlias = &ac.Alias
+			mctx.Player.TempValueAlias = &_dnd5eTmpl.Alias
 			// 参数确认
 			val := cmdArgs.GetArgN(1)
 			switch val {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -55,22 +55,6 @@ type Message struct {
 	Segment []message.IMessageElement `json:"-" yaml:"-" jsbind:"segment"`
 }
 
-// GroupPlayerInfoBase 群内玩家信息
-type GroupPlayerInfoBase struct {
-	Name                string `yaml:"name" jsbind:"name"` // 玩家昵称
-	UserID              string `yaml:"userId" jsbind:"userId"`
-	InGroup             bool   `yaml:"inGroup"`                                          // 是否在群内，有时一个人走了，信息还暂时残留
-	LastCommandTime     int64  `yaml:"lastCommandTime" jsbind:"lastCommandTime"`         // 上次发送指令时间
-	AutoSetNameTemplate string `yaml:"autoSetNameTemplate" jsbind:"autoSetNameTemplate"` // 名片模板
-
-	DiceSideNum  int    `yaml:"diceSideNum"`  // 面数，为0时等同于d100
-	DiceSideExpr string `yaml:"diceSideExpr"` // 面数，准备替代数字版本
-
-	TempValueAlias *map[string][]string `yaml:"-"` // 群内临时变量别名 - 其实这个有点怪的，为什么在这里？
-
-	UpdatedAtTime int64 `yaml:"-" json:"-"`
-}
-
 // GroupPlayerInfo 这是一个YamlWrapper，没有实际作用
 // 原因见 https://github.com/go-yaml/yaml/issues/712
 // type GroupPlayerInfo struct {

--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -582,6 +582,8 @@ func (ctx *MsgContext) setDndReadForVM(rcMode bool) {
 			curVal, _ = tryLoadByBuff(ctx, varname, curVal, false, detail)
 		}
 
+		realVarName := ctx.SystemTemplate.GetAlias(varname)
+
 		if !skip && rcMode {
 			// rc时将属性替换为调整值，只在0级起作用，避免在函数调用等地方造成影响
 			if isAbilityScores(varname) && vm.Depth() == 0 && vm.UpCtx == nil {
@@ -595,8 +597,8 @@ func (ctx *MsgContext) setDndReadForVM(rcMode bool) {
 					}
 					return v
 				}
-			} else if dndAttrParent[varname] != "" && curVal.TypeId == ds.VMTypeInt {
-				name := dndAttrParent[varname]
+			} else if dndAttrParent[realVarName] != "" && curVal.TypeId == ds.VMTypeInt {
+				name := dndAttrParent[realVarName]
 				base, err := ctx.SystemTemplate.GetRealValue(ctx, name)
 				v := curVal.MustReadInt()
 				if err == nil {

--- a/model/group_info.go
+++ b/model/group_info.go
@@ -17,7 +17,7 @@ func (*GroupInfo) TableName() string {
 	return "group_info"
 }
 
-// GroupPlayerInfoBase 群内玩家信息
+// GroupPlayerInfoBase 群内玩家信息 迁移自 im_session.go
 type GroupPlayerInfoBase struct {
 	// 补充这个字段，从而保证包含主键ID
 	ID     uint   `yaml:"-" jsbind:"-" gorm:"column:id;primaryKey;autoIncrement"` // 主键ID字段，自增


### PR DESCRIPTION
chore: 移除无用代码