### PR TITLE
fix: 修复 '.st 母语+1d10' 报错问题

### DIFF
--- a/dice/ext_st_helper.go
+++ b/dice/ext_st_helper.go
@@ -297,11 +297,25 @@ func cmdStValueMod(mctx *MsgContext, tmpl *GameSystemTemplate, attrs *Attributes
 	isSetNew := true
 	if curVal.TypeId == ds.VMTypeComputedValue {
 		cd, _ := curVal.ReadComputed()
-		// dnd5e专属
-		if v, ok := cd.Attrs.Load("base"); ok {
-			curVal = v
-			isSetNew = false
+		// dnd5e专属：如果有base属性，使用base值且不覆盖
+		if cd != nil && cd.Attrs != nil {
+			if v, ok := cd.Attrs.Load("base"); ok {
+				curVal = v
+				isSetNew = false
+			}
 		}
+		// 对于普通的computed value（如 &(教育)），计算出实际值
+		// 这样在进行+/-运算时才能得到正确的结果
+		if isSetNew && curVal.TypeId == ds.VMTypeComputedValue {
+			mctx.CreateVmIfNotExists()
+			curVal = curVal.ComputedExecute(mctx.vm, nil)
+			if mctx.vm.Error != nil {
+				// 如果计算出错，使用0
+				curVal = ds.NewIntVal(0)
+				mctx.vm.Error = nil
+			}
+		}
+		// isSetNew保持为true，这样修改后的值会被存储
 	}
 
 	// 进行变更
@@ -498,6 +512,10 @@ func getCmdStBase(soi CmdStOverrideInfo) *CmdItemInfo {
 			cardType := ReadCardType(mctx)
 
 			tmpl := ctx.Group.GetCharTemplate(dice)
+			// 立即设置SystemTemplate，确保VM创建时能使用正确的模板
+			ctx.SystemTemplate = tmpl
+			mctx.SystemTemplate = tmpl
+
 			tmplShow := tmpl // 用于st show的模板，如果show不同规则的模板，可以以其他规则格式显示
 			if cardType != tmplShow.Name {
 				if tmpl2, _ := dice.GameSystemMap.Load(cardType); tmpl2 != nil {
@@ -509,6 +527,9 @@ func getCmdStBase(soi CmdStOverrideInfo) *CmdItemInfo {
 				if tmpl2, _ := dice.GameSystemMap.Load(soi.TemplateName); tmpl2 != nil {
 					tmpl = tmpl2
 					tmplShow = tmpl2
+					// 更新SystemTemplate为新的模板
+					ctx.SystemTemplate = tmpl
+					mctx.SystemTemplate = tmpl
 				}
 			}
 
@@ -633,7 +654,7 @@ func getCmdStBase(soi CmdStOverrideInfo) *CmdItemInfo {
 				}
 
 				cmdStCharFormat(mctx, tmpl) // 转一下卡
-				mctx.SystemTemplate = tmpl
+				// SystemTemplate已经在函数开始时设置，这里不需要重复设置
 
 				// 进行简化卡的尝试解析
 				input := cmdArgs.CleanArgs


### PR DESCRIPTION
修改内容

#### 1. 修复 cmdStValueMod 函数中 computed value 的处理逻辑 (第 297-319 行)

问题：当使用类似 .st 母语+1d10 的指令时，如果属性是 computed value（如 COC7 中的母语引用教育 &(教育)），原代码只处理了 DND5e 特有的带 base 属性的情况，对于普通的 computed value 不会执行计算，导致在进行 +/- 运算时出错。

修复：
- 增加了对 computed value 的 nil 检查
- 如果 computed value 没有 base 属性，则执行 ComputedExecute 获取实际值
- 处理计算过程中可能的错误

#### 2. 确保 st 命令开始时设置 SystemTemplate (第 514-533 行)

问题：SystemTemplate 设置得太晚，导致在执行 mctx.Eval(tmpl.InitScript, nil) 和后续操作时，VM 可能没有正确的模板上下文。

修复：
- 在获取 tmpl 后立即设置 ctx.SystemTemplate 和 mctx.SystemTemplate
- 如果使用了 soi.TemplateName 覆盖模板，也更新 SystemTemplate
- 移除了 default 分支中重复的 SystemTemplate 设置

这个修复解决了 .st 母语+1d10 等涉及 computed value 属性修改时报错的问题。

close #1551 