### PR TITLE
fix(onebot): 修复了在 onebot 平台下 WebUI “加好友验证” 设置项即使为空时依然触发验证的问题

### DIFF
--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -395,14 +395,7 @@ func (p *PlatformAdapterOnebot) handleReqFriendAction(req gjson.Result, _ *evsoc
 	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
 	var extra string
 	// 匹配验证问题检查
-	var passQuestion bool
-	if toMatch == "" {
-		passQuestion = true
-	} else if comment == DiceFormat(ctx, toMatch) {
-		passQuestion = true
-	} else {
-		passQuestion = checkMultiFriendAddVerify(comment, toMatch)
-	}
+	passQuestion := toMatch == "" || comment == DiceFormat(ctx, toMatch) || checkMultiFriendAddVerify(comment, toMatch)
 	// 匹配黑名单检查
 	result := checkBlackList(req.Get("user_id").String(), "user", ctx)
 


### PR DESCRIPTION
rt。
fix #1579 

已测试，works on My machine

<img width="463" height="138" alt="image" src="https://github.com/user-attachments/assets/4c7e9408-c30e-4fd9-acc0-8f1422f18d08" />

onebot 协议端侧测试：

<img width="742" height="55" alt="image" src="https://github.com/user-attachments/assets/ad89a2bb-1573-4ed4-afb4-5357310573d2" />

## Summary by Sourcery

Bug Fixes:
- Ensure OneBot friend requests are auto-approved when the WebUI "add friend verification" field is left empty instead of still enforcing verification.