### PR TITLE
fix: 修复了在对接 milky adapter 时，骰子为群主时二次确认退群失效并报错的问题

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -175,9 +175,16 @@ func shouldDismissRequireOwnerConfirm(ctx *MsgContext, groupID string) (bool, bo
 		}
 		return role == "owner", true, role
 	case *PlatformAdapterMilky:
-		role, err := pa.GetGroupMemberRole(groupID, ctx.EndPoint.UserID)
+		memberInfo, err := pa.GetGroupMemberInfo(groupID, ctx.EndPoint.UserID)
 		if err != nil {
 			return false, false, fmt.Sprintf("get_group_member_info failed: %v", err)
+		}
+		if memberInfo == nil {
+			return false, false, errGetGroupMemberInfoNil
+		}
+		role, ok := parseQQGroupRole(memberInfo.Role)
+		if !ok {
+			return false, false, errGetGroupMemberInfoEmptyRole
 		}
 		return role == "owner", true, role
 	default:

--- a/dice/builtin_commands_test.go
+++ b/dice/builtin_commands_test.go
@@ -2,9 +2,12 @@
 package dice
 
 import (
-	"errors"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	milky "github.com/Szzrain/Milky-go-sdk"
@@ -23,6 +26,120 @@ const (
 	testMilkyOwnerRoleChinese        = "群主"
 	testMilkyAdminRoleChinese        = "管理员"
 )
+
+type noopMilkyLogger struct{}
+
+func (noopMilkyLogger) Infof(string, ...interface{})  {}
+func (noopMilkyLogger) Errorf(string, ...interface{}) {}
+func (noopMilkyLogger) Debugf(string, ...interface{}) {}
+func (noopMilkyLogger) Warnf(string, ...interface{})  {}
+func (noopMilkyLogger) Info(...interface{})           {}
+func (noopMilkyLogger) Error(...interface{})          {}
+func (noopMilkyLogger) Debug(...interface{})          {}
+func (noopMilkyLogger) Warn(...interface{})           {}
+
+type milkyRESTHarness struct {
+	t               *testing.T
+	role            string
+	apiError        string
+	expectedGroupID int64
+	expectedUserID  int64
+
+	mu         sync.Mutex
+	quitGroups []int64
+}
+
+func newMilkyRESTHarness(t *testing.T, role string, apiError string, expectedGroupID, expectedUserID int64) (*milky.Session, *milkyRESTHarness, func()) {
+	t.Helper()
+
+	h := &milkyRESTHarness{
+		t:               t,
+		role:            role,
+		apiError:        apiError,
+		expectedGroupID: expectedGroupID,
+		expectedUserID:  expectedUserID,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(h.handle))
+	session, err := milky.New("ws://127.0.0.1", server.URL, "", noopMilkyLogger{})
+	if err != nil {
+		server.Close()
+		t.Fatalf("failed to create milky session: %v", err)
+	}
+
+	return session, h, server.Close
+}
+
+func (h *milkyRESTHarness) handle(w http.ResponseWriter, r *http.Request) {
+	h.t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+
+	switch strings.TrimPrefix(r.URL.Path, "/") {
+	case milky.EndpointGetGroupMemberInfo:
+		var payload struct {
+			GroupID int64 `json:"group_id"`
+			UserID  int64 `json:"user_id"`
+			NoCache bool  `json:"no_cache"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			h.t.Fatalf("failed to decode get_group_member_info payload: %v", err)
+		}
+		if payload.GroupID != h.expectedGroupID || payload.UserID != h.expectedUserID || payload.NoCache {
+			h.t.Fatalf("unexpected get_group_member_info payload: %#v", payload)
+		}
+		if h.apiError != "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":  "failed",
+				"retcode": 1,
+				"message": h.apiError,
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  "ok",
+			"retcode": 0,
+			"data": map[string]any{
+				"member": map[string]any{
+					"group_id": h.expectedGroupID,
+					"user_id":  h.expectedUserID,
+					"role":     h.role,
+				},
+			},
+		})
+	case milky.EndpointSendGroupMessage:
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  "ok",
+			"retcode": 0,
+			"data": map[string]any{
+				"message_seq": 1,
+				"time":        1,
+			},
+		})
+	case milky.EndpointQuitGroup:
+		var payload struct {
+			GroupID int64 `json:"group_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			h.t.Fatalf("failed to decode quit_group payload: %v", err)
+		}
+		h.mu.Lock()
+		h.quitGroups = append(h.quitGroups, payload.GroupID)
+		h.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  "ok",
+			"retcode": 0,
+			"data":    nil,
+		})
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *milkyRESTHarness) quitGroupSnapshot() []int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]int64(nil), h.quitGroups...)
+}
 
 func newQuitCommandTestContext(t *testing.T, d *Dice, ep *EndPointInfo, senderID, groupID, groupName string) (*MsgContext, *Message) {
 	t.Helper()
@@ -211,15 +328,11 @@ func TestShouldDismissRequireOwnerConfirmMilkyRoleNormalization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			groupID := "QQ-Group:" + strconv.FormatInt(tt.groupQQID, 10)
 			userID := "QQ:" + strconv.FormatInt(tt.userQQID, 10)
+			session, _, cleanup := newMilkyRESTHarness(t, tt.role, "", tt.groupQQID, tt.userQQID)
+			defer cleanup()
 
 			pa := &PlatformAdapterMilky{
-				IntentSession: &milky.Session{},
-				getGroupMemberInfo: func(_ *milky.Session, groupIDInt, userIDInt int64, noCache bool) (*milky.GroupMemberInfo, error) {
-					if groupIDInt != tt.groupQQID || userIDInt != tt.userQQID || noCache {
-						t.Fatalf("unexpected lookup args: groupID=%d userID=%d noCache=%v", groupIDInt, userIDInt, noCache)
-					}
-					return &milky.GroupMemberInfo{Role: tt.role}, nil
-				},
+				IntentSession: session,
 			}
 
 			ctx := &MsgContext{
@@ -247,11 +360,11 @@ func TestShouldDismissRequireOwnerConfirmMilkyRoleNormalization(t *testing.T) {
 	}
 }
 
-func newMilkyQuitCommandTestContext(t *testing.T, d *Dice, senderID, groupID, groupName string) (*MsgContext, *Message, *[]int64) {
+func newMilkyQuitCommandTestContext(t *testing.T, d *Dice, senderID, groupID, groupName string) (*MsgContext, *Message, *milkyRESTHarness, func()) {
 	t.Helper()
 	d.ExtList = nil
 
-	quitCalls := []int64{}
+	session, harness, cleanup := newMilkyRESTHarness(t, testMilkyOwnerRole, "", testMilkyOwnerGroupQQID, testMilkyBotQQID)
 	pa := &PlatformAdapterMilky{}
 	ep := &EndPointInfo{
 		EndPointInfoBase: EndPointInfoBase{
@@ -263,39 +376,27 @@ func newMilkyQuitCommandTestContext(t *testing.T, d *Dice, senderID, groupID, gr
 	}
 	pa.EndPoint = ep
 	pa.Session = d.ImSession
-	pa.IntentSession = &milky.Session{}
-	pa.getGroupMemberInfo = func(_ *milky.Session, groupIDInt, userIDInt int64, noCache bool) (*milky.GroupMemberInfo, error) {
-		if groupIDInt != testMilkyOwnerGroupQQID || userIDInt != testMilkyBotQQID || noCache {
-			t.Fatalf("unexpected lookup args: groupID=%d userID=%d noCache=%v", groupIDInt, userIDInt, noCache)
-		}
-		return &milky.GroupMemberInfo{Role: testMilkyOwnerRole}, nil
-	}
-	pa.sendGroupMessage = func(_ *milky.Session, _ int64, _ *[]milky.IMessageElement) (*milky.MessageRet, error) {
-		return &milky.MessageRet{}, nil
-	}
-	pa.quitGroup = func(_ *milky.Session, groupIDInt int64) error {
-		quitCalls = append(quitCalls, groupIDInt)
-		return nil
-	}
+	pa.IntentSession = session
 	ep.Adapter = pa
 
 	d.Config.BotExitWithoutAt = true
 	ctx, msg := newQuitCommandTestContext(t, d, ep, senderID, groupID, groupName)
-	return ctx, msg, &quitCalls
+	return ctx, msg, harness, cleanup
 }
 
 func TestDismissMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	d, _, _, cleanup := newExecuteNewTestDice(t)
 	defer cleanup()
 
-	ctx, msg, quitCalls := newMilkyQuitCommandTestContext(t, d, "QQ:9010", testMilkyOwnerGroupID, "MilkyDismissGroup")
+	ctx, msg, harness, closeHarness := newMilkyQuitCommandTestContext(t, d, "QQ:9010", testMilkyOwnerGroupID, "MilkyDismissGroup")
+	defer closeHarness()
 
 	first := d.CmdMap["dismiss"].Solve(ctx, msg, &CmdArgs{})
 	if !first.Matched || !first.Solved {
 		t.Fatalf("unexpected initial result: %#v", first)
 	}
-	if len(*quitCalls) != 0 {
-		t.Fatalf("dismiss should not quit before confirmation, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 0 {
+		t.Fatalf("dismiss should not quit before confirmation, got %#v", got)
 	}
 
 	confirmKey := getDismissConfirmKeyForGroup(ctx, msg.Sender.UserID, msg.GroupID)
@@ -308,8 +409,8 @@ func TestDismissMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	if !second.Matched || !second.Solved {
 		t.Fatalf("unexpected confirmed result: %#v", second)
 	}
-	if len(*quitCalls) != 1 || (*quitCalls)[0] != testMilkyOwnerGroupQQID {
-		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 1 || got[0] != testMilkyOwnerGroupQQID {
+		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", got)
 	}
 }
 
@@ -318,7 +419,9 @@ func TestDismissMilkyLookupErrorFallsBackToSafetyConfirmation(t *testing.T) {
 	defer cleanup()
 	d.ExtList = nil
 
-	var quitCalls []int64
+	session, harness, closeHarness := newMilkyRESTHarness(t, "", "milky lookup failed", testMilkyFallbackGroupQQID, 10020)
+	defer closeHarness()
+
 	pa := &PlatformAdapterMilky{}
 	ep := &EndPointInfo{
 		EndPointInfoBase: EndPointInfoBase{
@@ -330,17 +433,7 @@ func TestDismissMilkyLookupErrorFallsBackToSafetyConfirmation(t *testing.T) {
 	}
 	pa.EndPoint = ep
 	pa.Session = d.ImSession
-	pa.IntentSession = &milky.Session{}
-	pa.getGroupMemberInfo = func(_ *milky.Session, _, _ int64, _ bool) (*milky.GroupMemberInfo, error) {
-		return nil, errors.New("milky lookup failed")
-	}
-	pa.sendGroupMessage = func(_ *milky.Session, _ int64, _ *[]milky.IMessageElement) (*milky.MessageRet, error) {
-		return &milky.MessageRet{}, nil
-	}
-	pa.quitGroup = func(_ *milky.Session, groupIDInt int64) error {
-		quitCalls = append(quitCalls, groupIDInt)
-		return nil
-	}
+	pa.IntentSession = session
 	ep.Adapter = pa
 
 	d.Config.BotExitWithoutAt = true
@@ -358,8 +451,8 @@ func TestDismissMilkyLookupErrorFallsBackToSafetyConfirmation(t *testing.T) {
 	if !first.Matched || !first.Solved {
 		t.Fatalf("unexpected initial result: %#v", first)
 	}
-	if len(quitCalls) != 0 {
-		t.Fatalf("dismiss should not quit before confirmation on lookup error, got %#v", quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 0 {
+		t.Fatalf("dismiss should not quit before confirmation on lookup error, got %#v", got)
 	}
 
 	confirmKey := getDismissConfirmKeyForGroup(ctx, msg.Sender.UserID, msg.GroupID)
@@ -372,8 +465,8 @@ func TestDismissMilkyLookupErrorFallsBackToSafetyConfirmation(t *testing.T) {
 	if !second.Matched || !second.Solved {
 		t.Fatalf("unexpected confirmed result: %#v", second)
 	}
-	if len(quitCalls) != 1 || quitCalls[0] != testMilkyFallbackGroupQQID {
-		t.Fatalf("expected exactly one milky quit call for group 2020, got %#v", quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 1 || got[0] != testMilkyFallbackGroupQQID {
+		t.Fatalf("expected exactly one milky quit call for group 2020, got %#v", got)
 	}
 }
 
@@ -381,14 +474,15 @@ func TestBotByeMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	d, _, _, cleanup := newExecuteNewTestDice(t)
 	defer cleanup()
 
-	ctx, msg, quitCalls := newMilkyQuitCommandTestContext(t, d, "QQ:9011", testMilkyOwnerGroupID, "MilkyBotByeGroup")
+	ctx, msg, harness, closeHarness := newMilkyQuitCommandTestContext(t, d, "QQ:9011", testMilkyOwnerGroupID, "MilkyBotByeGroup")
+	defer closeHarness()
 
 	first := d.CmdMap["bot"].Solve(ctx, msg, &CmdArgs{Args: []string{"bye"}})
 	if !first.Matched || !first.Solved {
 		t.Fatalf("unexpected initial result: %#v", first)
 	}
-	if len(*quitCalls) != 0 {
-		t.Fatalf(".bot bye should not quit before confirmation, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 0 {
+		t.Fatalf(".bot bye should not quit before confirmation, got %#v", got)
 	}
 
 	confirmKey := getDismissConfirmKeyForGroup(ctx, msg.Sender.UserID, msg.GroupID)
@@ -401,8 +495,8 @@ func TestBotByeMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	if !second.Matched || !second.Solved {
 		t.Fatalf("unexpected confirmed result: %#v", second)
 	}
-	if len(*quitCalls) != 1 || (*quitCalls)[0] != testMilkyOwnerGroupQQID {
-		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 1 || got[0] != testMilkyOwnerGroupQQID {
+		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", got)
 	}
 }
 
@@ -410,14 +504,15 @@ func TestBotExitMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	d, _, _, cleanup := newExecuteNewTestDice(t)
 	defer cleanup()
 
-	ctx, msg, quitCalls := newMilkyQuitCommandTestContext(t, d, "QQ:9013", testMilkyOwnerGroupID, "MilkyBotExitGroup")
+	ctx, msg, harness, closeHarness := newMilkyQuitCommandTestContext(t, d, "QQ:9013", testMilkyOwnerGroupID, "MilkyBotExitGroup")
+	defer closeHarness()
 
 	first := d.CmdMap["bot"].Solve(ctx, msg, &CmdArgs{Args: []string{"exit"}})
 	if !first.Matched || !first.Solved {
 		t.Fatalf("unexpected initial result: %#v", first)
 	}
-	if len(*quitCalls) != 0 {
-		t.Fatalf(".bot exit should not quit before confirmation, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 0 {
+		t.Fatalf(".bot exit should not quit before confirmation, got %#v", got)
 	}
 
 	confirmKey := getDismissConfirmKeyForGroup(ctx, msg.Sender.UserID, msg.GroupID)
@@ -430,8 +525,8 @@ func TestBotExitMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	if !second.Matched || !second.Solved {
 		t.Fatalf("unexpected confirmed result: %#v", second)
 	}
-	if len(*quitCalls) != 1 || (*quitCalls)[0] != testMilkyOwnerGroupQQID {
-		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 1 || got[0] != testMilkyOwnerGroupQQID {
+		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", got)
 	}
 }
 
@@ -439,14 +534,15 @@ func TestBotQuitMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	d, _, _, cleanup := newExecuteNewTestDice(t)
 	defer cleanup()
 
-	ctx, msg, quitCalls := newMilkyQuitCommandTestContext(t, d, "QQ:9012", testMilkyOwnerGroupID, "MilkyBotQuitGroup")
+	ctx, msg, harness, closeHarness := newMilkyQuitCommandTestContext(t, d, "QQ:9012", testMilkyOwnerGroupID, "MilkyBotQuitGroup")
+	defer closeHarness()
 
 	first := d.CmdMap["bot"].Solve(ctx, msg, &CmdArgs{Args: []string{"quit"}})
 	if !first.Matched || !first.Solved {
 		t.Fatalf("unexpected initial result: %#v", first)
 	}
-	if len(*quitCalls) != 0 {
-		t.Fatalf(".bot quit should not quit before confirmation, got %#v", *quitCalls)
+	if got := harness.quitGroupSnapshot(); len(got) != 0 {
+		t.Fatalf(".bot quit should not quit before confirmation, got %#v", got)
 	}
 
 	confirmKey := getDismissConfirmKeyForGroup(ctx, msg.Sender.UserID, msg.GroupID)
@@ -459,45 +555,17 @@ func TestBotQuitMilkyOwnerRequiresConfirmationBeforeQuit(t *testing.T) {
 	if !second.Matched || !second.Solved {
 		t.Fatalf("unexpected confirmed result: %#v", second)
 	}
-	if len(*quitCalls) != 1 || (*quitCalls)[0] != testMilkyOwnerGroupQQID {
-		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", *quitCalls)
-	}
-}
-
-func TestShouldDismissRequireOwnerConfirmMilkyNilMember(t *testing.T) {
-	pa := &PlatformAdapterMilky{
-		IntentSession: &milky.Session{},
-		getGroupMemberInfo: func(_ *milky.Session, _, _ int64, _ bool) (*milky.GroupMemberInfo, error) {
-			return nil, errors.New(errGetGroupMemberInfoNil)
-		},
-	}
-
-	ctx := &MsgContext{
-		EndPoint: &EndPointInfo{
-			EndPointInfoBase: EndPointInfoBase{
-				UserID:       "QQ:10003",
-				Platform:     "QQ",
-				ProtocolType: "milky",
-			},
-			Adapter: pa,
-		},
-	}
-
-	needConfirm, checked, detail := shouldDismissRequireOwnerConfirm(ctx, "QQ-Group:2007")
-	if checked || needConfirm {
-		t.Fatalf("expected milky nil member result to fail check, got needConfirm=%v checked=%v detail=%q", needConfirm, checked, detail)
-	}
-	if !strings.Contains(detail, errGetGroupMemberInfoNil) {
-		t.Fatalf("expected nil-member detail, got %q", detail)
+	if got := harness.quitGroupSnapshot(); len(got) != 1 || got[0] != testMilkyOwnerGroupQQID {
+		t.Fatalf("expected exactly one milky quit call for group 2010, got %#v", got)
 	}
 }
 
 func TestShouldDismissRequireOwnerConfirmMilkyEmptyRole(t *testing.T) {
+	session, _, cleanup := newMilkyRESTHarness(t, "", "", 2008, 10004)
+	defer cleanup()
+
 	pa := &PlatformAdapterMilky{
-		IntentSession: &milky.Session{},
-		getGroupMemberInfo: func(_ *milky.Session, _, _ int64, _ bool) (*milky.GroupMemberInfo, error) {
-			return &milky.GroupMemberInfo{}, nil
-		},
+		IntentSession: session,
 	}
 
 	ctx := &MsgContext{

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -33,10 +33,6 @@ type PlatformAdapterMilky struct {
 	MilkyProcess      *procs.Process  `json:"-" yaml:"-"`
 	BuiltInLoginState MilkyLoginState `json:"loginState" yaml:"-"`
 	QrCodeData        []byte          `json:"-"                          yaml:"-"`
-
-	getGroupMemberInfo func(session *milky.Session, groupID, userID int64, noCache bool) (*milky.GroupMemberInfo, error)         `json:"-" yaml:"-"`
-	sendGroupMessage   func(session *milky.Session, groupID int64, elements *[]milky.IMessageElement) (*milky.MessageRet, error) `json:"-" yaml:"-"`
-	quitGroup          func(session *milky.Session, groupID int64) error                                                         `json:"-" yaml:"-"`
 }
 
 type MilkyLoginState int64
@@ -58,7 +54,7 @@ func (pa *PlatformAdapterMilky) SendSegmentToGroup(ctx *MsgContext, groupID stri
 		return
 	}
 	elements := ParseMessageToMilky(msg)
-	ret, err := pa.callSendGroupMessage(id, &elements)
+	ret, err := pa.IntentSession.SendGroupMessage(id, &elements)
 	if err != nil {
 		log.Errorf("Failed to send group message to %s: %v", groupID, err)
 		return
@@ -709,7 +705,7 @@ func (pa *PlatformAdapterMilky) SendToGroup(ctx *MsgContext, groupID string, tex
 		log.Debugf("No valid message elements to send to group %s", groupID)
 		ret = &milky.MessageRet{}
 	} else {
-		ret, err = pa.callSendGroupMessage(id, &elements)
+		ret, err = pa.IntentSession.SendGroupMessage(id, &elements)
 	}
 	if err != nil {
 		log.Errorf("Failed to send group message to %s: %v", groupID, err)
@@ -771,7 +767,7 @@ func (pa *PlatformAdapterMilky) QuitGroup(ctx *MsgContext, groupID string) {
 		log.Errorf("Invalid group ID %s: %v", groupID, err)
 		return
 	}
-	err = pa.callQuitGroup(id)
+	err = pa.IntentSession.QuitGroup(id)
 	if err != nil {
 		log.Errorf("Failed to quit group %s: %v", groupID, err)
 		return
@@ -779,59 +775,26 @@ func (pa *PlatformAdapterMilky) QuitGroup(ctx *MsgContext, groupID string) {
 	log.Infof("Successfully quit group %s", groupID)
 }
 
-func (pa *PlatformAdapterMilky) GetGroupMemberRole(groupID string, userID string) (string, error) {
+func (pa *PlatformAdapterMilky) GetGroupMemberInfo(groupID string, userID string) (*milky.GroupMemberInfo, error) {
 	if pa == nil || pa.IntentSession == nil {
-		return "", errors.New("milky session unavailable")
+		return nil, errors.New("milky session unavailable")
 	}
 
 	rawGroupID := strings.TrimSpace(ExtractQQGroupID(groupID))
 	rawUserID := strings.TrimSpace(ExtractQQUserID(userID))
 	if rawGroupID == "" || rawUserID == "" {
-		return "", errors.New("cannot resolve milky group/user id")
+		return nil, errors.New("cannot resolve milky group/user id")
 	}
 
 	groupIDInt, err := strconv.ParseInt(rawGroupID, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid milky group id %q: %w", groupID, err)
+		return nil, fmt.Errorf("invalid milky group id %q: %w", groupID, err)
 	}
 	userIDInt, err := strconv.ParseInt(rawUserID, 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("invalid milky user id %q: %w", userID, err)
+		return nil, fmt.Errorf("invalid milky user id %q: %w", userID, err)
 	}
-
-	memberInfo, err := pa.callGetGroupMemberInfo(groupIDInt, userIDInt, false)
-	if err != nil {
-		return "", err
-	}
-	if memberInfo == nil {
-		return "", errors.New(errGetGroupMemberInfoNil)
-	}
-	role, ok := parseQQGroupRole(memberInfo.Role)
-	if !ok {
-		return "", errors.New(errGetGroupMemberInfoEmptyRole)
-	}
-	return role, nil
-}
-
-func (pa *PlatformAdapterMilky) callGetGroupMemberInfo(groupID, userID int64, noCache bool) (*milky.GroupMemberInfo, error) {
-	if pa.getGroupMemberInfo != nil {
-		return pa.getGroupMemberInfo(pa.IntentSession, groupID, userID, noCache)
-	}
-	return pa.IntentSession.GetGroupMemberInfo(groupID, userID, noCache)
-}
-
-func (pa *PlatformAdapterMilky) callSendGroupMessage(groupID int64, elements *[]milky.IMessageElement) (*milky.MessageRet, error) {
-	if pa.sendGroupMessage != nil {
-		return pa.sendGroupMessage(pa.IntentSession, groupID, elements)
-	}
-	return pa.IntentSession.SendGroupMessage(groupID, elements)
-}
-
-func (pa *PlatformAdapterMilky) callQuitGroup(groupID int64) error {
-	if pa.quitGroup != nil {
-		return pa.quitGroup(pa.IntentSession, groupID)
-	}
-	return pa.IntentSession.QuitGroup(groupID)
+	return pa.IntentSession.GetGroupMemberInfo(groupIDInt, userIDInt, false)
 }
 
 func (pa *PlatformAdapterMilky) SetGroupCardName(ctx *MsgContext, cardName string) {


### PR DESCRIPTION
rt
已自测通过，如图：

![Screenshot_2026-03-24-23-20-58-517_com tencent mobileqq](https://github.com/user-attachments/assets/9a834825-6f17-4fb9-ac3e-3a515811062a)
