### PR TITLE
chore: spam to ban on issue

### DIFF
--- a/.github/workflows/close-unread-issues.yml
+++ b/.github/workflows/close-unread-issues.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   check-then-close:
+    #    don't run on forks
+    if: ${{ github.repository == 'sealdice/sealdice-core' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -25,6 +27,56 @@ jobs:
           script: |
             const text = '我填写了简短且清晰明确的标题，以便开发者在翻阅 issue 列表时能快速确定大致问题。而不是“一个建议”、“卡住了”等';
             return new RegExp(`- \\[x\\]\\s*${text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`).test(context.payload.issue.body);
+
+      - name: Check Open Issues and Violations
+        id: judge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          REPO: ${{ github.repository }}
+          IGNORE_LABEL: "issue-checker-ignore"
+        run: |
+          OPEN_COUNT=$(gh issue list -R "$REPO" \
+            --author "$ISSUE_AUTHOR" \
+            --state open \
+            --exclude-label "$IGNORE_LABEL" \
+            --json number --jq '. | length')
+          
+          HAS_PREVIOUS_VIOLATION=$(gh issue list -R "$REPO" --author "$AUTHOR" --state all --label "violation" --json number --jq '. | length')
+          
+          echo "open_count=$OPEN_COUNT" >> $GITHUB_OUTPUT
+          echo "prev_violations=$HAS_PREVIOUS_VIOLATION" >> $GITHUB_OUTPUT
+
+      - name: Warn User
+        if: steps.judge.outputs.open_count > 10 && steps.judge.outputs.open_count <= 15 && steps.judge.outputs.prev_violations == 0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment $ISSUE --body "警告：您当前已拥有超过 10 个 Open Issue。此仓库有上限为 15 的 Issue 限制，如果此 Issue 有开启的必要，请让维护者添加 issue-checker-ignore 标签。否则请关闭一些不必要的 issue。"
+
+      - name: First Strike
+        if: steps.judge.outputs.open_count > 15 && steps.judge.outputs.prev_violations == 0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment $ISSUE --body "这是您的第一次警告。您已超过 15 个 Open Issue 限制。当前 Issue 已关闭并标记，再次违反将被封禁。"
+          gh issue edit $ISSUE --add-label "violation"
+          gh issue close $ISSUE --reason "not_planned"
+
+      - name: Second Strike - BAN
+        if: steps.judge.outputs.open_count > 15 && steps.judge.outputs.prev_violations > 0
+        env:
+          ADMIN_PAT: ${{ secrets.SEALDICE_ADMIN_PAT }}
+          ORG_NAME: "sealdice"
+          SPAMMER: ${{ github.event.issue.user.login }}
+        run: |
+          echo "Detecting second violation. Banning $SPAMMER..."
+          curl -X PUT \
+            -H "Authorization: token $ADMIN_PAT" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/orgs/$ORG_NAME/blocks/$SPAMMER
 
       - name: Close issue
         if: steps.unread-checkbox-check.outputs.result == 'true' || steps.blank-issue-check.outputs.result == 'false' && !contains( github.event.issue.labels.*.name, 'issue-checker-ignore')

--- a/.github/workflows/close-unread-issues.yml
+++ b/.github/workflows/close-unread-issues.yml
@@ -89,16 +89,3 @@ jobs:
               state: 'closed',
               state_reason: 'not_planned'
             });
-
-      - name: Remove Label
-        if: contains( github.event.issue.labels.*.name, 'issue-checker-ignore')
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'issue-checker-ignore'
-            });
-

--- a/.github/workflows/close-unread-issues.yml
+++ b/.github/workflows/close-unread-issues.yml
@@ -37,9 +37,8 @@ jobs:
           IGNORE_LABEL: "issue-checker-ignore"
         run: |
           OPEN_COUNT=$(gh issue list -R "$REPO" \
-            --author "$ISSUE_AUTHOR" \
+            --author "$AUTHOR" \
             --state open \
-            --exclude-label "$IGNORE_LABEL" \
             --json number --jq '. | length')
           
           HAS_PREVIOUS_VIOLATION=$(gh issue list -R "$REPO" --author "$AUTHOR" --state all --label "violation" --json number --jq '. | length')
@@ -48,7 +47,7 @@ jobs:
           echo "prev_violations=$HAS_PREVIOUS_VIOLATION" >> $GITHUB_OUTPUT
 
       - name: Warn User
-        if: steps.judge.outputs.open_count > 10 && steps.judge.outputs.open_count <= 15 && steps.judge.outputs.prev_violations == 0
+        if: steps.judge.outputs.open_count > 10 && steps.judge.outputs.open_count <= 15 && steps.judge.outputs.prev_violations == 0 && !contains( github.event.issue.labels.*.name, 'issue-checker-ignore')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
@@ -56,7 +55,7 @@ jobs:
           gh issue comment $ISSUE --body "警告：您当前已拥有超过 10 个 Open Issue。此仓库有上限为 15 的 Issue 限制，如果此 Issue 有开启的必要，请让维护者添加 issue-checker-ignore 标签。否则请关闭一些不必要的 issue。"
 
       - name: First Strike
-        if: steps.judge.outputs.open_count > 15 && steps.judge.outputs.prev_violations == 0
+        if: steps.judge.outputs.open_count > 15 && steps.judge.outputs.prev_violations == 0 && !contains( github.event.issue.labels.*.name, 'issue-checker-ignore')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
@@ -66,7 +65,7 @@ jobs:
           gh issue close $ISSUE --reason "not_planned"
 
       - name: Second Strike - BAN
-        if: steps.judge.outputs.open_count > 15 && steps.judge.outputs.prev_violations > 0
+        if: steps.judge.outputs.open_count > 15 && steps.judge.outputs.prev_violations > 0 && !contains( github.event.issue.labels.*.name, 'issue-checker-ignore')
         env:
           ADMIN_PAT: ${{ secrets.SEALDICE_ADMIN_PAT }}
           ORG_NAME: "sealdice"


### PR DESCRIPTION
考虑到最近 WSL 仓库被恶意 bot 刷 issue 的事件，随便写了一个这个

## Summary by Sourcery

添加自动化管控机制，以限制滥用式创建 Issue，并封禁屡犯用户。

增强内容：
- 将 `close-unread-issues` 工作流限制为只在主仓库 `sealdice/sealdice-core` 中运行。
- 引入一个任务步骤，用于统计某个用户的未关闭 Issue 数量并检查其是否有既往违规记录，同时忽略带有特定标签的 Issue。
- 当用户超过配置的未关闭 Issue 阈值时，自动发出警告并关闭 Issue，并通过标签标记违规行为。
- 当用户在已有违规记录的情况下再次超过 Issue 限制时，自动在组织级别封禁该用户。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automated enforcement to limit abusive issue creation and block repeat offenders.

Enhancements:
- Restrict the close-unread-issues workflow to run only in the main sealdice/sealdice-core repository.
- Introduce a job step to count a user's open issues and check for prior violations, ignoring issues with a specific label.
- Add automated warnings and issue closure when users exceed configured open issue thresholds, with a label marking violations.
- Automatically block users at the organization level when they exceed the issue limit after a prior violation.

</details>