### PR TITLE
fix: 修复js重载引起插件列表清空的问题，此时ExtRemove应该跳过快照

### DIFF
--- a/dice/ext.go
+++ b/dice/ext.go
@@ -567,7 +567,10 @@ func (group *GroupInfo) extDeactivateInternal(ei *ExtInfo, reason DeactivateReas
 			}
 		}
 	}
-	group.ensureSnapshotFromActivated()
+	// 系统级停用（用于重载等场景）不应更新快照，避免覆盖已保存的快照
+	if reason != DeactivateReasonSystem {
+		group.ensureSnapshotFromActivated()
+	}
 	group.UpdatedAtTime = time.Now().Unix()
 	return removed
 }


### PR DESCRIPTION
自测通过