### PR TITLE
feat: 在保持 CQCode/海豹码兼容的前提下引入内部统一消息 IR

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -9,7 +9,6 @@ import (
 	"unicode"
 
 	ds "github.com/sealdice/dicescript"
-	"github.com/tidwall/gjson"
 
 	"sealdice-core/message"
 )
@@ -380,116 +379,7 @@ func (cmdArgs *CmdArgs) commandParseNew(ctx *MsgContext, msg *Message, isParseEx
 
 // extractResultFromSegments 从消息段中提取纯文本内容 部分文本使用了CQ码。问题的原因在于，CmdArgs的参数可能是图片等其他数据，但CmdArgs缺乏对这个功能的支持。
 func extractResultFromSegments(segments []message.IMessageElement) string {
-	cqMessage := strings.Builder{}
-	var foundFirstText bool
-	for _, v := range segments {
-		// 警告，这个函数不要复用到其他地方，如果复用，请删掉下面这个代码
-		// 代码的意思是：从第一个有文本的元素开始，后面的全部认为是参数。
-		// 检查是否是文本元素
-		if v.Type() == message.Text {
-			foundFirstText = true
-		}
-		// 只有找到第一个文本元素后才开始将剩下的拼凑到结果中
-		if !foundFirstText {
-			continue
-		}
-		switch v.Type() {
-		case message.At:
-			// 跳过 @ 信息，因为已通过 parseAtInfo 单独处理
-			// 不要转换为 CQ 码，否则会污染 CleanArgs 导致表达式解析失败
-			continue
-		case message.Text:
-			res, ok := v.(*message.TextElement)
-			if !ok {
-				continue
-			}
-			cqMessage.WriteString(res.Content)
-		case message.Face:
-			res, ok := v.(*message.FaceElement)
-			if !ok {
-				continue
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:face,id=%v]", res.FaceID)
-		case message.File:
-			res, ok := v.(*message.FileElement)
-			if !ok {
-				continue
-			}
-			fileVal := res.File
-			if fileVal == "" {
-				fileVal = res.URL
-			}
-			if fileVal == "" {
-				continue
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:file,file=%v]", fileVal)
-		case message.Image:
-			res, ok := v.(*message.ImageElement)
-			if !ok {
-				continue
-			}
-			url := res.URL
-			if res.URL == "" {
-				url = res.File.URL
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:image,file=%v]", url)
-		case message.Record:
-			res, ok := v.(*message.RecordElement)
-			if !ok {
-				continue
-			}
-			var recordFile string
-			if res.File != nil {
-				recordFile = res.File.URL
-				if recordFile == "" {
-					recordFile = res.File.File
-				}
-			}
-			if recordFile == "" {
-				continue
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:record,file=%v]", recordFile)
-		case message.Reply:
-			res, ok := v.(*message.ReplyElement)
-			if !ok {
-				continue
-			}
-			parseInt, err := strconv.Atoi(res.ReplySeq)
-			if err != nil {
-				continue
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:reply,id=%v]", parseInt)
-		case message.TTS:
-			res, ok := v.(*message.TTSElement)
-			if !ok {
-				continue
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:tts,text=%v]", res.Content)
-		case message.Poke:
-			res, ok := v.(*message.PokeElement)
-			if !ok {
-				continue
-			}
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:poke,qq=%v]", res.Target)
-		default:
-			// 不是标准类型的情况
-			res, ok := v.(*message.DefaultElement)
-			if !ok {
-				continue
-			}
-			// 将其转换为CQ码
-			var (
-				cqParamParts []string
-			)
-			dMap := gjson.ParseBytes(res.Data).Map()
-			for paramStr, paramValue := range dMap {
-				cqParamParts = append(cqParamParts, fmt.Sprintf("%s=%s", paramStr, paramValue))
-			}
-			cqParam := strings.Join(cqParamParts, ",")
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:%s,%s]", res.RawType, cqParam)
-		}
-	}
-	return cqMessage.String()
+	return message.SegmentsToLegacyCQText(segments)
 }
 
 // parseAtInfo 解析@信息，设置相关的@状态标志

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -40,13 +40,13 @@ import (
 // the bot tries to send.  A buffered channel makes it easy to wait for async
 // replies from PreTriggerCommand.
 type mockPlatformAdapter struct {
-	mu              sync.Mutex
-	groupMsgs       []string
-	personMsgs      []string
-	groupSegmentMsg [][]message.IMessageElement
+	mu               sync.Mutex
+	groupMsgs        []string
+	personMsgs       []string
+	groupSegmentMsg  [][]message.IMessageElement
 	personSegmentMsg [][]message.IMessageElement
-	quitGroups      []string
-	msgCh           chan string
+	quitGroups       []string
+	msgCh            chan string
 }
 
 // compile-time check

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -40,11 +40,13 @@ import (
 // the bot tries to send.  A buffered channel makes it easy to wait for async
 // replies from PreTriggerCommand.
 type mockPlatformAdapter struct {
-	mu         sync.Mutex
-	groupMsgs  []string
-	personMsgs []string
-	quitGroups []string
-	msgCh      chan string
+	mu              sync.Mutex
+	groupMsgs       []string
+	personMsgs      []string
+	groupSegmentMsg [][]message.IMessageElement
+	personSegmentMsg [][]message.IMessageElement
+	quitGroups      []string
+	msgCh           chan string
 }
 
 // compile-time check
@@ -52,6 +54,15 @@ var _ PlatformAdapter = (*mockPlatformAdapter)(nil)
 
 func newMockPlatformAdapter() *mockPlatformAdapter {
 	return &mockPlatformAdapter{msgCh: make(chan string, 32)}
+}
+
+func cloneSegments(src []message.IMessageElement) []message.IMessageElement {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]message.IMessageElement, len(src))
+	copy(out, src)
+	return out
 }
 
 // waitForMsg blocks until a message arrives or the timeout elapses.
