### PR TITLE
fix: 修复 DiceMaxMode 未重置的问题

### DIFF
--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -459,9 +459,10 @@ func DiceExprEvalBase(ctx *MsgContext, s string, flags RollExtraFlags) (*VMResul
 
 	vm.Config.DisableStmts = flags.DisableBlock
 	vm.Config.IgnoreDiv0 = flags.IgnoreDiv0
+	oldDiceMaxMode := vm.Config.DiceMaxMode
 	vm.Config.DiceMaxMode = flags.BigFailDiceOn
 	defer func() {
-		vm.Config.DiceMaxMode = false
+		vm.Config.DiceMaxMode = oldDiceMaxMode
 	}()
 	if vm.Config.DefaultDiceSideExpr == "" {
 		vm.Config.DefaultDiceSideExpr = strconv.FormatInt(flags.DefaultDiceSideNum, 10)

--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -460,6 +460,9 @@ func DiceExprEvalBase(ctx *MsgContext, s string, flags RollExtraFlags) (*VMResul
 	vm.Config.DisableStmts = flags.DisableBlock
 	vm.Config.IgnoreDiv0 = flags.IgnoreDiv0
 	vm.Config.DiceMaxMode = flags.BigFailDiceOn
+	defer func() {
+		vm.Config.DiceMaxMode = false
+	}()
 	if vm.Config.DefaultDiceSideExpr == "" {
 		vm.Config.DefaultDiceSideExpr = strconv.FormatInt(flags.DefaultDiceSideNum, 10)
 	}


### PR DESCRIPTION
close #1267

## Summary by Sourcery

Bug Fixes:
- 修复在掷骰表达式计算完成后 `DiceMaxMode` 标志未被重置的问题，防止其在后续计算中被意外持续保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix DiceMaxMode flag not being reset after dice expression evaluation, preventing unintended persistence across subsequent evaluations.

</details>