### PR TITLE
fix: 修复在初始化、logid为0时错误执行以及无法全量更新表导致错误的情况

### DIFF
--- a/migrate/v2/v160/v160_logid0.go
+++ b/migrate/v2/v160/v160_logid0.go
@@ -21,15 +21,17 @@ func V160LogIDZeroCleanMigrate(dboperator operator.DatabaseOperator, logf func(s
 		return nil
 	}
 
-	var hasLogIDZero bool
-	if err := db.Raw("SELECT EXISTS(SELECT 1 FROM logs WHERE id = 0 LIMIT 1)").Scan(&hasLogIDZero).Error; err != nil {
+	var hasLogIDZeroInt int64
+	if err := db.Raw("SELECT EXISTS(SELECT 1 FROM logs WHERE id = 0 LIMIT 1)").Scan(&hasLogIDZeroInt).Error; err != nil {
 		return err
 	}
+	hasLogIDZero := hasLogIDZeroInt != 0
 
-	var hasItemLogIDZero bool
-	if err := db.Raw("SELECT EXISTS(SELECT 1 FROM log_items WHERE log_id = 0 LIMIT 1)").Scan(&hasItemLogIDZero).Error; err != nil {
+	var hasItemLogIDZeroInt int64
+	if err := db.Raw("SELECT EXISTS(SELECT 1 FROM log_items WHERE log_id = 0 LIMIT 1)").Scan(&hasItemLogIDZeroInt).Error; err != nil {
 		return err
 	}
+	hasItemLogIDZero := hasItemLogIDZeroInt != 0
 
 	if !hasLogIDZero && !hasItemLogIDZero {
 		return nil
@@ -45,7 +47,7 @@ func V160LogIDZeroCleanMigrate(dboperator operator.DatabaseOperator, logf func(s
 		return logResult.Error
 	}
 
-	// log_id=0 清理后，回填剩余日志(size 仅需更新 id>0 的有效日志行)
+	// log_id=0 清理后，回填剩余日志 (size 仅需更新 id>0 的有效日志行)
 	recountResult := db.Model(&model.LogInfo{}).Where("id > 0").Update("size", gorm.Expr(
 		"(SELECT COUNT(1) FROM log_items WHERE log_items.log_id = logs.id AND log_items.removed IS NULL)",
 	))


### PR DESCRIPTION
rt.

close #1622

## Summary by Sourcery

当所需的日志表或 `log_id=0` 记录不存在时，跳过 v160 的 `log_id=0` 清理迁移；并且仅针对有效的日志条目重新计算日志大小字段。

Bug Fixes:
- 在全新或普通安装、且不存在所需数据表或 `log_id=0` 记录的情况下，避免运行 `log_id=0` 清理迁移。
- 在清理之后，确保对所有剩余的有效日志（`id > 0`）重新计算日志大小值，以防止出现过期的计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip the v160 log_id=0 cleanup migration when required log tables or log_id=0 records are absent, and ensure log size fields are recomputed only for valid log entries.

Bug Fixes:
- Avoid running the log_id=0 cleanup migration on fresh or normal installations where the necessary tables or log_id=0 records do not exist.
- Ensure log size values are recalculated for all remaining valid logs (id > 0) after cleanup to prevent stale counts.

</details>

Bug 修复：
- 当所需的日志表缺失或不包含 ID 为 0 的记录时，跳过 v160 日志 ID 0 清理迁移。
- 确保为所有日志记录重新计算日志大小字段，而不是只针对其中一部分记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

当所需的日志表或 `log_id=0` 记录不存在时，跳过 v160 的 `log_id=0` 清理迁移；并且仅针对有效的日志条目重新计算日志大小字段。

Bug Fixes:
- 在全新或普通安装、且不存在所需数据表或 `log_id=0` 记录的情况下，避免运行 `log_id=0` 清理迁移。
- 在清理之后，确保对所有剩余的有效日志（`id > 0`）重新计算日志大小值，以防止出现过期的计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip the v160 log_id=0 cleanup migration when required log tables or log_id=0 records are absent, and ensure log size fields are recomputed only for valid log entries.

Bug Fixes:
- Avoid running the log_id=0 cleanup migration on fresh or normal installations where the necessary tables or log_id=0 records do not exist.
- Ensure log size values are recalculated for all remaining valid logs (id > 0) after cleanup to prevent stale counts.

</details>

</details>