### PR TITLE
fix: dnd5e规则下st show值的异常，以及.buff hp+5时是读取hp值+5然后设定为buff值的问题。另外r指令扩展了输出类型，可输出非int

### DIFF
--- a/dice/ext_st_helper.go
+++ b/dice/ext_st_helper.go
@@ -281,7 +281,11 @@ func cmdStGetItemsForExport(mctx *MsgContext, tmpl *GameSystemTemplate, stInfo *
 }
 
 func cmdStValueMod(mctx *MsgContext, tmpl *GameSystemTemplate, attrs *AttributesItem, commandInfo map[string]any, i *stSetOrModInfoItem, cmdArgs *CmdArgs, stInfo *CmdStOverrideInfo) {
-	// 获取当前值
+	if stInfo.ToMod != nil {
+		stInfo.ToMod(mctx, cmdArgs, i, attrs, tmpl)
+	}
+
+	// 获取当前值（在 ToMod 可能重定向名称后再读取）
 	curVal, _ := attrs.valueMap.Load(i.name)
 	if curVal == nil {
 		curVal, _, _, _ = tmpl.GetDefaultValue(i.name)
@@ -298,10 +302,6 @@ func cmdStValueMod(mctx *MsgContext, tmpl *GameSystemTemplate, attrs *Attributes
 			curVal = v
 			isSetNew = false
 		}
-	}
-
-	if stInfo.ToMod != nil {
-		stInfo.ToMod(mctx, cmdArgs, i, attrs, tmpl)
 	}
 
 	// 进行变更

--- a/dice/game_system_template.go
+++ b/dice/game_system_template.go
@@ -184,9 +184,7 @@ func (t *GameSystemTemplateV2) GetShowValueAs(ctx *MsgContext, k string) (*ds.VM
 	_, exists := t.GetAttrValue(ctx, k)
 
 	getVal := func(expr string) (*VMResultV2, error) {
-		v := ctx.EvalFString(expr, &ds.RollConfig{
-			DefaultDiceSideExpr: strconv.FormatInt(getDefaultDicePoints(ctx), 10),
-		})
+		v := ctx.EvalFString(expr, nil)
 		return v, nil
 	}
 
@@ -209,9 +207,7 @@ func (t *GameSystemTemplateV2) GetShowValueAs(ctx *MsgContext, k string) (*ds.VM
 	}
 
 	if expr, exists := t.Commands.St.Show.ShowValueAs[k]; exists && expr != "" {
-		res := ctx.EvalFString(expr, &ds.RollConfig{
-			DefaultDiceSideExpr: strconv.FormatInt(getDefaultDicePoints(ctx), 10),
-		})
+		res := ctx.EvalFString(expr, nil)
 		if res != nil && res.vm.Error == nil {
 			return &res.VMValue, nil
 		}


### PR DESCRIPTION
.buff hp+10
<木落>的属性变化:
$buff_hp: 2.3 ➯ 12.3 (增加10=10)
[√] 已绑卡

.st hp:5
.st show hp
<木落>的个人属性为:
hp:17.3/20[5]
