### PR TITLE
fix: dingtalk closed channel panic

### DIFF
--- a/dice/platform_adapter_dingtalk.go
+++ b/dice/platform_adapter_dingtalk.go
@@ -77,13 +77,12 @@ func (pa *PlatformAdapterDingTalk) SendToPerson(ctx *MsgContext, uid string, tex
 	rawUserID := ExtractDingTalkUserID(uid)
 
 	pa.sessionMu.RLock()
+	defer pa.sessionMu.RUnlock()
 	if pa.IntentSession == nil || !pa.sessionOpened {
-		pa.sessionMu.RUnlock()
 		pa.Session.Parent.Logger.Warn("Dingtalk session 未开启，忽略私聊发送")
 		return
 	}
 	session := pa.IntentSession
-	pa.sessionMu.RUnlock()
 
 	messageID, err := session.MessagePrivateSend(rawUserID, pa.RobotCode, &msg)
 	if err != nil {
@@ -107,14 +106,12 @@ func (pa *PlatformAdapterDingTalk) SendToGroup(ctx *MsgContext, uid string, text
 	rawGroupID := ExtractDingTalkGroupID(uid)
 
 	pa.sessionMu.RLock()
+	defer pa.sessionMu.RUnlock()
 	if pa.IntentSession == nil || !pa.sessionOpened {
-		pa.sessionMu.RUnlock()
 		pa.Session.Parent.Logger.Warn("Dingtalk session 未开启，忽略群聊发送")
 		return
 	}
 	session := pa.IntentSession
-	pa.sessionMu.RUnlock()
-
 	messageID, err := session.MessageGroupSend(rawGroupID, pa.RobotCode, pa.CoolAppCode, &msg)
 	if err != nil {
 		pa.Session.Parent.Logger.Error("Dingtalk SendToGroup Error: ", err)
@@ -249,17 +246,18 @@ func (pa *PlatformAdapterDingTalk) Serve() int {
 
 	pa.sessionMu.Lock()
 	defer pa.sessionMu.Unlock()
-
 	if pa.IntentSession == nil {
 		pa.IntentSession = dingtalk.New(pa.ClientID, pa.Token)
 		pa.IntentSession.AddEventHandler(pa.OnChatReceive)
 		pa.IntentSession.AddEventHandler(pa.OnGroupJoined)
 	}
+	session := pa.IntentSession
 
-	if err := pa.IntentSession.Open(); err != nil {
+	if err := session.Open(); err != nil {
 		pa.sessionOpened = false
 		return 1
 	}
+
 	pa.sessionOpened = true
 
 	logger.Info("Dingtalk 连接成功")
@@ -296,21 +294,20 @@ func ExtractDingTalkGroupID(id string) string {
 func (pa *PlatformAdapterDingTalk) closeSessionLocked() error {
 	pa.sessionMu.Lock()
 	defer pa.sessionMu.Unlock()
-
-	if pa.IntentSession == nil || !pa.sessionOpened {
-		pa.sessionOpened = false
-		return nil
-	}
-	err := pa.IntentSession.Close()
+	session := pa.IntentSession
+	opened := pa.sessionOpened
 	pa.sessionOpened = false
 	pa.IntentSession = nil
-	return err
+
+	if session == nil || !opened {
+		return nil
+	}
+	return session.Close()
 }
 
 func (pa *PlatformAdapterDingTalk) openSessionLocked() error {
 	pa.sessionMu.Lock()
 	defer pa.sessionMu.Unlock()
-
 	if pa.IntentSession == nil {
 		pa.IntentSession = dingtalk.New(pa.ClientID, pa.Token)
 		pa.IntentSession.AddEventHandler(pa.OnChatReceive)
@@ -319,10 +316,13 @@ func (pa *PlatformAdapterDingTalk) openSessionLocked() error {
 	if pa.sessionOpened {
 		return nil
 	}
-	if err := pa.IntentSession.Open(); err != nil {
+	session := pa.IntentSession
+
+	if err := session.Open(); err != nil {
 		pa.sessionOpened = false
 		return err
 	}
+
 	pa.sessionOpened = true
 	return nil
 }


### PR DESCRIPTION
fix #1638 

## Summary by Sourcery

通过同步机制和状态跟踪来保护钉钉会话的生命周期，避免在通道关闭时发生 panic，并确保正确更新端点状态。

Bug 修复：
- 通过在使用前检查会话是否存在且处于打开状态，防止在发送钉钉消息时发生 panic。
- 通过仅在会话有效且处于打开状态时安全地关闭会话，避免在重新登录或禁用钉钉适配器时出现错误。

增强：
- 引入带互斥锁保护的辅助函数用于打开和关闭钉钉会话，并显式跟踪其打开状态。
- 复用单个带已注册事件处理器的钉钉会话实例，在正确切换其打开状态的同时，在连接成功时一致地更新端点状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard DingTalk session lifecycle with synchronization and state tracking to avoid panics when channels are closed and ensure endpoint status is updated correctly.

Bug Fixes:
- Prevent panics when sending DingTalk messages by checking that the session exists and is open before use.
- Avoid errors when re-login or disabling the DingTalk adapter by safely closing sessions only when they are valid and open.

Enhancements:
- Introduce mutex-protected helpers for opening and closing the DingTalk session and track its open state explicitly.
- Reuse a single DingTalk session instance with registered event handlers while correctly toggling its open state, and consistently update endpoint state on successful connects.

</details>