### PR TITLE
fix(cmd): 修复rav代骰命令因 @ 信息污染 CleanArgs 导致解析失败的问题

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -396,11 +396,9 @@ func extractResultFromSegments(segments []message.IMessageElement) string {
 		}
 		switch v.Type() {
 		case message.At:
-			res, ok := v.(*message.AtElement)
-			if !ok {
-				continue
-			}
-			cqMessage.WriteString(fmt.Sprintf("[CQ:at,qq=%v]", res.Target))
+			// 跳过 @ 信息，因为已通过 parseAtInfo 单独处理
+			// 不要转换为 CQ 码，否则会污染 CleanArgs 导致表达式解析失败
+			continue
 		case message.Text:
 			res, ok := v.(*message.TextElement)
 			if !ok {


### PR DESCRIPTION
在这个commit:  220c90a7  feat(cmd): 重构cmd的消息段转换函数  中

extractResultFromSegments 将 AtElement 转换为 CQ 码，导致最终的CleanArgs 包含 [CQ:at,qq=xxx]，
使 .rav 等命令的表达式解析失败，报错"类型不是数字:"。

复现：
> .rav 力量80 @张三
> 类型不是数字:

