### PR TITLE
feat: 实现JS扩展重载的版本控制机制以解决竞态条件

### DIFF
--- a/api/js.go
+++ b/api/js.go
@@ -43,12 +43,12 @@ func jsExec(c echo.Context) error {
 	}
 
 	source := "(function(exports, require, module) {" + v.Value + "\n})()"
-
+	loop := myDice.ExtLoopManager.GetWebLoop()
 	waitRun := make(chan int, 1)
 
 	var ret goja.Value
 	myDice.JsPrinter.RecordStart()
-	myDice.JsLoop.RunOnLoop(func(vm *goja.Runtime) {
+	loop.RunOnLoop(func(vm *goja.Runtime) {
 		defer func() {
 			// 防止崩掉进程
 			if r := recover(); r != nil {

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -90,7 +90,7 @@ func (d *Dice) JsInit() {
 
 	loop := eventloop.NewEventLoop(eventloop.EnableConsole(false), eventloop.WithRegistry(reg))
 	_ = fetch.Enable(loop, goproxy.NewProxyHttpServer())
-	d.JsLoop = loop
+	versionID := d.ExtLoopManager.SetLoop(loop)
 
 	printer := &PrinterFunc{d, false, []string{}}
 	d.JsPrinter = printer
@@ -157,7 +157,7 @@ func (d *Dice) JsInit() {
 		ext := vm.NewObject()
 		_ = seal.Set("ext", ext)
 		_ = ext.Set("newCmdItemInfo", func() *CmdItemInfo {
-			return &CmdItemInfo{IsJsSolveFunc: true}
+			return &CmdItemInfo{IsJsSolveFunc: true, JSLoopVersion: versionID}
 		})
 		_ = ext.Set("newCmdExecuteResult", func(solved bool) CmdExecuteResult {
 			return CmdExecuteResult{
@@ -172,13 +172,14 @@ func (d *Dice) JsInit() {
 			}
 			return &ExtInfo{
 				Name: name, Author: author, Version: version,
-				GetDescText: GetExtensionDesc,
-				AutoActive:  true,
-				IsJsExt:     true,
-				Brief:       "一个JS自定义扩展",
-				Official:    official,
-				CmdMap:      CmdMapCls{},
-				Source:      d.JsLoadingScript,
+				GetDescText:   GetExtensionDesc,
+				AutoActive:    true,
+				IsJsExt:       true,
+				Brief:         "一个JS自定义扩展",
+				Official:      official,
+				CmdMap:        CmdMapCls{},
+				Source:        d.JsLoadingScript,
+				JSLoopVersion: versionID,
 			}
 		})
 		_ = ext.Set("find", func(name string) *ExtInfo {
@@ -201,6 +202,9 @@ func (d *Dice) JsInit() {
 			if ei.OnLoad != nil {
 				ei.OnLoad()
 			}
+			// 设置本次loop的版本，用于比较
+			ei.JSLoopVersion = versionID
+
 			d.ApplyExtDefaultSettings()
 			// Pinenutn: Range模板 ServiceAtNew重构代码
 			d.ImSession.ServiceAtNew.Range(func(key string, groupInfo *GroupInfo) bool {
@@ -642,11 +646,7 @@ func (d *Dice) jsClear() {
 	// Pinenutn: 由于切换成了其他的syncMap，所以初始化策略需要修改
 	d.GameSystemMap = new(SyncMap[string, *GameSystemTemplate])
 	d.RegisterBuiltinSystemTemplate()
-	// 关闭js vm
-	if d.JsLoop != nil {
-		d.JsLoop.Terminate()
-		d.JsLoop = nil
-	}
+	d.ExtLoopManager.SetLoop(nil)
 }
 
 func isScriptFile(filename string) bool {

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -112,8 +112,14 @@ func GetExtensionDesc(ei *ExtInfo) string {
 func (i *ExtInfo) callWithJsCheck(d *Dice, f func()) {
 	if i.IsJsExt {
 		if d.Config.JsEnable {
+			loop, err := d.ExtLoopManager.GetLoop(i.JSLoopVersion)
+			if err != nil {
+				// 打个DEBUG日志？
+				i.dice.Logger.Errorf("扩展<%s>运行环境已经过期: %v", i.Name, err)
+				return
+			}
 			waitRun := make(chan int, 1)
-			d.JsLoop.RunOnLoop(func(vm *goja.Runtime) {
+			loop.RunOnLoop(func(vm *goja.Runtime) {
 				defer func() {
 					// 防止崩掉进程
 					if r := recover(); r != nil {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -893,8 +893,15 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 						if i.OnNotCommandReceived != nil {
 							notCommandReceiveCall := func() {
 								if i.IsJsExt {
+									// 先判断运行环境
+									loop, err := d.ExtLoopManager.GetLoop(i.JSLoopVersion)
+									if err != nil {
+										// 打个DEBUG日志？
+										mctx.Dice.Logger.Errorf("扩展<%s>运行环境已经过期: %v", i.Name, err)
+										return
+									}
 									waitRun := make(chan int, 1)
-									d.JsLoop.RunOnLoop(func(runtime *goja.Runtime) {
+									loop.RunOnLoop(func(runtime *goja.Runtime) {
 										defer func() {
 											if r := recover(); r != nil {
 												mctx.Dice.Logger.Errorf("扩展<%s>处理非指令消息异常: %v 堆栈: %v", i.Name, r, string(debug.Stack()))
@@ -1161,15 +1168,20 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 					if i.OnNotCommandReceived != nil {
 						notCommandReceiveCall := func() {
 							if i.IsJsExt {
+								loop, err := d.ExtLoopManager.GetLoop(i.JSLoopVersion)
+								if err != nil {
+									// 打个DEBUG日志？
+									i.dice.Logger.Errorf("扩展<%s>运行环境已经过期: %v", i.Name, err)
+									return
+								}
 								waitRun := make(chan int, 1)
-								d.JsLoop.RunOnLoop(func(runtime *goja.Runtime) {
+								loop.RunOnLoop(func(runtime *goja.Runtime) {
 									defer func() {
 										if r := recover(); r != nil {
 											mctx.Dice.Logger.Errorf("扩展<%s>处理非指令消息异常: %v 堆栈: %v", i.Name, r, string(debug.Stack()))
 										}
 										waitRun <- 1
 									}()
-
 									i.OnNotCommandReceived(mctx, msg)
 								})
 								<-waitRun
@@ -1729,8 +1741,14 @@ func (s *IMSession) commandSolve(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs
 		var ret CmdExecuteResult
 		// 如果是js命令，那么加锁
 		if item.IsJsSolveFunc {
+			loop, err := s.Parent.ExtLoopManager.GetLoop(item.JSLoopVersion)
+			if err != nil {
+				// 打个DEBUG日志？
+				s.Parent.Logger.Errorf("扩展注册的指令<%s>运行环境已经过期: %v", item.Name, err)
+				return false
+			}
 			waitRun := make(chan int, 1)
-			s.Parent.JsLoop.RunOnLoop(func(vm *goja.Runtime) {
+			loop.RunOnLoop(func(vm *goja.Runtime) {
 				defer func() {
 					if r := recover(); r != nil {
 						// log.Errorf("异常: %v 堆栈: %v", r, string(debug.Stack()))


### PR DESCRIPTION
### 试图解决的关键问题 
1. 竞态条件问题
- 问题 ：多线程环境下，一个线程正在执行JS扩展，另一个线程触发重载，导致访问已释放的 EventLoop
- 解决 ：通过版本号检查，确保不会在已过期的 EventLoop 上执行代码 

2. 内存安全问题
- 问题 ： ExtInfo 持有已释放的 EventLoop 引用，可能导致悬空指针和内存访问错误
- 解决 ：使用版本号而非直接引用，避免内存泄漏和悬空指针 

3. "幽灵扩展"现象
- 问题 ：重载后旧扩展仍在运行，导致状态不一致和意外行为
- 解决 ：版本不匹配时直接跳过执行，防止旧版本扩展继续运行
