### PR TITLE
修复主页Lagrange Sign永远为×，并实现签名测试逻辑

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -351,9 +351,8 @@ func anySignOK(urls []string, attempts, maxParallel int) bool {
 	var wg sync.WaitGroup
 
 	for _, u := range urls {
-		u := u
 		wg.Add(1)
-		go func() {
+		go func(u string) {
 			defer wg.Done()
 			sem <- struct{}{}
 			ok := checkStrictSignURL(u, attempts)
@@ -364,7 +363,7 @@ func anySignOK(urls []string, attempts, maxParallel int) bool {
 				default:
 				}
 			}
-		}()
+		}(u)
 	}
 
 	done := make(chan struct{})

--- a/api/utils.go
+++ b/api/utils.go
@@ -48,38 +48,6 @@ func doAuth(c echo.Context) bool {
 	return myDice.Parent.AccessTokens.Exists(token)
 }
 
-func extractURLsFromServersArray(blk map[string]any) []string {
-	var out []string
-	srv, ok := blk["servers"]
-	if !ok {
-		myDice.Logger.Debugf("sign block has no 'servers' field")
-		return out
-	}
-	lst, ok := srv.([]any)
-	if !ok {
-		myDice.Logger.Debugf("'servers' is not an array")
-		return out
-	}
-
-	for _, it := range lst {
-		m, ok := it.(map[string]any)
-		if !ok {
-			continue
-		}
-		if ig, ok := m["ignored"].(bool); ok && ig {
-			continue
-		}
-		u, _ := m["url"].(string)
-		if u == "" {
-			continue
-		}
-		u = strings.TrimSpace(u)
-		out = append(out, u)
-	}
-	out = normalizeAndUniqURLs(out)
-	return out
-}
-
 func GetHexData(c echo.Context, method string, name string) (value []byte, finished bool) {
 	var err error
 	var strValue string
@@ -207,6 +175,10 @@ const (
 	checkTimeout = 5 * time.Second
 )
 
+var strictSignHTTPClient = &http.Client{
+	Timeout: 15 * time.Second,
+}
+
 const SignTargetVersion = "30366"
 
 func checkHTTPConnectivity(url string) bool {
@@ -271,56 +243,71 @@ func getSignProbeURLs() []string {
 	return nil
 }
 
+type signServer struct {
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Ignored bool   `json:"ignored"`
+}
+
+type signBlock struct {
+	Version  string       `json:"version"`
+	Selected bool         `json:"selected"`
+	Servers  []signServer `json:"servers"`
+}
+
 func fetchSignProbeURLsFromConn() []string {
-	info, err := dice.LagrangeGetSignInfo(myDice)
-	if err != nil || info == nil {
+	raw, err := dice.LagrangeGetSignInfo(myDice)
+	if err != nil || raw == nil {
 		myDice.Logger.Debugf("LagrangeGetSignInfo failed: %v", err)
 		return nil
 	}
 
-	b, _ := json.Marshal(info)
-
-	var arr []map[string]any
-	if err := json.Unmarshal(b, &arr); err != nil {
-		var m map[string]any
-		if err2 := json.Unmarshal(b, &m); err2 != nil {
-			myDice.Logger.Debugf("sign info unmarshal failed: %v / %v", err, err2)
-			return nil
-		}
-		urls := extractURLsFromServersArray(m)
-		myDice.Logger.Debugf("sign info parsed (map top-level), count=%d", len(urls))
-		return urls
+	data, err := json.Marshal(raw)
+	if err != nil {
+		myDice.Logger.Debugf("sign info marshal failed: %v", err)
+		return nil
 	}
+	var blocks []signBlock
+	if err := json.Unmarshal(data, &blocks); err != nil || len(blocks) == 0 {
+		myDice.Logger.Debugf("sign info unmarshal error or empty: %v", err)
+		return nil
+	}
+	myDice.Logger.Debugf("sign info total blocks=%d", len(blocks))
 
-	myDice.Logger.Debugf("sign info total blocks=%d", len(arr))
-
-	var chosen map[string]any
-	for _, blk := range arr {
-		if v, ok := blk["version"].(string); ok && v == SignTargetVersion {
-			chosen = blk
+	var chosen *signBlock
+	for i := range blocks {
+		if blocks[i].Version == SignTargetVersion {
+			chosen = &blocks[i]
 			myDice.Logger.Debugf("sign info choose block by version=%s", SignTargetVersion)
 			break
 		}
 	}
 	if chosen == nil {
-		for _, blk := range arr {
-			if sel, ok := blk["selected"].(bool); ok && sel {
-				chosen = blk
+		for i := range blocks {
+			if blocks[i].Selected {
+				chosen = &blocks[i]
 				myDice.Logger.Debugf("sign info choose block by selected=true")
 				break
 			}
 		}
 	}
-	if chosen == nil && len(arr) > 0 {
-		chosen = arr[len(arr)-1]
+	if chosen == nil {
+		chosen = &blocks[len(blocks)-1]
 		myDice.Logger.Debugf("sign info choose last block as fallback")
 	}
-	if chosen == nil {
-		myDice.Logger.Debugf("sign info no block chosen")
-		return nil
-	}
 
-	urls := extractURLsFromServersArray(chosen)
+	var urls []string
+	for _, s := range chosen.Servers {
+		if s.Ignored {
+			continue
+		}
+		u := strings.TrimSpace(s.URL)
+		if u == "" {
+			continue
+		}
+		urls = append(urls, u)
+	}
+	urls = normalizeAndUniqURLs(urls)
 	myDice.Logger.Debugf("sign servers extracted, count=%d", len(urls))
 	return urls
 }
@@ -355,16 +342,49 @@ func normalizeAndUniqURLs(in []string) []string {
 	return out
 }
 
+func anySignOK(urls []string, attempts, maxParallel int) bool {
+	if maxParallel <= 0 {
+		maxParallel = 4
+	}
+	sem := make(chan struct{}, maxParallel)
+	found := make(chan struct{}, 1)
+	var wg sync.WaitGroup
+
+	for _, u := range urls {
+		u := u
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			ok := checkStrictSignURL(u, attempts)
+			<-sem
+			if ok {
+				select {
+				case found <- struct{}{}:
+				default:
+				}
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+
+	select {
+	case <-found:
+		return true
+	case <-done:
+		return false
+	}
+}
+
 func checkStrictSignURL(url string, attempts int) bool {
 	if attempts <= 0 {
 		attempts = 1
 	}
-	client := http.Client{
-		Timeout: 15 * time.Second,
-	}
 
 	for i := range attempts {
-		resp, err := client.Get(url)
+		resp, err := strictSignHTTPClient.Get(url)
 		myDice.Logger.Debugf("sign probe: %s (try %d/%d)", url, i+1, attempts)
 		if err != nil {
 			myDice.Logger.Debugf("sign probe error: %v", err)
@@ -378,12 +398,10 @@ func checkStrictSignURL(url string, attempts int) bool {
 			myDice.Logger.Debugf("sign probe bad status: %d", resp.StatusCode)
 			return false
 		}
-
 		if n == 0 {
 			myDice.Logger.Debugf("sign probe empty body")
 			return false
 		}
-
 		if strings.HasPrefix(url, "https://") {
 			if resp.TLS == nil || len(resp.TLS.VerifiedChains) == 0 {
 				myDice.Logger.Debugf("sign probe tls not verified")
@@ -416,18 +434,12 @@ func checkNetworkHealth(c echo.Context) error {
 		defer wg.Done()
 		urls := getSignProbeURLs()
 		if len(urls) == 0 {
-			// 没有下发任何签名地址，直接视为失败（不写 rsChan）
 			myDice.Logger.Debugf("no sign endpoints were delivered")
 			return
 		}
-		// 逐个地址探测：只要某个地址“连续 checkTimes 次严格成功”，就算 sign 可用
-		for _, u := range urls {
-			if checkStrictSignURL(u, checkTimes) {
-				rsChan <- "sign"
-				return
-			}
+		if anySignOK(urls, checkTimes, 4) {
+			rsChan <- "sign"
 		}
-		// 全部地址都没达到“连续 checkTimes 次成功”，不写入 rsChan（前端就看不到 sign）
 	}()
 	go checkUrls("google", []string{"https://google.com"})
 	go checkUrls("github", []string{"https://github.com"})

--- a/api/utils.go
+++ b/api/utils.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +46,38 @@ func doAuth(c echo.Context) bool {
 		token = c.QueryParam("token")
 	}
 	return myDice.Parent.AccessTokens.Exists(token)
+}
+
+func extractURLsFromServersArray(blk map[string]any) []string {
+	var out []string
+	srv, ok := blk["servers"]
+	if !ok {
+		myDice.Logger.Debugf("sign block has no 'servers' field")
+		return out
+	}
+	lst, ok := srv.([]any)
+	if !ok {
+		myDice.Logger.Debugf("'servers' is not an array")
+		return out
+	}
+
+	for _, it := range lst {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ig, ok := m["ignored"].(bool); ok && ig {
+			continue
+		}
+		u, _ := m["url"].(string)
+		if u == "" {
+			continue
+		}
+		u = strings.TrimSpace(u)
+		out = append(out, u)
+	}
+	out = normalizeAndUniqURLs(out)
+	return out
 }
 
 func GetHexData(c echo.Context, method string, name string) (value []byte, finished bool) {
@@ -88,7 +123,6 @@ func getGithubAvatar(c echo.Context) error {
 
 	resp := req.Send()
 	if resp.OK() {
-		// 设置缓存时间为3天
 		c.Response().Header().Set("Cache-Control", "max-age=259200")
 
 		return c.Blob(http.StatusOK, resp.ContentType(), resp.Bytes())
@@ -173,6 +207,8 @@ const (
 	checkTimeout = 5 * time.Second
 )
 
+const SignTargetVersion = "30366"
+
 func checkHTTPConnectivity(url string) bool {
 	client := http.Client{
 		Timeout: checkTimeout,
@@ -208,12 +244,162 @@ func checkHTTPConnectivity(url string) bool {
 	return ok
 }
 
+var (
+	signURLsCache      []string
+	signURLsCacheAt    time.Time
+	signURLsCacheMutex sync.Mutex
+	signURLsTTL        = 10 * time.Minute
+)
+
+func getSignProbeURLs() []string {
+	signURLsCacheMutex.Lock()
+	defer signURLsCacheMutex.Unlock()
+
+	if time.Since(signURLsCacheAt) < signURLsTTL && len(signURLsCache) > 0 {
+		myDice.Logger.Debugf("sign urls from cache, count=%d", len(signURLsCache))
+		return append([]string(nil), signURLsCache...)
+	}
+	urls := fetchSignProbeURLsFromConn()
+	urls = normalizeAndUniqURLs(urls)
+	myDice.Logger.Debugf("sign urls fetched fresh, count=%d", len(urls))
+
+	if len(urls) > 0 {
+		signURLsCache = urls
+		signURLsCacheAt = time.Now()
+		return append([]string(nil), urls...)
+	}
+	return nil
+}
+
+func fetchSignProbeURLsFromConn() []string {
+	info, err := dice.LagrangeGetSignInfo(myDice)
+	if err != nil || info == nil {
+		myDice.Logger.Debugf("LagrangeGetSignInfo failed: %v", err)
+		return nil
+	}
+
+	b, _ := json.Marshal(info)
+
+	var arr []map[string]any
+	if err := json.Unmarshal(b, &arr); err != nil {
+		var m map[string]any
+		if err2 := json.Unmarshal(b, &m); err2 != nil {
+			myDice.Logger.Debugf("sign info unmarshal failed: %v / %v", err, err2)
+			return nil
+		}
+		urls := extractURLsFromServersArray(m)
+		myDice.Logger.Debugf("sign info parsed (map top-level), count=%d", len(urls))
+		return urls
+	}
+
+	myDice.Logger.Debugf("sign info total blocks=%d", len(arr))
+
+	var chosen map[string]any
+	for _, blk := range arr {
+		if v, ok := blk["version"].(string); ok && v == SignTargetVersion {
+			chosen = blk
+			myDice.Logger.Debugf("sign info choose block by version=%s", SignTargetVersion)
+			break
+		}
+	}
+	if chosen == nil {
+		for _, blk := range arr {
+			if sel, ok := blk["selected"].(bool); ok && sel {
+				chosen = blk
+				myDice.Logger.Debugf("sign info choose block by selected=true")
+				break
+			}
+		}
+	}
+	if chosen == nil && len(arr) > 0 {
+		chosen = arr[len(arr)-1]
+		myDice.Logger.Debugf("sign info choose last block as fallback")
+	}
+	if chosen == nil {
+		myDice.Logger.Debugf("sign info no block chosen")
+		return nil
+	}
+
+	urls := extractURLsFromServersArray(chosen)
+	myDice.Logger.Debugf("sign servers extracted, count=%d", len(urls))
+	return urls
+}
+
+func ensureScheme(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return s
+	}
+	return "https://" + s
+}
+
+func normalizeAndUniqURLs(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	var out []string
+	for _, u := range in {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			continue
+		}
+		u = ensureScheme(u)
+		for strings.Contains(u, "///") {
+			u = strings.ReplaceAll(u, "///", "/")
+		}
+		if _, ok := seen[u]; !ok {
+			seen[u] = struct{}{}
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+func checkStrictSignURL(url string, attempts int) bool {
+	if attempts <= 0 {
+		attempts = 1
+	}
+	client := http.Client{
+		Timeout: 15 * time.Second,
+	}
+
+	for i := range attempts {
+		resp, err := client.Get(url)
+		myDice.Logger.Debugf("sign probe: %s (try %d/%d)", url, i+1, attempts)
+		if err != nil {
+			myDice.Logger.Debugf("sign probe error: %v", err)
+			return false
+		}
+
+		n, _ := io.CopyN(io.Discard, resp.Body, 1)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			myDice.Logger.Debugf("sign probe bad status: %d", resp.StatusCode)
+			return false
+		}
+
+		if n == 0 {
+			myDice.Logger.Debugf("sign probe empty body")
+			return false
+		}
+
+		if strings.HasPrefix(url, "https://") {
+			if resp.TLS == nil || len(resp.TLS.VerifiedChains) == 0 {
+				myDice.Logger.Debugf("sign probe tls not verified")
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func checkNetworkHealth(c echo.Context) error {
 	total := 5 // baidu, seal, sign, google, github
 	var ok []string
 	var wg sync.WaitGroup
 	wg.Add(total)
-	rsChan := make(chan string, 5)
+	rsChan := make(chan string, total)
 
 	checkUrls := func(target string, urls []string) {
 		defer wg.Done()
@@ -226,7 +412,23 @@ func checkNetworkHealth(c echo.Context) error {
 	}
 	go checkUrls("baidu", []string{"https://baidu.com"})
 	go checkUrls("seal", dice.BackendUrls)
-	go checkUrls("sign", []string{"https://sign.lagrangecore.org/api/sign/ping"})
+	go func() {
+		defer wg.Done()
+		urls := getSignProbeURLs()
+		if len(urls) == 0 {
+			// 没有下发任何签名地址，直接视为失败（不写 rsChan）
+			myDice.Logger.Debugf("no sign endpoints were delivered")
+			return
+		}
+		// 逐个地址探测：只要某个地址“连续 checkTimes 次严格成功”，就算 sign 可用
+		for _, u := range urls {
+			if checkStrictSignURL(u, checkTimes) {
+				rsChan <- "sign"
+				return
+			}
+		}
+		// 全部地址都没达到“连续 checkTimes 次成功”，不写入 rsChan（前端就看不到 sign）
+	}()
 	go checkUrls("google", []string{"https://google.com"})
 	go checkUrls("github", []string{"https://github.com"})
 


### PR DESCRIPTION
这里的逻辑是调得conn.go，拉取签名列表json，然后测试每一个30366的地址
会测试能否访问通（HTTP 200），以及证书
如果有任意一个签名可访问且几次测试中没有任何一次失败，那就会显示Lagrange Sign为√
这次狗应该不会叫了？