### PR TITLE
chore: delete comments on successful PR title check

### DIFF
--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -40,3 +40,11 @@ jobs:
             - `chore: fixing build pipeline`
             - etc.
             More information can be found [here](https://www.conventionalcommits.org/zh-hans/v1.0.0/).
+
+      - name: Remove comment if fixed
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ steps.check.outputs.success == 'true'}}
+        with:
+          header: 'PR Title Check'
+          delete: true
+          


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

CI：
- 更新 PR 标题检查器的工作流程，当标题检查通过时，删除之前的置顶评论。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the PR title checker workflow to delete its previous sticky comment when the title check succeeds.

</details>