### PR TITLE
fix(rollvm):修复rollvm内可能导致崩溃的方法

### DIFF
--- a/dice/rollvm.go
+++ b/dice/rollvm.go
@@ -553,7 +553,9 @@ func (e *RollExpression) Evaluate(_ *Dice, ctx *MsgContext) (*VMStack, string, e
 			}
 			continue
 		case TypePop:
-			top--
+			if top > 0 {
+				top--
+			}
 			continue
 		case TypeLoadFormatString:
 			num := int(code.Value)


### PR DESCRIPTION
rt
该错误报告用户崩溃日志：
[崩溃日志_20250805_220805.txt](https://github.com/user-attachments/files/20114744/_20250805_220805.txt)

经查源码发现rollvm.go L556 似乎默认了在typepop方法下top指针一定不为0，从而导致此豹在更改自定义回复后无法成功走通。rollvm-migration.go从而报错

自测已跑通+解决。amd64 Windows与Linux平台测试包已分发，需要更多测试样例

CC @fy0