### PR TITLE
feat(security): 修改密码之后现有会话立即失效

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -246,7 +246,7 @@ func doSignIn(c echo.Context) error {
 		head := hex.EncodeToString(Int64ToBytes(now))
 		token := dice.RandStringBytesMaskImprSrcSB2(64) + ":" + head
 
-		myDice.Parent.AccessTokens[token] = true
+		myDice.Parent.AccessTokens.Store(token, true)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Parent.Save()
 		return c.JSON(http.StatusOK, map[string]string{

--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -317,6 +317,8 @@ func DiceConfigSet(c echo.Context) error {
 	if val, ok := jsonMap["uiPassword"]; ok {
 		if !dm.JustForTest {
 			myDice.Parent.UIPasswordHash = val.(string)
+			// 清空所有现有的访问令牌，强制重新登录
+			myDice.Parent.AccessTokens = dice.SyncMap[string, bool]{}
 		}
 	}
 

--- a/api/utils.go
+++ b/api/utils.go
@@ -43,10 +43,7 @@ func doAuth(c echo.Context) bool {
 	if token == "" {
 		token = c.QueryParam("token")
 	}
-	if myDice.Parent.AccessTokens[token] {
-		return true
-	}
-	return false
+	return myDice.Parent.AccessTokens.Exists(token)
 }
 
 func GetHexData(c echo.Context, method string, name string) (value []byte, finished bool) {


### PR DESCRIPTION
- 将 AccessTokens 从 map 改为 SyncMap，提高并发安全性
- 在修改 UI 密码时清除所有现有访问令牌，强制重新登录
- 更新访问令牌的存储和验证方式，提高效率和安全性

Close #1303 