### PR TITLE
fix: 修复了在 serve.yaml 的 imSession 字段为空时报 panic 的问题

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -2139,17 +2139,7 @@ func (d *Dice) loads() {
 			d.Logger.Error("serve.yaml parse failed")
 			panic(err2)
 		}
-		if dNew.ImSession != nil {
-			if dNew.ImSession.EndPoints != nil {
-				d.ImSession.EndPoints = dNew.ImSession.EndPoints
-			} else {
-				missingPlatformConfigInServe = true
-				d.ImSession.EndPoints = make([]*EndPointInfo, 0)
-			}
-		} else {
-			missingPlatformConfigInServe = true
-			d.ImSession.EndPoints = make([]*EndPointInfo, 0)
-		}
+		missingPlatformConfigInServe = d.loadIMSessionEndpoints(dNew.ImSession)
 		d.DiceMasters = dNew.DiceMasters
 		if len(d.DiceMasters) == 0 {
 			d.DiceMasters = DefaultConfig.DiceMasters
@@ -2367,13 +2357,7 @@ func (d *Dice) loads() {
 		i.Session = d.ImSession
 		i.AdapterSetup()
 	}
-	if len(d.ImSession.EndPoints) == 0 {
-		if missingPlatformConfigInServe {
-			d.Logger.Warn("serve.yaml 中未找到平台账号配置，海豹将不会连接聊天平台。请检查 serve.yaml，或在界面中重新添加账号。")
-		} else {
-			d.Logger.Warn("当前没有可用的平台账号，海豹将不会连接聊天平台，也无法收发消息。请检查账号设置或 serve.yaml 配置。")
-		}
-	}
+	d.warnIfNoPlatformEndpoint(missingPlatformConfigInServe)
 
 	d.LogWriter.LogLimit = int(d.Config.UILogLimit)
 
@@ -2385,6 +2369,28 @@ func (d *Dice) loads() {
 	d.MarkModified()
 }
 
+func (d *Dice) loadIMSessionEndpoints(imSession *IMSession) bool {
+	if imSession == nil || imSession.EndPoints == nil {
+		d.ImSession.EndPoints = make([]*EndPointInfo, 0)
+		return true
+	}
+
+	d.ImSession.EndPoints = imSession.EndPoints
+	return false
+}
+
+func (d *Dice) warnIfNoPlatformEndpoint(missingPlatformConfigInServe bool) {
+	if len(d.ImSession.EndPoints) != 0 {
+		return
+	}
+
+	if missingPlatformConfigInServe {
+		d.Logger.Warn("serve.yaml 中未找到平台账号配置，海豹将不会连接聊天平台。请检查 serve.yaml，或在界面中重新添加账号。")
+		return
+	}
+
+	d.Logger.Warn("当前没有可用的平台账号，海豹将不会连接聊天平台，也无法收发消息。请检查账号设置或 serve.yaml 配置。")
+}
 func (d *Dice) loadAdvanced() {
 	d.Logger.Info("开始读取 advanced.yaml")
 	advancedConfig := AdvancedConfig{


### PR DESCRIPTION
rt。
目前 serve.yaml 在加载序列化以及运行时的可空性判定不一致，个人考虑以它可空为基础进行实现

## Summary by Sourcery

更安全、更透明地处理 `serve.yaml` 中缺失的平台端点配置。

Bug Fixes:
- 当 `serve.yaml` 中的 `imSession` 或其 `EndPoints` 字段为 `nil` 时，通过安全地初始化一个空的端点列表来防止发生 panic。

Enhancements:
- 当 `serve.yaml` 缺少平台账号配置，或没有可用的端点时，记录警告日志，说明机器人将不会连接到任何聊天平台。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing platform endpoint configuration in serve.yaml more safely and transparently.

Bug Fixes:
- Prevent a panic when the imSession or its EndPoints field in serve.yaml is nil by safely initializing an empty endpoint list.

Enhancements:
- Log warnings when serve.yaml lacks platform account configuration or when no usable endpoints are available, indicating that the bot will not connect to any chat platform.

</details>

错误修复：
- 当 serve.yaml 中的 `imSession` 字段或其 `EndPoints` 为空（nil）时，通过安全地初始化一个空的 endpoint 列表来避免发生 panic。

增强内容：
- 当 serve.yaml 中未配置任何平台账号，或在加载配置后没有可用的 endpoints 时，添加警告信息，明确说明机器人将不会连接到任何聊天平台。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更安全、更透明地处理 `serve.yaml` 中缺失的平台端点配置。

Bug Fixes:
- 当 `serve.yaml` 中的 `imSession` 或其 `EndPoints` 字段为 `nil` 时，通过安全地初始化一个空的端点列表来防止发生 panic。

Enhancements:
- 当 `serve.yaml` 缺少平台账号配置，或没有可用的端点时，记录警告日志，说明机器人将不会连接到任何聊天平台。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing platform endpoint configuration in serve.yaml more safely and transparently.

Bug Fixes:
- Prevent a panic when the imSession or its EndPoints field in serve.yaml is nil by safely initializing an empty endpoint list.

Enhancements:
- Log warnings when serve.yaml lacks platform account configuration or when no usable endpoints are available, indicating that the bot will not connect to any chat platform.

</details>

</details>