### PR TITLE
feat(log): `log get` 支持 `-f` 参数重新上传日志到服务器

### DIFF
--- a/api/story_log.go
+++ b/api/story_log.go
@@ -189,5 +189,5 @@ func logSendToBackend(groupID string, logName string) (bool, string, error) {
 		EndPoint: myDice.UIEndpoint,
 	}
 
-	return dice.LogSendToBackend(ctx, groupID, logName)
+	return dice.LogSendToBackend(ctx, groupID, logName, true)
 }

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -127,14 +127,14 @@ func RegisterBuiltinExtLog(self *Dice) {
 .log on [<日志名>]  // 开始记录，不写日志名则开启最近一次日志，注意on后跟空格！
 .log off // 暂停记录
 .log end // 完成记录并发送日志文件
-.log get [<日志名>] // 重新上传日志，并获取链接
+.log get [<日志名>] [-f]// 重新上传日志，并获取链接, -f 强制重新上传
 .log halt // 强行关闭当前log，不上传日志
 .log list // 查看当前群的日志列表
 .log del <日志名> // 删除一份日志
 .log stat [<日志名>] // 查看统计
 .log stat [<日志名>] --all // 查看统计(全团)，--all前必须有空格
 .log list <群号> // 查看指定群的日志列表(无法取得日志时，找骰主做这个操作)
-.log masterget <群号> <日志名> // 重新上传日志，并获取链接(无法取得日志时，找骰主做这个操作)
+.log masterget <群号> <日志名> [-f] // 重新上传日志，并获取链接(无法取得日志时，找骰主做这个操作),-f 强制重新上传
 .log export <日志名> // 直接取得日志txt(服务出问题或有其他需要时使用)
 .log export <日志名> <邮箱地址> // 通过邮件取得日志txt，多个邮箱用空格隔开`
 
@@ -168,8 +168,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 
-			getAndUpload := func(gid, lname string) {
-				unofficial, fn, err := LogSendToBackend(ctx, gid, lname)
+			getAndUpload := func(gid, lname string, force bool) {
+				unofficial, fn, err := LogSendToBackend(ctx, gid, lname, force)
 				if err != nil {
 					reason := strings.TrimPrefix(err.Error(), "#")
 					VarSetValueStr(ctx, "$t错误原因", reason)
@@ -269,7 +269,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
-				getAndUpload(groupID, logName)
+				force := cmdArgs.GetKwarg("f") != nil
+				getAndUpload(groupID, logName, force)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "get") {
 				// 仿照 log on 为 log get 添加了 IsPrivate 判断
@@ -289,7 +290,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
-				getAndUpload(group.GroupID, logName)
+				force := cmdArgs.GetKwarg("f") != nil
+				getAndUpload(group.GroupID, logName, force)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "end") {
 				if group.LogCurName == "" {
@@ -310,7 +312,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 
 				time.Sleep(time.Duration(0.3 * float64(time.Second)))
 				// Note: 2024-10-15 经过简单测试，似乎能缓解#1034的问题，但无法根本解决。
-				go getAndUpload(group.GroupID, group.LogCurName)
+				go getAndUpload(group.GroupID, group.LogCurName, false)
 				group.LogCurName = ""
 				group.MarkDirty(ctx.Dice)
 				return CmdExecuteResult{Matched: true, Solved: true}
@@ -1060,7 +1062,7 @@ func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix s
 	return tempLog.Name(), nil
 }
 
-func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (bool, string, error) {
+func LogSendToBackend(ctx *MsgContext, groupID string, logName string, force bool) (bool, string, error) {
 	dice := ctx.Dice
 	dirPath := filepath.Join(dice.BaseConfig.DataDir, "log-exports")
 
@@ -1079,6 +1081,7 @@ func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (bool, st
 		LogName:   logName,
 		UniformID: ctx.EndPoint.UserID,
 		GroupID:   groupID,
+		Force:     force,
 	}
 	uploadCtx.Version = storylog.StoryVersionV1
 

--- a/dice/storylog/storylog.go
+++ b/dice/storylog/storylog.go
@@ -26,6 +26,7 @@ type UploadEnv struct {
 	UniformID string
 	GroupID   string
 	Token     string
+	Force     bool
 
 	lines []*model.LogOneItem
 	data  *[]byte

--- a/dice/storylog/upload_v1.go
+++ b/dice/storylog/upload_v1.go
@@ -21,7 +21,7 @@ func uploadV1(env UploadEnv) (string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
-	if len(url) > 0 && uploadTS > updateTS {
+	if !env.Force && len(url) > 0 && uploadTS > updateTS {
 		// 已有URL且上传时间晚于Log更新时间（最后录入时间），直接返回
 		env.Log.Infof(
 			"查询到之前上传的URL, 直接使用 Log:%s.%s 上传时间:%s 更新时间:%s URL:%s",
@@ -32,7 +32,9 @@ func uploadV1(env UploadEnv) (string, error) {
 		)
 		return url, nil
 	}
-	if len(url) == 0 {
+	if env.Force {
+		env.Log.Infof("强制重新上传 Log:%s.%s", env.GroupID, env.LogName)
+	} else if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
 	} else {
 		env.Log.Infof(

--- a/dice/storylog/upload_v105.go
+++ b/dice/storylog/upload_v105.go
@@ -136,7 +136,7 @@ func uploadV105(env UploadEnv) (string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
-	if len(url) > 0 && uploadTS > updateTS {
+	if !env.Force && len(url) > 0 && uploadTS > updateTS {
 		// 已有URL且上传时间晚于Log更新时间（最后录入时间），直接返回
 		env.Log.Infof(
 			"查询到之前上传的URL, 直接使用 Log:%s.%s 上传时间:%s 更新时间:%s URL:%s",
@@ -147,7 +147,9 @@ func uploadV105(env UploadEnv) (string, error) {
 		)
 		return url, nil
 	}
-	if len(url) == 0 {
+	if env.Force {
+		env.Log.Infof("强制重新上传 Log:%s.%s", env.GroupID, env.LogName)
+	} else if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
 	} else {
 		env.Log.Infof(


### PR DESCRIPTION
close #1563 
  ui提取log全部按强制重新上传算，懒得改ui，看看 @fy0 怎么想，改回使用缓存也行

## 由 Sourcery 提供的摘要

添加对强制重新上传 story 日志的支持，并在日志上传流水线中传递一个 `force` 标记。

新功能：
- 为 `.log get` 和 `.log masterget` 命令引入 `-f` 标志，用于强制重新上传日志，而不是使用缓存的 URL。

改进：
- 在 `LogSendToBackend` 和 story 日志上传流程中贯穿传递一个 `force` 参数，用于控制是否可以重用已有的上传 URL。
- 确保由 UI 发起的日志上传始终向后端执行强制重新上传。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for forcing story log re-uploads and propagate a force flag through the log upload pipeline.

New Features:
- Introduce a -f flag for .log get and .log masterget commands to force re-uploading logs instead of using cached URLs.

Enhancements:
- Plumb a force parameter through LogSendToBackend and story log upload flows to control whether existing upload URLs may be reused.
- Ensure UI-initiated log uploads always perform a forced re-upload to the backend.

</details>