### PR TITLE
fix(logger): logs sent to WebUI have wrong timestamp

### DIFF
--- a/logger/ui_log_writer.go
+++ b/logger/ui_log_writer.go
@@ -8,7 +8,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var logLimitDefault int64 = 100
+const (
+	logLimitDefault   = 100
+	timeFormatISO8601 = "2006-01-02T15:04:05.000Z0700"
+)
 
 type LogItem struct {
 	Level  string  `json:"level"`
@@ -41,7 +44,7 @@ func (l *UIWriter) Write(p []byte) (int, error) {
 	}
 	err := json.Unmarshal(p, &a)
 	if err == nil {
-		ts, _ := time.Parse(time.RFC3339Nano, a.Time)
+		ts, _ := time.Parse(timeFormatISO8601, a.Time)
 		l.Items = append(l.Items, &LogItem{
 			Level:  a.Level.String(),
 			Module: a.Module,
@@ -52,6 +55,7 @@ func (l *UIWriter) Write(p []byte) (int, error) {
 		limit := l.LogLimit
 		if limit == 0 {
 			l.LogLimit = logLimitDefault
+			limit = logLimitDefault
 		}
 		if len(l.Items) > int(limit) {
 			l.Items = l.Items[1:]


### PR DESCRIPTION
See `logger/logger.go#L178-L190`:

```go
func newEncoder(console bool) zapcore.Encoder {
	encoderConfig := zap.NewProductionEncoderConfig()
	encoderConfig.TimeKey = "time"
	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
	encoderConfig.NameKey = "module"
	encoderConfig.EncodeName = zapcore.FullNameEncoder
	if console {
		return zapcore.NewConsoleEncoder(encoderConfig)
	}
	return zapcore.NewJSONEncoder(encoderConfig)
}
```

And zapcore impl of `ISO8601TimeEncoder`:

```go
func ISO8601TimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
	encodeTimeLayout(t, "2006-01-02T15:04:05.000Z0700", enc)
}
```

Close #1379