### PR TITLE
fix: 修复退群消息不发送问题

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1495,6 +1495,8 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 			// 发送退群消息
 			msgText := DiceFormatTmpl(msgCtx, "核心:骰子自动退群告别语")
 			ep.Adapter.SendToGroup(msgCtx, grp.GroupID, msgText, "")
+			//退群在退群消息延迟两秒后发送，确保消息发送完成
+			time.Sleep(2 * time.Second)
 			// 删除群聊绑定信息，更新群处理时间
 			grp.DiceIDExistsMap.Delete(ep.UserID)
 			grp.UpdatedAtTime = time.Now().Unix()


### PR DESCRIPTION
进行了时序优化，退群操作等待2秒确保消息发送完成。投入测试确实修复了不发送退群消息问题，但测试样例较少，不能完全保证问题修复