### PR TITLE
修复主界面网络检测Lagrange一律显示为无法连接的问题。

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -226,7 +226,7 @@ func checkNetworkHealth(c echo.Context) error {
 	}
 	go checkUrls("baidu", []string{"https://baidu.com"})
 	go checkUrls("seal", dice.BackendUrls)
-	go checkUrls("sign", []string{"https://sign.lagrangecore.org/api/sign/ping"})
+	go checkUrls("sign", []string{"https://sign.lagrangecore.org/api/sign/30366"})
 	go checkUrls("google", []string{"https://google.com"})
 	go checkUrls("github", []string{"https://github.com"})
 


### PR DESCRIPTION
Update utils.go
本质上是因为
gi checkUrls里sign那行访问的是/ping这个现在已经不存在了的接口
改成
https://sign.lagrangecore.org/api/sign/30366
就好了