### PR TITLE
chore: Revert "feat: recover SealTrustedClientPrivateKey"

### DIFF
--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -1305,8 +1305,7 @@ func RegisterBuiltinExtFun(self *Dice) {
 	}
 
 	cmdCheckHelp := `.check // 生成海豹校验码，可用于在官网校验是否是可信海豹
-.check --plain // 生成 ASCII 字符的海豹校验码
-.check recover // 恢复可信客户端私钥（仅海豹开发组使用，如果你正在阅读这行文字，说明这个功能不是给你用的）`
+.check --plain // 生成 ASCII 字符的海豹校验码`
 	cmdCheck := CmdItemInfo{
 		Name:      "check",
 		ShortHelp: cmdCheckHelp,
@@ -1315,17 +1314,6 @@ func RegisterBuiltinExtFun(self *Dice) {
 			if cmdArgs.IsArgEqual(1, "help") {
 				return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 			}
-
-			if cmdArgs.IsArgEqual(1, "recover") {
-				encrypted, err := RecoverSealTrustedClientPrivateKey()
-				if err != nil {
-					ReplyToSender(ctx, msg, fmt.Sprintf("恢复失败: %s", err.Error()))
-					return CmdExecuteResult{Matched: true, Solved: true}
-				}
-				ReplyToSender(ctx, msg, fmt.Sprintf("已加密的可信客户端私钥（请使用对应RSA私钥解密）:\n%s", encrypted))
-				return CmdExecuteResult{Matched: true, Solved: true}
-			}
-
 			var code string
 			if kv := cmdArgs.GetKwarg("plain"); kv != nil && kv.AsBool {
 				code = GenerateVerificationCode(

--- a/dice/verify.go
+++ b/dice/verify.go
@@ -3,7 +3,6 @@ package dice
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -19,33 +18,6 @@ var (
 	// SealTrustedClientPrivateKey 可信客户端私钥
 	SealTrustedClientPrivateKey = ``
 )
-
-// recoverKeyRSAPublicKey 用来 dump 上面那个 key 用的 key, 这个是 RSA 8192, 私钥只有我有, 这个功能很快就会移除, 别想着在这上面做文章了, 洗洗睡吧
-const recoverKeyRSAPublicKey = `-----BEGIN PUBLIC KEY-----
-MIIEIjANBgkqhkiG9w0BAQEFAAOCBA8AMIIECgKCBAEAxdYpWeo5XhmHTrKXcTi3
-WxSsfjqEtrNTUtvGO/3UpuJuj1uMy0z9hqCsdilGnl1YMtvNMpS8E8q0rTAdVBpK
-kLHdTRmW6KSVZM6SVyes3BCKwSr56gLtDks1lsy+TyTyLrD3UfR0rJGKFOUimoBt
-wDG3b+U4ychEdVSwB983isE+WM+i9z5AH9An46Fx4AB92ubLGn6Y4j48vb1kGJUR
-MZ0J7gNevdac48M2pTJpoF/HGKBY104wn1qiF2/67nZtZSUFzhhOCIuOfNXOlZNj
-pp7rxgLzlDjAMyvdxF4QB8+k8vB75yg7U38Q+b7vH2Zgsw5nT4iGx9dQRqcxAzxm
-A87djCNbwHH43ml10lhMUKbnbMpzeCAFcThNTafrmIw+gqsbAe+n4b71xFmeo0LK
-ckqQawL03teq8USAiAms9xfjpxWMn8sFOA1jixMjT7yvccBh+4z8MRjXcObS4s3L
-rm5Rlb6lWisa83Yzh2zvDTvfzWb5x6iIXD3l3l3pgN/CzlD2gtRikCyA9rHMc40K
-x3c5Gg21xMJwfbklyBIM4JCmSys3aQeNpI40qOgZWZ3F36/sgbDfJ2IPledja13S
-xhi5+LQUTarXAp8dKYZ7THSAOiWtqT80heNnMiAmTZnmUaqJd6sxS1XFZbeZcLwq
-JI5rNWzR2FZXm2l1g7PqT4wcVr4bNpvY9UhB390f7GXZT2zhKyhcHxWA6sQeXdrV
-JNIU99OYIDGlcS1WpUqLG9bJRLAINKqkbTFNOOhxvityFJAkpNt00tS/i2aVrvpo
-z2kzJEvsU0Sc/JybjU+t6pA8QhiPa159I6XW7fSGoU+jT3xNbge/T7MdO/ETc3/S
-3giap80eIZBsE89H5aLz2eliDAOZUl9r6jROfC0CKGvquvPEb8Msiy6vfWq2/M7J
-CbmM0qtWGM6YooZPyILp0aNL5kI2Nw4qQBeOG21Ui8JwOgyq5oEn30ZHqRidhOWy
-YueJHM43owJv4iMqKk7w6E0CtznAnQm8N5R9znPDegsFH5tUslKtsuFdelVDphK2
-6UcNsx+8tKbe0pwOMGmU/sTDr+rjaR3H7P2/tuURV4GzMpPW+M8UnIA7atGJNdUb
-lEbu/GOMJkbQaXQTAz1UCfTMykyJndVdJRJ37YOt5gsyS3vNFwSY1j9BGxs5czhE
-uAHBHTDyrypHExtuxQNTNbp3aLjvmbSfb/oW7q9UvhcmWuuAG8bStcZcspe9/CtU
-h55dQs+xaS0xoEyEmFVu1JNrEld7xInCNxxnzlcu21K6gjP0AmJsoDcwVNPkL3An
-/5vbvH92Exq5P1grOQoaOHL10yO460EH23AioFJ3u5tulnDtbw8UfX60zSWAsTyG
-0wIDAQAB
------END PUBLIC KEY-----`
 
 func initVerify() {
 	log := logger.M()
@@ -134,19 +106,4 @@ func GenerateVerificationKeyForPublicDice(data any) string {
 		return fmt.Sprintf("SEAL#%s", base64.StdEncoding.EncodeToString(dp))
 	}
 	return fmt.Sprintf("SEAL~%s", base64.StdEncoding.EncodeToString(dp))
-}
-
-// RecoverSealTrustedClientPrivateKey 使用 recoverKeyRSAPublicKey 加密 SealTrustedClientPrivateKey
-func RecoverSealTrustedClientPrivateKey() (string, error) {
-	if len(SealTrustedClientPrivateKey) == 0 {
-		return "", errors.New("SealTrustedClientPrivateKey 为空，无法恢复")
-	}
-	if len(recoverKeyRSAPublicKey) == 0 {
-		return "", errors.New("recoverKeyRSAPublicKey 未设置，无法恢复")
-	}
-	encrypted, err := crypto.RSAEncryptOAEP([]byte(SealTrustedClientPrivateKey), recoverKeyRSAPublicKey)
-	if err != nil {
-		return "", fmt.Errorf("加密失败: %w", err)
-	}
-	return encrypted, nil
 }

--- a/utils/crypto/rsa.go
+++ b/utils/crypto/rsa.go
@@ -4,9 +4,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 )
 
 // RSASign RSA 签名
@@ -51,30 +49,4 @@ func RSAVerify256(data []byte, base64Sig, publicKey string) error {
 	}
 	hashed := CalculateSHA256(data)
 	return rsa.VerifyPSS(key, crypto.SHA256, hashed, sign, nil)
-}
-
-// RSAEncryptOAEP 使用 RSA 公钥加密数据（OAEP + SHA256），返回 base64 编码的密文。
-// 对于超出单次加密长度限制的数据会自动分块加密。
-func RSAEncryptOAEP(plaintext []byte, publicKey string) (string, error) {
-	key := ReadPublicKey[rsa.PublicKey](publicKey)
-	if key == nil {
-		return "", errors.New("failed to parse RSA public key")
-	}
-	hash := sha256.New()
-	// 单次加密最大长度 = keySize - 2*hashSize - 2
-	maxChunkSize := key.Size() - 2*hash.Size() - 2
-	var ciphertext []byte
-	for len(plaintext) > 0 {
-		chunk := plaintext
-		if len(chunk) > maxChunkSize {
-			chunk = plaintext[:maxChunkSize]
-		}
-		encrypted, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, key, chunk, nil)
-		if err != nil {
-			return "", err
-		}
-		ciphertext = append(ciphertext, encrypted...)
-		plaintext = plaintext[len(chunk):]
-	}
-	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }


### PR DESCRIPTION
Reverts sealdice/sealdice-core#1650

## Summary by Sourcery

回退之前新增的用于恢复受信任客户端私钥的功能，并移除相关的加密工具和命令入口点。

Enhancements:
- 移除 `RecoverSealTrustedClientPrivateKey` 辅助函数及其 `.check recover` 命令入口，以禁用私钥恢复功能。
- 删除在移除恢复流程后不再需要的 RSA OAEP 加密辅助工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the previously added functionality for recovering the trusted client private key and remove the associated encryption utility and command entry point.

Enhancements:
- Remove the RecoverSealTrustedClientPrivateKey helper and its .check recover command entry to disable private key recovery functionality.
- Delete the RSA OAEP encryption helper no longer needed after removing the recovery flow.

</details>