### PR TITLE
fix: 修改日志export指令的临时文件位置及上传方式

### DIFF
--- a/dice/ext_log_upload_cache_test.go
+++ b/dice/ext_log_upload_cache_test.go
@@ -1,0 +1,135 @@
+//nolint:testpackage
+package dice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sealdiceLogger "sealdice-core/logger"
+	"sealdice-core/model"
+	"sealdice-core/utils/constant"
+)
+
+func TestLogSendToBackendReuploadsMissingCachedURL(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1004"
+	logName := "expired-upload"
+	appendTestLog(t, mockDB, groupID, logName)
+
+	oldURL := "https://logs.example/?key=Old1#123456"
+	db := mockDB.GetLogDB(constant.WRITE)
+	if err := db.Model(&model.LogInfo{}).
+		Where("group_id = ? AND name = ?", groupID, logName).
+		UpdateColumns(map[string]interface{}{
+			"upload_url":  oldURL,
+			"upload_time": time.Now().Add(time.Minute).Unix(),
+		}).Error; err != nil {
+		t.Fatalf("seed cached upload: %v", err)
+	}
+
+	var probeCount atomic.Int32
+	var uploadCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/dice/api/load_data":
+			probeCount.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPut && r.URL.Path == "/dice/api/log":
+			uploadCount.Add(1)
+			_, _ = w.Write([]byte(`{"url":"https://logs.example/?key=New1#654321"}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	oldBackends := BackendUrls
+	BackendUrls = []string{server.URL}
+	t.Cleanup(func() { BackendUrls = oldBackends })
+
+	ctx := &MsgContext{
+		Dice: &Dice{
+			BaseConfig: BaseConfig{DataDir: t.TempDir()},
+			DBOperator: mockDB,
+			Logger:     sealdiceLogger.M(),
+		},
+		EndPoint: &EndPointInfo{EndPointInfoBase: EndPointInfoBase{UserID: "UI:1000"}},
+	}
+
+	_, gotURL, _, err := LogSendToBackend(ctx, groupID, logName)
+	if err != nil {
+		t.Fatalf("LogSendToBackend: %v", err)
+	}
+	if gotURL != "https://logs.example/?key=New1#654321" {
+		t.Fatalf("url = %q, want newly uploaded URL", gotURL)
+	}
+	if got := probeCount.Load(); got != 1 {
+		t.Fatalf("probe requests = %d, want 1", got)
+	}
+	if got := uploadCount.Load(); got != 1 {
+		t.Fatalf("upload requests = %d, want 1", got)
+	}
+}
+
+func TestLogSendToBackendFallsBackToCachedURLWhenProbeAndUploadFail(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1005"
+	logName := "uncertain-upload"
+	appendTestLog(t, mockDB, groupID, logName)
+
+	oldURL := "https://logs.example/?key=Old2#123456"
+	db := mockDB.GetLogDB(constant.WRITE)
+	if err := db.Model(&model.LogInfo{}).
+		Where("group_id = ? AND name = ?", groupID, logName).
+		UpdateColumns(map[string]interface{}{
+			"upload_url":  oldURL,
+			"upload_time": time.Now().Add(time.Minute).Unix(),
+		}).Error; err != nil {
+		t.Fatalf("seed cached upload: %v", err)
+	}
+
+	var uploadCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/custom/path/load_data":
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+		case r.Method == http.MethodPut && r.URL.Path == "/custom/path/log":
+			uploadCount.Add(1)
+			http.Error(w, "upload failed", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	ctx := &MsgContext{
+		Dice: &Dice{
+			BaseConfig: BaseConfig{DataDir: t.TempDir()},
+			DBOperator: mockDB,
+			Logger:     sealdiceLogger.M(),
+			AdvancedConfig: AdvancedConfig{
+				Enable:             true,
+				StoryLogBackendUrl: server.URL + "/custom/path/log",
+			},
+		},
+		EndPoint: &EndPointInfo{EndPointInfoBase: EndPointInfoBase{UserID: "UI:1000"}},
+	}
+
+	_, gotURL, notice, err := LogSendToBackend(ctx, groupID, logName)
+	if err != nil {
+		t.Fatalf("LogSendToBackend: %v", err)
+	}
+	if gotURL != oldURL {
+		t.Fatalf("url = %q, want cached URL %q", gotURL, oldURL)
+	}
+	if !strings.Contains(notice, "重新上传日志失败") || !strings.Contains(notice, "可能仍然有效") {
+		t.Fatalf("notice = %q, want upload failure and uncertain cached URL warning", notice)
+	}
+	if got := uploadCount.Load(); got != 1 {
+		t.Fatalf("upload requests = %d, want 1", got)
+	}
+}

--- a/dice/storylog/cache_validation_test.go
+++ b/dice/storylog/cache_validation_test.go
@@ -1,0 +1,73 @@
+package storylog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestProbeCachedLogURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       cachedLogProbeResult
+	}{
+		{name: "alive", statusCode: http.StatusOK, want: cachedLogProbeAlive},
+		{name: "missing", statusCode: http.StatusNotFound, want: cachedLogProbeMissing},
+		{name: "gone", statusCode: http.StatusGone, want: cachedLogProbeMissing},
+		{name: "server error", statusCode: http.StatusInternalServerError, want: cachedLogProbeUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/custom/backend/load_data" {
+					t.Fatalf("path = %q, want /custom/backend/load_data", r.URL.Path)
+				}
+				if got := r.URL.Query().Get("key"); got != "AbCd" {
+					t.Fatalf("key = %q, want AbCd", got)
+				}
+				if got := r.URL.Query().Get("password"); got != "123456" {
+					t.Fatalf("password = %q, want 123456", got)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer token" {
+					t.Fatalf("Authorization = %q, want Bearer token", got)
+				}
+				w.WriteHeader(test.statusCode)
+			}))
+			defer server.Close()
+
+			env := UploadEnv{
+				Backends: []string{server.URL + "/custom/backend/log"},
+				Token:    "token",
+				Log:      zap.NewNop().Sugar(),
+			}
+			if got := probeCachedLogURL(env, "https://logs.example/?key=AbCd#123456"); got != test.want {
+				t.Fatalf("probeCachedLogURL() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestProbeCachedLogURLNetworkFailureIsUnknown(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	backend := server.URL + "/dice/api/log"
+	server.Close()
+
+	env := UploadEnv{
+		Backends: []string{backend},
+		Log:      zap.NewNop().Sugar(),
+	}
+	if got := probeCachedLogURL(env, "https://logs.example/?key=AbCd#123456"); got != cachedLogProbeUnknown {
+		t.Fatalf("probeCachedLogURL() = %v, want %v", got, cachedLogProbeUnknown)
+	}
+}
+
+func TestProbeCachedLogURLRejectsUnusableCachedURL(t *testing.T) {
+	env := UploadEnv{Log: zap.NewNop().Sugar()}
+	if got := probeCachedLogURL(env, "https://logs.example/"); got != cachedLogProbeMissing {
+		t.Fatalf("probeCachedLogURL() = %v, want %v", got, cachedLogProbeMissing)
+	}
+}

--- a/dice/storylog/storylog.go
+++ b/dice/storylog/storylog.go
@@ -2,18 +2,31 @@ package storylog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
 	"sealdice-core/model"
 	"sealdice-core/utils/dboperator/engine"
+)
+
+const cachedLogProbeTimeout = 3 * time.Second
+
+type cachedLogProbeResult uint8
+
+const (
+	cachedLogProbeUnknown cachedLogProbeResult = iota
+	cachedLogProbeAlive
+	cachedLogProbeMissing
 )
 
 type UploadEnv struct {
@@ -55,6 +68,86 @@ func Upload(env UploadEnv) (string, string, error) {
 		return uploadV105(env)
 	}
 	return "", "", errors.New("未指定日志版本")
+}
+
+func checkCachedLogURL(env UploadEnv, rawURL string) cachedLogProbeResult {
+	result := probeCachedLogURL(env, rawURL)
+	switch result {
+	case cachedLogProbeMissing:
+		env.Log.Infof("之前上传的日志链接已失效，将重新上传 Log:%s.%s URL:%s", env.GroupID, env.LogName, rawURL)
+	case cachedLogProbeUnknown:
+		env.Log.Warnf("无法确认之前上传的日志链接是否有效，将尝试重新上传 Log:%s.%s URL:%s", env.GroupID, env.LogName, rawURL)
+	}
+	return result
+}
+
+func fallbackToCachedLogURL(env *UploadEnv, rawURL string, probeResult cachedLogProbeResult) (string, string, bool) {
+	if rawURL == "" || probeResult != cachedLogProbeUnknown {
+		return "", env.Notice, false
+	}
+	const notice = "重新上传日志失败，现返回之前缓存的链接；该链接可能仍然有效。"
+	env.appendNotice(notice)
+	env.Log.Warnf("%s Log:%s.%s URL:%s", notice, env.GroupID, env.LogName, rawURL)
+	return rawURL, env.Notice, true
+}
+
+func probeCachedLogURL(env UploadEnv, rawURL string) cachedLogProbeResult {
+	logURL, err := url.Parse(rawURL)
+	if err != nil {
+		return cachedLogProbeMissing
+	}
+	key, password := logURL.Query().Get("key"), logURL.Fragment
+	if key == "" || password == "" {
+		return cachedLogProbeMissing
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cachedLogProbeTimeout)
+	defer cancel()
+
+	missing := false
+	for _, backend := range env.Backends {
+		backendURL, parseErr := url.Parse(backend)
+		if parseErr != nil {
+			continue
+		}
+		path := strings.TrimRight(backendURL.Path, "/")
+		if !strings.HasSuffix(path, "/log") {
+			continue
+		}
+		backendURL.Path = strings.TrimSuffix(path, "/log") + "/load_data"
+		backendURL.RawPath = ""
+		query := backendURL.Query()
+		query.Set("key", key)
+		query.Set("password", password)
+		backendURL.RawQuery = query.Encode()
+		backendURL.Fragment = ""
+
+		req, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, backendURL.String(), nil)
+		if requestErr != nil {
+			continue
+		}
+		req.Header.Set("Range", "bytes=0-0")
+		if env.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+env.Token)
+		}
+
+		resp, requestErr := http.DefaultClient.Do(req) //nolint:gosec
+		if requestErr != nil {
+			continue
+		}
+		_ = resp.Body.Close()
+
+		switch {
+		case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+			return cachedLogProbeAlive
+		case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+			missing = true
+		}
+	}
+	if missing {
+		return cachedLogProbeMissing
+	}
+	return cachedLogProbeUnknown
 }
 
 func uploadToBackend(env UploadEnv, backend string, data io.Reader) string {

--- a/dice/storylog/upload_v1.go
+++ b/dice/storylog/upload_v1.go
@@ -20,7 +20,12 @@ func uploadV1(env UploadEnv) (string, string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
+	cachedURL := url
+	probeResult := cachedLogProbeMissing
 	if len(url) > 0 && uploadTS > updateTS {
+		probeResult = checkCachedLogURL(env, url)
+	}
+	if probeResult == cachedLogProbeAlive {
 		// 已有URL且上传时间晚于Log更新时间（最后录入时间），直接返回
 		env.Log.Infof(
 			"查询到之前上传的URL, 直接使用 Log:%s.%s 上传时间:%s 更新时间:%s URL:%s",
@@ -33,7 +38,7 @@ func uploadV1(env UploadEnv) (string, string, error) {
 	}
 	if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
-	} else {
+	} else if uploadTS <= updateTS {
 		env.Log.Infof(
 			"Log上传后又有更新, 重新上传 Log:%s.%s 上传时间:%s 更新时间:%s",
 			env.GroupID, env.LogName,
@@ -71,6 +76,9 @@ func uploadV1(env UploadEnv) (string, string, error) {
 		env.Log.Errorf("记录Log上传信息失败: %v", errDB)
 	}
 	if len(url) == 0 {
+		if fallbackURL, notice, ok := fallbackToCachedLogURL(&env, cachedURL, probeResult); ok {
+			return fallbackURL, notice, nil
+		}
 		return "", env.Notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
 	return url, env.Notice, nil

--- a/dice/storylog/upload_v105.go
+++ b/dice/storylog/upload_v105.go
@@ -137,7 +137,12 @@ func uploadV105(env UploadEnv) (string, string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
+	cachedURL := url
+	probeResult := cachedLogProbeMissing
 	if len(url) > 0 && uploadTS > updateTS {
+		probeResult = checkCachedLogURL(env, url)
+	}
+	if probeResult == cachedLogProbeAlive {
 		// 已有URL且上传时间晚于Log更新时间（最后录入时间），直接返回
 		env.Log.Infof(
 			"查询到之前上传的URL, 直接使用 Log:%s.%s 上传时间:%s 更新时间:%s URL:%s",
@@ -150,7 +155,7 @@ func uploadV105(env UploadEnv) (string, string, error) {
 	}
 	if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
-	} else {
+	} else if uploadTS <= updateTS {
 		env.Log.Infof(
 			"Log上传后又有更新, 重新上传 Log:%s.%s 上传时间:%s 更新时间:%s",
 			env.GroupID, env.LogName,
@@ -177,6 +182,9 @@ func uploadV105(env UploadEnv) (string, string, error) {
 		env.Log.Errorf("记录Log上传信息失败: %v", errDB)
 	}
 	if len(url) == 0 {
+		if fallbackURL, notice, ok := fallbackToCachedLogURL(&env, cachedURL, probeResult); ok {
+			return fallbackURL, notice, nil
+		}
 		return "", env.Notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
 	return url, env.Notice, nil


### PR DESCRIPTION
由于原代码输出txt文件至tmp目录，导致容器运行时，无法正常上传文件到群文件。

考虑到对容器映射/tmp目录是不合理也不优雅的，尝试移动生成的临时文件到海豹数据目录位置。

修复censor_log表不存在导致的数据库报错

## Sourcery 摘要

在重复使用缓存的日志链接之前验证其有效性；如果之前上传的文件已不可用，则重新上传日志。

错误修复：
- 检测已过期的缓存日志 URL，并重新上传日志，而不是返回不可用的链接。
- 当无法验证缓存日志链接的可用性时，继续使用这些缓存链接，避免不必要的重新上传。

增强功能：
- 对两种受支持的日志上传格式一致地应用缓存 URL 验证。

测试：
- 增加对缓存日志 URL 验证的覆盖，涵盖链接正常、缺失、不可用和格式错误等场景。
- 增加集成测试，验证过期的缓存链接会触发重新上传。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过使用适当的临时文件位置，并安全地处理过期或状态不确定的缓存上传链接，提高容器化部署中的日志导出可靠性。

错误修复：
- 将生成的日志临时文件移至 Sealdice 数据目录，使容器部署无需挂载主机的 `/tmp` 目录即可上传日志。
- 处理缺少 `censor_log` 数据库表的情况，避免产生数据库错误。
- 在复用缓存的日志 URL 前进行验证；当缓存文件不可用时，重新上传日志。
- 当可用性检查或重新上传尝试失败时，回退使用缓存的 URL，同时警告这些链接可能仍然有效。

改进：
- 对两种受支持的日志上传格式统一应用缓存 URL 验证。

测试：
- 增加缓存 URL 验证的测试覆盖，包括有效、缺失、不可用、格式错误和网络故障等情况。
- 增加集成测试，确认过期的缓存 URL 会触发重新上传，并在恢复失败时保留状态不确定的 URL。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过将文件暂存到 Sealdice 数据目录中，提高容器化部署中的日志导出上传可靠性。

Bug 修复：
- 将导出的日志文件和 OneBot 上传副本存储到 Sealdice 数据目录中，使容器化部署无需依赖宿主机的 /tmp 挂载即可上传这些文件。

增强功能：
- 允许文件提取使用调用方提供的临时目录，同时默认保持现有的系统临时目录行为。
- 确保源导出文件清理后，暂存的上传文件仍然可用，并且外部 OneBot 客户端可以读取这些文件。

测试：
- 增加测试覆盖，验证导出的日志和暂存的 OneBot 上传文件使用数据临时目录，并保留文件内容、权限以及上传副本的生命周期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make log export uploads reliable in containerized deployments by staging files in the Sealdice data directory.

Bug Fixes:
- Store exported log files and OneBot upload copies in the Sealdice data directory so containerized deployments can upload them without relying on the host /tmp mount.

Enhancements:
- Allow file extraction to use a caller-provided temporary directory while preserving existing system-temporary-directory behavior by default.
- Ensure staged upload files remain available after the source export is cleaned up and are readable by external OneBot clients.

Tests:
- Add coverage verifying exported logs and staged OneBot uploads use the data temporary directory, preserve file contents, permissions, and upload-copy lifetime.

</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>