### PR TITLE
fix: nil ptr deref when setting default dice with no player

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -2159,7 +2159,10 @@ func (d *Dice) registerCoreCommands() {
 }
 
 func getDefaultDicePoints(ctx *MsgContext) int64 {
-	diceSides := int64(ctx.Player.DiceSideNum)
+	diceSides := int64(0)
+	if ctx.Player != nil {
+		diceSides = int64(ctx.Player.DiceSideNum)
+	}
 	if diceSides == 0 && ctx.Group != nil {
 		diceSides = ctx.Group.DiceSideNum
 	}


### PR DESCRIPTION
未经测试。

可能复现和测试途径：QQ 加好友的回复词