### PR TITLE
fix(reply): 防止表达式结果为空并优化求值诊断

### DIFF
--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -456,6 +457,10 @@ func DiceExprEvalBase(ctx *MsgContext, s string, flags RollExtraFlags) (*VMResul
 	vm := ctx.vm
 	vm.Ret = nil
 	vm.Error = nil
+	exprLog := strings.ReplaceAll(s, "\x1e", "`")
+	if len(exprLog) > 200 {
+		exprLog = exprLog[:200] + "...(truncated)"
+	}
 
 	vm.Config.DisableStmts = flags.DisableBlock
 	vm.Config.IgnoreDiv0 = flags.IgnoreDiv0
@@ -482,24 +487,41 @@ func DiceExprEvalBase(ctx *MsgContext, s string, flags RollExtraFlags) (*VMResul
 	}
 
 	err := ctx.vm.Run(s)
-	if err != nil || ctx.vm.Ret == nil {
+	ret := ctx.vm.Ret
+	if err != nil || ret == nil {
+		if err == nil && ret == nil {
+			err = errors.New("脚本执行结果为空")
+		}
+		if ret == nil {
+			logger.M().Warnf(
+				"DiceExprEvalBase V2返回空结果: err=%v flags={V1Only:%v V2Only:%v DisableBlock:%v IgnoreDiv0:%v} expr=%q",
+				err, flags.V1Only, flags.V2Only, flags.DisableBlock, flags.IgnoreDiv0, exprLog,
+			)
+		}
 		if flags.V2Only {
 			return nil, "", err
 		}
-		logger.M().Error("脚本执行出错V2: ", strings.ReplaceAll(s, "\x1e", "`"), "->", err)
+		logger.M().Error("脚本执行出错V2: ", exprLog, "->", err)
 		errV2 := err // 某种情况下没有这个值，很奇怪
 
 		// 尝试一下V1
 		val, detail, err := ctx.Dice._ExprEvalBaseV1(s, ctx, flags)
 		if err != nil {
+			logger.M().Warnf(
+				"DiceExprEvalBase 回退V1失败: errV2=%v errV1=%v flags={V1Only:%v V2Only:%v} expr=%q",
+				errV2, err, flags.V1Only, flags.V2Only, exprLog,
+			)
 			// 我们不关心 v1 的报错
 			return nil, detail, errV2
 		}
+		logger.M().Warnf(
+			"DiceExprEvalBase 回退V1成功: errV2=%v flags={V1Only:%v V2Only:%v} expr=%q",
+			errV2, flags.V1Only, flags.V2Only, exprLog,
+		)
 
 		return &VMResultV2m{val.ConvertToV2(), ctx.vm, val, cocFlagVarPrefix, errV2}, detail, err
-	} else {
-		return &VMResultV2m{ctx.vm.Ret, ctx.vm, nil, cocFlagVarPrefix, nil}, ctx.vm.GetDetailText(), nil
 	}
+	return &VMResultV2m{ret, ctx.vm, nil, cocFlagVarPrefix, nil}, ctx.vm.GetDetailText(), nil
 }
 
 // DiceExprTextBase


### PR DESCRIPTION
## Summary by Sourcery

改进自定义回复表达式求值的健壮性和诊断能力，避免返回 nil 结果，并提供更清晰的日志记录。

错误修复：
- 通过显式处理 nil 结果，防止自定义回复条件检查将 nil 的表达式求值结果视为成功。
- 确保 `DiceExprEvalBase` 将 VM 返回的 nil 视为错误并正确向上传播，而不是在静默状态下视为成功。

增强：
- 为表达式求值失败添加更丰富、结构化的日志记录，包括标志位、版本信息、截断后的表达式，以及在不同 VM 版本之间回退行为的记录。
- 为回复条件表达式引入可重写的求值函数钩子，以便于测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and diagnostics of custom reply expression evaluation to avoid nil results and provide clearer logging.

Bug Fixes:
- Prevent custom reply condition checks from treating nil expression evaluation results as successful by explicitly handling nil results.
- Ensure DiceExprEvalBase treats a nil VM return as an error and propagates it correctly instead of silently succeeding.

Enhancements:
- Add richer, structured logging for expression evaluation failures, including flags, versions, truncated expressions, and fallback behavior between VM versions.
- Introduce an overridable evaluation function hook for reply condition expressions to facilitate testing.

</details>