### PR TITLE
fix: 修复 coc7 扩展会在开启时修改角色卡模板的问题

### DIFF
--- a/dice/ext_coc7.go
+++ b/dice/ext_coc7.go
@@ -1370,11 +1370,6 @@ func RegisterBuiltinExtCoc7(self *Dice) {
 
 		},
 		OnCommandReceived: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) {
-			if ctx != nil && ctx.Dice != nil {
-				if tmpl, ok := ctx.Dice.GameSystemMap.Load("coc7"); ok && tmpl != nil {
-					ctx.SystemTemplate = tmpl
-				}
-			}
 		},
 		GetDescText: GetExtensionDesc,
 		CmdMap: CmdMapCls{


### PR DESCRIPTION
fix #1526 
具体原因为 coc7 拓展内存在一个 OnCommandReceived 回调，其将会在指令执行完成后把 ctx 的角色卡模板修改为 coc7（而无论该角色卡是否真的为这个模板）。#1526 中提到的同步运行不会复现是因为指令执行在 OnCommandReceived 执行之前。由于此OnCommandReceived 作用意义不明（因为早在此之前就已经加载过一次角色卡模板），并且 dnd5e 中也无类似设计，经测试后此处可以删除。