### PR TITLE
fix(DnD): 当熟练系数是浮点数时检定结果显示异常

### DIFF
--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -606,7 +606,7 @@ func (ctx *MsgContext) setDndReadForVM(rcMode bool) {
 					detail.Text = fmt.Sprintf("%s调整值%d", name, mod)
 					v -= mod
 
-					exprProficiency := fmt.Sprintf("&%s.factor * 熟练", varname)
+					exprProficiency := fmt.Sprintf("floor(&%s.factor * 熟练)", varname)
 					skip = true
 					if ret2, _ := ctx.vm.RunExpr(exprProficiency, false); ret2 != nil {
 						// 注意: 这个值未必总能读到，如果ret2为nil，那么我们可以忽略这个加值的存在


### PR DESCRIPTION
Close #1369 

对问题的准确描述应该是：当熟练加值存在小数时（如 `*0.5` 或 `*1.5`），不论舍入后的计算结果是否是整数，都会显示异常。

非常好绕来绕去，要不是 go 能步进追三方库的调用绝逼查不出来

