### PR TITLE
fix: 修正升级模块执行时，在非SQLite环境下可能会导致运行错误无法建表的问题

### DIFF
--- a/migrate/v2/v120/v120.go
+++ b/migrate/v2/v120/v120.go
@@ -62,13 +62,18 @@ var V120LogMessageMigration = upgrade.Upgrade{
 	Description: "V120到V131内，有一个被应用的数据库修正，旨在将错误的message字段类型修改为正确的",
 	Apply: func(logf func(string), operator engine.DatabaseOperator) error {
 		logf("[INFO] 尝试检查数据库状态")
+		if operator.Type() != "sqlite" {
+			logf("[INFO] 仅sqlite数据库部分情况下需要处理，您无需处理")
+			return nil
+		}
 		logDB, err := utils.GetSQLXDB(operator.GetLogDB(constant.WRITE))
 		if err != nil {
 			return err
 		}
 		err = LogItemFixDatatype(logDB)
 		if err != nil {
-			return err
+			logf("[INFO] 升级失败，请检查数据库状态")
+			return nil
 		}
 		logf("[INFO] 升级完毕")
 		return nil


### PR DESCRIPTION
需要注意的是，现在的Ver1.5.0仅会在一开始建表一次。若需要二次建表，需要删除或者去掉upgrade的JSON文件。