### PR TITLE
fix: 修正dbText计算使用的函数名str改为toStr

### DIFF
--- a/dice/templates/coc7.yaml
+++ b/dice/templates/coc7.yaml
@@ -128,7 +128,7 @@ attrs: # 属性
     语言: 教育 # 语言的默认值随着教育增长而增加，但也可以是不同的值
     闪避: 敏捷 / 2
 
-    dbText: $STR_SIZ_SUM < 65 ? -2, $STR_SIZ_SUM < 85 ? -1, $STR_SIZ_SUM < 125 ? 0, $STR_SIZ_SUM < 165 ? "1d4", $STR_SIZ_SUM < 205 ? "1d6", 1 ? str(($STR_SIZ_SUM - 205) / 80 + 2) + "d6"
+    dbText: $STR_SIZ_SUM < 65 ? -2, $STR_SIZ_SUM < 85 ? -1, $STR_SIZ_SUM < 125 ? 0, $STR_SIZ_SUM < 165 ? "1d4", $STR_SIZ_SUM < 205 ? "1d6", 1 ? toStr(($STR_SIZ_SUM - 205) / 80 + 2) + "d6"
   # detailOverwrite:
   #   db: 'dbText'
   #   体格: '体格'


### PR DESCRIPTION
close #1600

## Summary by Sourcery

Bug Fixes:
- 修复在 COC7 `dbText` 计算模板中错误使用不存在或错误的字符串转换函数的问题，从而防止潜在的运行时或求值错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect use of a non-existent or wrong string conversion function in the COC7 dbText calculation template, preventing potential runtime or evaluation errors.

</details>