### PR TITLE
fix: 修复因 diceScript 改动造成的 .st show 无法工作的问题

### DIFF
--- a/dice/templates/dnd5e.yaml
+++ b/dice/templates/dnd5e.yaml
@@ -11,11 +11,11 @@ initScript: |
   }
 
   func skillShowKeyAs(key, val) {
-    return `{key}{&val.factor ? '*'+ (&val.factor == 1 ? '' : str(&val.factor)) }`
+    return `{key}{&val.factor ? '*'+ (&val.factor == 1 ? '' : toStr(&val.factor)) }`
   }
 
   func abilityShowKeyAs(key, keyFactor) {
-    return `{key}{keyFactor ? '*'+ (keyFactor == 1 ? '' : str(keyFactor)) }`
+    return `{key}{keyFactor ? '*'+ (keyFactor == 1 ? '' : toStr(keyFactor)) }`
   }
 
   func pbCalc(base, factor, ab) { // 基础值，熟练系数，属性值


### PR DESCRIPTION
木落神了

## Summary by Sourcery

错误修复：
- 修正 DnD5e 技能和能力显示辅助函数中的值到字符串转换问题，恢复 `.st show` 输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct value-to-string conversion in DnD5e skill and ability display helpers to restore `.st show` output.

</details>