@@ -99,9 +110,31 @@ func (m *mockPlatformAdapter) MemberKick(_ string, _ string)            {}
 func (m *mockPlatformAdapter) GetGroupInfoAsync(_ string)               {}
 func (m *mockPlatformAdapter) EditMessage(_ *MsgContext, _, _ string)   {}
 func (m *mockPlatformAdapter) RecallMessage(_ *MsgContext, _ string)    {}
-func (m *mockPlatformAdapter) SendSegmentToGroup(_ *MsgContext, _ string, _ []message.IMessageElement, _ string) {
+func (m *mockPlatformAdapter) SendSegmentToGroup(_ *MsgContext, _ string, segs []message.IMessageElement, _ string) {
+	m.mu.Lock()
+	m.groupSegmentMsg = append(m.groupSegmentMsg, cloneSegments(segs))
+	m.mu.Unlock()
+	text := message.SegmentsToLegacyCQText(segs)
+	if text == "" {
+		text = message.SegmentsToText(segs)
+	}
+	select {
+	case m.msgCh <- text:
+	default:
+	}
 }
-func (m *mockPlatformAdapter) SendSegmentToPerson(_ *MsgContext, _ string, _ []message.IMessageElement, _ string) {
+func (m *mockPlatformAdapter) SendSegmentToPerson(_ *MsgContext, _ string, segs []message.IMessageElement, _ string) {
+	m.mu.Lock()
+	m.personSegmentMsg = append(m.personSegmentMsg, cloneSegments(segs))
+	m.mu.Unlock()
+	text := message.SegmentsToLegacyCQText(segs)
+	if text == "" {
+		text = message.SegmentsToText(segs)
+	}
+	select {
+	case m.msgCh <- text:
+	default:
+	}
 }
 func (m *mockPlatformAdapter) SendFileToPerson(_ *MsgContext, _ string, _ string, _ string) {}
 func (m *mockPlatformAdapter) SendFileToGroup(_ *MsgContext, _ string, _ string, _ string)  {}
@@ -408,6 +441,91 @@ func TestExecuteNew_Segment_TextReconstructed(t *testing.T) {
 	_, ok := adapter.waitForMsg(2 * time.Second)
 	if !ok {
 		t.Fatal("timeout: command in text segment was not processed")
+	}
+	if msg.Message != ".r 2d6" {
+		t.Fatalf("Message should be reconstructed from Segment, got %q", msg.Message)
+	}
+}
+
+// TestExecuteNew_TextOnly_BridgedToSegments verifies legacy text-only inbound
+// messages are normalized to segment-based representation before parsing.
+func TestExecuteNew_TextOnly_BridgedToSegments(t *testing.T) {
+	d, ep, adapter, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	msg := &Message{
+		Platform:    "QQ",
+		MessageType: "group",
+		GroupID:     "QQ-Group:9527",
+		GroupName:   "TestGroup",
+		Time:        time.Now().Unix(),
+		Sender:      SenderBase{UserID: "QQ:222", Nickname: "Tester"},
+		Message:     ".r 1d6",
+		Segment:     nil, // legacy input: only Message text
+	}
+
+	d.ImSession.ExecuteNew(ep, msg)
+
+	_, ok := adapter.waitForMsg(2 * time.Second)
+	if !ok {
+		t.Fatal("timeout: legacy text-only message was not processed")
+	}
+	if len(msg.Segment) == 0 {
+		t.Fatal("expected text-only message to be bridged into Segment")
+	}
+	textElem, ok := msg.Segment[0].(*message.TextElement)
+	if !ok || textElem.Content != ".r 1d6" {
+		t.Fatalf("unexpected bridged segment: %#v", msg.Segment[0])
+	}
+}
+
+// TestExecuteNew_SegmentPreferredForCommandParsing verifies when Message and
+// Segment disagree, Segment remains the source for command parsing.
+func TestExecuteNew_SegmentPreferredForCommandParsing(t *testing.T) {
+	d, ep, adapter, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	msg := &Message{
+		Platform:    "QQ",
+		MessageType: "group",
+		GroupID:     "QQ-Group:789",
+		GroupName:   "TestGroup",
+		Time:        time.Now().Unix(),
+		Sender:      SenderBase{UserID: "QQ:222", Nickname: "Tester"},
+		Message:     "just chatting", // conflicting legacy view
+		Segment: []message.IMessageElement{
+			&message.TextElement{Content: ".r 2d6"},
+		},
+	}
+
+	d.ImSession.ExecuteNew(ep, msg)
+
+	_, ok := adapter.waitForMsg(2 * time.Second)
+	if !ok {
+		t.Fatal("timeout: expected command from Segment to be processed")
+	}
+}
+
+// TestMockAdapter_SendSegmentCompatibility verifies smoke test adapter can
+// observe segment-path sending while still yielding a text projection.
+func TestMockAdapter_SendSegmentCompatibility(t *testing.T) {
+	adapter := newMockPlatformAdapter()
+	segs := []message.IMessageElement{
+		&message.TextElement{Content: "hello"},
+		&message.AtElement{Target: "123"},
+	}
+
+	adapter.SendSegmentToGroup(nil, "QQ-Group:1", segs, "")
+
+	if len(adapter.groupSegmentMsg) != 1 {
+		t.Fatalf("expected one segment send record, got %d", len(adapter.groupSegmentMsg))
+	}
+	gotText, ok := adapter.waitForMsg(500 * time.Millisecond)
+	if !ok {
+		t.Fatal("expected text projection emitted for segment send")
+	}
+	if gotText == "" {
+		t.Fatal("expected non-empty text projection for segment send")
 	}
 }
 

--- a/dice/im_helpers.go
+++ b/dice/im_helpers.go
@@ -14,6 +14,7 @@ import (
 	ds "github.com/sealdice/dicescript"
 
 	"sealdice-core/logger"
+	"sealdice-core/message"
 	"sealdice-core/utils/panicHandler"
 )
 
@@ -472,6 +473,20 @@ func ReplyGroup(ctx *MsgContext, msg *Message, text string) {
 	ReplyGroupRaw(ctx, msg, text, "")
 }
 
+// ReplyGroupSegmentRaw 是 segment 主链路入口的兼容封装。
+// 当前仍复用文本发送链路以保持行为一致，后续可直接切到 adapter 的 SendSegmentToGroup。
+func ReplyGroupSegmentRaw(ctx *MsgContext, msg *Message, segments []message.IMessageElement, flag string) {
+	text := strings.TrimSpace(message.SegmentsToLegacyCQText(segments))
+	if text == "" {
+		text = strings.TrimSpace(message.SegmentsToText(segments))
+	}
+	ReplyGroupRaw(ctx, msg, text, flag)
+}
+
+func ReplyGroupSegment(ctx *MsgContext, msg *Message, segments []message.IMessageElement) {
+	ReplyGroupSegmentRaw(ctx, msg, segments, "")
+}
+
 func ReplyPersonRaw(ctx *MsgContext, msg *Message, text string, flag string) {
 	if ctx.AliasPrefixText != "" {
 		text = ctx.AliasPrefixText + text
@@ -570,6 +585,20 @@ func CrossMsgBySearch(se *IMSession, p, t, txt string, pr bool) bool {
 
 func ReplyPerson(ctx *MsgContext, msg *Message, text string) {
 	ReplyPersonRaw(ctx, msg, text, "")
+}
+
+// ReplyPersonSegmentRaw 是 segment 主链路入口的兼容封装。
+// 当前仍复用文本发送链路以保持行为一致，后续可直接切到 adapter 的 SendSegmentToPerson。
+func ReplyPersonSegmentRaw(ctx *MsgContext, msg *Message, segments []message.IMessageElement, flag string) {
+	text := strings.TrimSpace(message.SegmentsToLegacyCQText(segments))
+	if text == "" {
+		text = strings.TrimSpace(message.SegmentsToText(segments))
+	}
+	ReplyPersonRaw(ctx, msg, text, flag)
+}
+
+func ReplyPersonSegment(ctx *MsgContext, msg *Message, segments []message.IMessageElement) {
+	ReplyPersonSegmentRaw(ctx, msg, segments, "")
 }
 
 func SendFileToSenderRaw(ctx *MsgContext, msg *Message, path string, flag string) {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -59,6 +59,30 @@ type Message struct {
 	Segment []message.IMessageElement `jsbind:"segment" json:"-" yaml:"-"`
 }
 
+// normalizeForPipeline 保证消息同时具备 segment 与兼容文本视图：
+// - Segment 作为内部主表示
+// - Message 作为兼容文本视图
+func (msg *Message) normalizeForPipeline() {
+	if msg == nil {
+		return
+	}
+	if len(msg.Segment) == 0 && msg.Message != "" {
+		// 入站桥接：从旧文本格式构造 segment，禁用资源解析避免文件/网络访问。
+		msg.Segment = message.ConvertStringMessage(
+			msg.Message,
+			message.WithResolveResource(false),
+		)
+		if len(msg.Segment) == 0 {
+			msg.Segment = []message.IMessageElement{
+				&message.TextElement{Content: msg.Message},
+			}
+		}
+	}
+	if msg.Message == "" && len(msg.Segment) > 0 {
+		msg.Message = message.SegmentsToText(msg.Segment)
+	}
+}
+
 // GroupPlayerInfo 这是一个YamlWrapper，没有实际作用
 // 原因见 https://github.com/go-yaml/yaml/issues/712
 // type GroupPlayerInfo struct {
@@ -724,6 +748,7 @@ func (ctx *MsgContext) fillPrivilege(msg *Message) int {
 
 func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 	d := s.Parent
+	msg.normalizeForPipeline()
 
 	mctx := &MsgContext{}
 	mctx.Dice = d
@@ -1097,6 +1122,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 // 这个 ExcuteNew 方法优化了对消息段的解析，其他平台应当尽快实现消息段解析并使用这个方法
 func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 	d := s.Parent
+	msg.normalizeForPipeline()
 
 	mctx := &MsgContext{}
 	mctx.Dice = d
@@ -1105,16 +1131,6 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 	mctx.Session = s
 	mctx.EndPoint = ep
 	log := d.Logger
-
-	// 处理消息段，如果 2.0 要完全抛弃依赖 Message.Message 的字符串解析，把这里删掉
-	if msg.Message == "" {
-		for _, elem := range msg.Segment {
-			// 类型断言
-			if e, ok := elem.(*message.TextElement); ok {
-				msg.Message += e.Content
-			}
-		}
-	}
 
 	if msg.MessageType != "group" && msg.MessageType != "private" {
 		return

--- a/docs/message-ir.md
+++ b/docs/message-ir.md
@@ -1,0 +1,230 @@
+# Message IR / UniMessage 设计说明
+
+## 目标
+
+海豹仍然继续支持用户侧输入：
+
+- 普通文本
+- CQCode
+- 海豹码
+
+但它们不再应当作为海豹内部消息流转时的“主协议”。
+
+当前目标是把海豹内部消息统一到一套中间表示，也就是 Message IR / UniMessage：
+
+- 外层使用 `MessageEnvelope` 承载元信息
+- 内容使用 `Segments []message.IMessageElement`
+
+在当前实现中，`Segments` 就是实际落地的 UniMessage。
+
+## 核心模型
+
+当前消息外层结构位于：
+
+- `dice/im_session.go`
+
+核心规则：
+
+- `Message.Segment` 是唯一真源
+- `Message.Message` 是兼容文本视图
+
+也就是说：
+
+1. 业务逻辑应优先以 `Segment` 为准
+2. `Message` 只用于兼容旧逻辑、旧扩展、旧日志文本消费
+
+这套主从关系由：
+
+- `(*Message).normalizeForPipeline()`
+
+负责收口。
+
+它的职责是：
+
+1. 当消息只有旧文本时，把旧文本桥接成 `Segment`
+2. 当消息只有 `Segment` 时，派生兼容 `Message`
+
+## 元素集合
+
+当前 Message IR 元素定义位于：
+
+- `message/message.go`
+
+当前最小元素集合包括：
+
+- `TextElement`
+- `AtElement`
+- `ReplyElement`
+- `ImageElement`
+- `RecordElement`
+- `FileElement`
+- `FaceElement`
+- `PokeElement`
+- `TTSElement`
+- `DefaultElement`
+
+其中 `DefaultElement` 必须保留，用于承接未知平台消息段或暂未支持的消息能力，避免静默丢失信息。
+
+## 解析层
+
+用户侧旧语法的统一入口目前仍然是：
+
+- `message.ConvertStringMessage()`
+
+它负责把：
+
+- 普通文本
+- CQCode
+- 海豹码
+
+统一转换为 `Segments`。
+
+为了避免在“仅仅做桥接”时触发文件读取或网络访问，当前还支持：
+
+- `message.WithResolveResource(false)`
+
+这个选项用于：
+
+- 把旧文本标准化为 `Segment`
+- 但不去真的解析图片/文件资源
+
+这样可以保证入口统一时不会引入额外 IO 副作用。
+
+## 文本视图
+
+当前已经补出的文本投影能力位于：
+
+- `message/message_segment_text.go`
+
+目前已有三类基础能力：
+
+- `SegmentsToText()`
+  - 兼容文本视图
+- `SegmentsToLegacyCQText()`
+  - 旧 CQ 文本兼容视图
+- `ToSegmentText()` / `ParseSegmentText()`
+  - 带占位符映射的文本视图基础能力
+
+当前建议使用方式：
+
+- 兼容旧命令逻辑：`SegmentsToLegacyCQText()`
+- 兼容普通文本视图：`SegmentsToText()`
+
+后续目标：
+
+- 给命令层补真正的 `CommandTextView`
+- 逐步减少“segment 再拼回 CQ”的桥接依赖
+
+## 执行入口
+
+当前执行入口状态如下：
+
+- `IMSession.ExecuteNew()` 是 segment-first 的主执行入口
+- `IMSession.Execute()` 也已经会先做消息标准化
+
+这意味着：
+
+- 海豹现在已经具备统一入站标准化能力
+- 即使有些旧逻辑还在读 `Message.Message`，消息在进入主链路前也已经尽量统一成了 `Segment`
+
+## 发送链路
+
+当前发送方向的目标是：
+
+- 业务层产出 `Segments`
+- adapter 负责把 `Segments` 编码成平台 payload
+
+兼容规则是：
+
+- `SendToGroup(text)` / `SendToPerson(text)` 继续保留
+- 但它们应该只做：
+  - `text -> ConvertStringMessage(text) -> SendSegment*`
+
+目前这条规则已经在第一批 adapter 上落地。
+
+## 当前已对齐的 adapter
+
+目前已完成第一轮 segment-first 发送或 segment-preserving 入站改造的 adapter 包括：
+
+- `platform_adapter_gocq.go`
+- `platform_adapter_walleq.go`
+- `platform_adapter_milky.go`
+- `platform_adapter_discord.go`
+- `platform_adapter_kook.go`
+- `platform_adapter_dodo.go`
+- `platform_adapter_satori.go`
+
+说明：
+
+- 这些 adapter 并不都已经做到“完全原生结构化入站”
+- 但至少已经进入同一套 `Segments` 主链路
+- `SealChat` 本轮未改，因为需要考虑项目对接影响
+- `Red` 本轮不再考虑
+
+## 目前已经统一到什么程度
+
+当前已经做到的部分：
+
+1. 海豹已经有实际上的内部 Message IR
+   - 即 `Message.Segment`
+
+2. 旧文本输入已经能够统一桥接到 IR
+   - 通过 `normalizeForPipeline()`
+
+3. 第一批 adapter 已能以 `SendSegment*` 作为主发送链路
+
+4. smoke tests 已更新为覆盖：
+   - 旧文本桥接到 segment
+   - `Segment` 为真源
+   - `Message` 为兼容视图
+
+## 目前还没有完全统一的部分
+
+当前仍处于过渡状态的部分：
+
+1. 命令解析仍然在部分地方依赖 Legacy CQ 文本桥
+   - `dice/cmd_parse.go`
+
+2. 文本切分仍然是按旧的文本/CQ 模型工作
+   - `utils/split_text.go`
+
+3. 日志、敏感词、扩展等仍大量消费 `Message.Message`
+   - 而不是专门的 IR 视图
+
+4. 一些 adapter 的入站只是“最小 segment 化”
+   - 不是完整的原生结构化解析
+
+## 当前阶段判断
+
+当前状态可以这样定义：
+
+- 是，海豹现在已经有了内部 UniMessage / Message IR
+- 是，入口已经基本统一到 segment-first 语义
+- 是，第一批 adapter 已经开始围绕它工作
+- 否，整个项目还没有完全进入“只认 UniMessage”的最终状态
+
+换句话说：
+
+- 这不是还在概念设计阶段
+- 也不是已经彻底完成
+- 而是已经进入“IR 已建立、入口已统一、部分 adapter 已切换、业务消费层仍需继续收口”的中间阶段
+
+## 下一步建议
+
+下一步最值得继续推进的工作是：
+
+1. 给命令层补 `CommandTextView`
+   - 逐步替代 `SegmentsToLegacyCQText()`
+
+2. 让消息切分变成 segment-aware
+   - 不再只依赖 CQ 文本保护式切分
+
+3. 继续安全地推进其他 adapter
+   - 例如 `official_qq`
+   - 以及不涉及外部协议对接风险的平台
+
+4. 逐步让业务消费方从 `Message.Message` 转向 IR 视图
+   - 命令
+   - 日志
+   - 敏感词
+   - 扩展

--- a/message/message.go
+++ b/message/message.go
@@ -584,8 +584,9 @@ func SealCodeToCqCode(text string) string {
 
 // convertConfig ConvertStringMessage的配置
 type convertConfig struct {
-	logger  *zap.SugaredLogger
-	onError func(err error, cqType string, cqArgs map[string]string)
+	logger          *zap.SugaredLogger
+	onError         func(err error, cqType string, cqArgs map[string]string)
+	resolveResource bool
 }
 
 // ConvertOption ConvertStringMessage的选项函数
@@ -605,10 +606,54 @@ func WithOnError(fn func(err error, cqType string, cqArgs map[string]string)) Co
 	return func(c *convertConfig) { c.onError = fn }
 }
 
+// WithResolveResource 设置是否在转换时解析资源文件（如 image/file/record）。
+// 默认 true 以保持历史行为；对于入站消息标准化建议传 false，避免无意义文件/网络访问。
+func WithResolveResource(enabled bool) ConvertOption {
+	return func(c *convertConfig) {
+		c.resolveResource = enabled
+	}
+}
+
+func toElementWithConfig(t string, dMap map[string]string, cfg *convertConfig) (IMessageElement, error) {
+	if cfg == nil || cfg.resolveResource {
+		return toElement(t, dMap)
+	}
+
+	switch t {
+	case "file":
+		return &FileElement{
+			File: strings.TrimSpace(dMap["file"]),
+			URL:  strings.TrimSpace(dMap["url"]),
+		}, nil
+	case "image":
+		file := strings.TrimSpace(dMap["file"])
+		urlVal := strings.TrimSpace(dMap["url"])
+		if urlVal == "" {
+			urlVal = file
+		}
+		return &ImageElement{
+			File: &FileElement{File: file, URL: urlVal},
+			URL:  urlVal,
+		}, nil
+	case "record":
+		file := strings.TrimSpace(dMap["file"])
+		urlVal := strings.TrimSpace(dMap["url"])
+		if urlVal == "" {
+			urlVal = file
+		}
+		return &RecordElement{
+			File: &FileElement{File: file, URL: urlVal},
+		}, nil
+	default:
+		return toElement(t, dMap)
+	}
+}
+
 func ConvertStringMessage(raw string, opts ...ConvertOption) (r []IMessageElement) {
 	cfg := &convertConfig{
 		// 默认使用全局logger，确保控制台+前端日志可见
-		logger: zap.S().Named("message"),
+		logger:          zap.S().Named("message"),
+		resolveResource: true,
 	}
 	for _, opt := range opts {
 		opt(cfg)
@@ -657,7 +702,7 @@ func ConvertStringMessage(raw string, opts ...ConvertOption) (r []IMessageElemen
 	}
 
 	saveCQCode := func() {
-		elem, err := toElement(arg, dMap)
+		elem, err := toElementWithConfig(arg, dMap, cfg)
 		if err != nil {
 			// 错误时跳过该CQ码，不原样发出，但记录日志
 			var fe *CQFileError

--- a/message/message_segment_text.go
+++ b/message/message_segment_text.go
@@ -1,0 +1,213 @@
+package message
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// SegmentText 表示带占位符的文本和占位符映射，用于将 segment 投影到文本视图。
+type SegmentText struct {
+	Text         string
+	Placeholders map[int]IMessageElement
+}
+
+// ToSegmentText 将消息元素转换为带占位符的文本表示。
+func ToSegmentText(segments []IMessageElement) SegmentText {
+	var placeholders map[int]IMessageElement
+	var builder strings.Builder
+	for idx, elem := range segments {
+		if textElem, ok := elem.(*TextElement); ok {
+			builder.WriteString(textElem.Content)
+			continue
+		}
+		placeholderIndex := idx + 1
+		if placeholders == nil {
+			placeholders = make(map[int]IMessageElement)
+		}
+		placeholders[placeholderIndex] = elem
+		builder.WriteByte('$')
+		builder.WriteString(strconv.Itoa(placeholderIndex))
+	}
+	return SegmentText{
+		Text:         builder.String(),
+		Placeholders: placeholders,
+	}
+}
+
+// ToMessageElements 根据占位符映射还原消息元素切片。
+func (st SegmentText) ToMessageElements() []IMessageElement {
+	if st.Text == "" {
+		return nil
+	}
+	var result []IMessageElement
+	var builder strings.Builder
+	for i := 0; i < len(st.Text); {
+		if st.Text[i] != '$' {
+			r, size := utf8.DecodeRuneInString(st.Text[i:])
+			builder.WriteRune(r)
+			i += size
+			continue
+		}
+		if i+1 >= len(st.Text) || st.Text[i+1] < '0' || st.Text[i+1] > '9' {
+			builder.WriteByte('$')
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(st.Text) && st.Text[j] >= '0' && st.Text[j] <= '9' {
+			j++
+		}
+		idxStr := st.Text[i+1 : j]
+		placeholderIndex, err := strconv.Atoi(idxStr)
+		if err != nil {
+			builder.WriteByte('$')
+			builder.WriteString(idxStr)
+			i = j
+			continue
+		}
+		elem, ok := st.Placeholders[placeholderIndex]
+		if !ok || elem == nil {
+			builder.WriteByte('$')
+			builder.WriteString(idxStr)
+			i = j
+			continue
+		}
+		if builder.Len() > 0 {
+			result = append(result, &TextElement{Content: builder.String()})
+			builder.Reset()
+		}
+		result = append(result, elem)
+		i = j
+	}
+	if builder.Len() > 0 {
+		result = append(result, &TextElement{Content: builder.String()})
+	}
+	return result
+}
+
+// SegmentsToText 返回用于命令解析/兼容文本的 segment 文本投影。
+func SegmentsToText(segments []IMessageElement) string {
+	return ToSegmentText(segments).Text
+}
+
+// ParseSegmentText 根据文本和占位符映射重建 segment。
+func ParseSegmentText(text string, placeholders map[int]IMessageElement) []IMessageElement {
+	return SegmentText{
+		Text:         text,
+		Placeholders: placeholders,
+	}.ToMessageElements()
+}
+
+// SegmentsToLegacyCQText 将内部消息元素转换为历史 CQ 文本视图，用于兼容旧命令解析流程。
+func SegmentsToLegacyCQText(segments []IMessageElement) string {
+	var cqMessage strings.Builder
+	var foundFirstText bool
+	for _, v := range segments {
+		if v.Type() == Text {
+			foundFirstText = true
+		}
+		if !foundFirstText {
+			continue
+		}
+		switch v.Type() {
+		case At:
+			// 旧流程在命令解析阶段单独处理 @，这里保持一致。
+			continue
+		case Text:
+			res, ok := v.(*TextElement)
+			if ok {
+				cqMessage.WriteString(res.Content)
+			}
+		case Face:
+			res, ok := v.(*FaceElement)
+			if ok {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:face,id=%v]", res.FaceID)
+			}
+		case File:
+			res, ok := v.(*FileElement)
+			if !ok {
+				continue
+			}
+			fileVal := res.File
+			if fileVal == "" {
+				fileVal = res.URL
+			}
+			if fileVal != "" {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:file,file=%v]", fileVal)
+			}
+		case Image:
+			res, ok := v.(*ImageElement)
+			if !ok {
+				continue
+			}
+			urlVal := res.URL
+			if urlVal == "" && res.File != nil {
+				urlVal = res.File.URL
+				if urlVal == "" {
+					urlVal = res.File.File
+				}
+			}
+			if urlVal != "" {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:image,file=%v]", urlVal)
+			}
+		case Record:
+			res, ok := v.(*RecordElement)
+			if !ok {
+				continue
+			}
+			var recordFile string
+			if res.File != nil {
+				recordFile = res.File.URL
+				if recordFile == "" {
+					recordFile = res.File.File
+				}
+			}
+			if recordFile != "" {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:record,file=%v]", recordFile)
+			}
+		case Reply:
+			res, ok := v.(*ReplyElement)
+			if !ok {
+				continue
+			}
+			parseInt, err := strconv.Atoi(res.ReplySeq)
+			if err != nil {
+				continue
+			}
+			_, _ = fmt.Fprintf(&cqMessage, "[CQ:reply,id=%v]", parseInt)
+		case TTS:
+			res, ok := v.(*TTSElement)
+			if ok {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:tts,text=%v]", res.Content)
+			}
+		case Poke:
+			res, ok := v.(*PokeElement)
+			if ok {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:poke,qq=%v]", res.Target)
+			}
+		default:
+			res, ok := v.(*DefaultElement)
+			if !ok {
+				continue
+			}
+			dMap := map[string]interface{}{}
+			if len(res.Data) > 0 {
+				_ = json.Unmarshal(res.Data, &dMap)
+			}
+			var cqParamParts []string
+			for paramStr, paramValue := range dMap {
+				cqParamParts = append(cqParamParts, fmt.Sprintf("%s=%v", paramStr, paramValue))
+			}
+			cqParam := strings.Join(cqParamParts, ",")
+			if cqParam == "" {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:%s]", res.RawType)
+			} else {
+				_, _ = fmt.Fprintf(&cqMessage, "[CQ:%s,%s]", res.RawType, cqParam)
+			}
+		}
+	}
+	return cqMessage.String()
+}


### PR DESCRIPTION
close #771 
本 PR 基于 smallseal 进行消息入口统一化处理，作为为海豹引入内部统一消息 IR 的基建 PR。
*测试未进行，置为draft中

## Summary by Sourcery

在保持对传统 text/CQCode/海豹码 流程兼容的前提下，引入内部的「分段优先」消息归一化层（Message IR）。

新功能：
- 新增基于 Segment 的 Message IR 处理管线，其中 `Message.Segment` 作为主表示形式，`Message.Message` 作为从属的兼容性文本视图。
- 为群聊和私聊消息提供基于 Segment 的回复辅助方法（reply helpers），并与现有的基于文本的发送路径对接。
- 在字符串到 Segment 的转换过程中引入可配置的资源解析机制，以便对入站消息进行轻量级归一化，而不触发文件或网络访问。

增强改进：
- 在执行入口对入站消息进行归一化，确保 Segment / 文本视图一致；当二者同时存在时，在命令解析中优先使用 Segment。
- 添加工具，用于将 Segment 投影为文本或传统 CQ 风格文本，包括基于占位符的 `SegmentText` 辅助方法，以及从 Segment 元素进行 CQ 兼容的文本重建。
- 扩展 mock 平台适配器和测试，用于观察基于 Segment 的发送行为，同时仍为现有的冒烟测试提供文本投影。

文档：
- 添加设计文档，描述 Message IR / UniMessage 模型、其设计目标、元素集合、各平台适配器状态，以及向「分段优先」内部协议迁移的指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an internal segment-first message normalization layer (Message IR) while preserving compatibility with legacy text/CQCode/海豹码 flows.

New Features:
- Add a segment-based Message IR pipeline where Message.Segment is the primary representation and Message.Message acts as a derived compatibility text view.
- Provide segment-based reply helpers for group and personal messages that bridge to existing text-based sending paths.
- Introduce configurable resource resolution in string-to-segment conversion to allow lightweight normalization of inbound messages without triggering file or network access.

Enhancements:
- Normalize inbound messages at execution entry points to ensure consistent segment/text views and prefer segments for command parsing when both are present.
- Add utilities to project segments into text or legacy CQ-style text, including placeholder-based SegmentText helpers and CQ-compatible reconstruction from segment elements.
- Extend the mock platform adapter and tests to observe segment-based sending while still exposing a text projection for existing smoke tests.

Documentation:
- Add a design document describing the Message IR / UniMessage model, its goals, element set, adapter status, and migration guidelines toward a segment-first internal protocol.

</details>