### PR TITLE
fix: 修复删除端点后没有保存的问题

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -172,6 +172,10 @@ func ImConnectionsDel(c echo.Context) error {
 	}{}
 	err := c.Bind(&v)
 	if err == nil {
+		defer func() {
+			myDice.LastUpdatedTime = time.Now().Unix()
+			myDice.Save(false)
+		}()
 		for index, i := range myDice.ImSession.EndPoints {
 			if i.ID == v.ID {
 				// 禁用该endpoint防止出问题

--- a/dice/platform_adapter_dingtalk.go
+++ b/dice/platform_adapter_dingtalk.go
@@ -14,10 +14,10 @@ import (
 
 type PlatformAdapterDingTalk struct {
 	Session       *IMSession        `json:"-"           yaml:"-"`
-	ClientID      string            `json:"clientID"    yaml:"clientID"`
-	Token         string            `json:"token"       yaml:"token"`
-	RobotCode     string            `json:"robotCode"   yaml:"robotCode"`
-	CoolAppCode   string            `json:"coolAppCode" yaml:"coolAppCode"`
+	ClientID      string            `json:"-"    yaml:"clientID"`
+	Token         string            `json:"-"       yaml:"token"`
+	RobotCode     string            `json:"-"   yaml:"robotCode"`
+	CoolAppCode   string            `json:"-" yaml:"coolAppCode"`
 	EndPoint      *EndPointInfo     `json:"-"           yaml:"-"`
 	IntentSession *dingtalk.Session `json:"-"           yaml:"-"`
 	sessionMu     sync.RWMutex

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -20,7 +20,7 @@ import (
 // PlatformAdapterDiscord 只有token需要记录，别的是生成的
 type PlatformAdapterDiscord struct {
 	Session            *IMSession         `json:"-"                  yaml:"-"`
-	Token              string             `json:"token"              yaml:"token"`
+	Token              string             `json:"-"              yaml:"token"`
 	ProxyURL           string             `json:"proxyURL"           yaml:"proxyURL"`
 	ReverseProxyUrl    string             `json:"reverseProxyUrl"    yaml:"reverseProxyUrl"`
 	ReverseProxyCDNUrl string             `json:"reverseProxyCDNUrl" yaml:"reverseProxyCDNUrl"`
@@ -308,7 +308,9 @@ func (pa *PlatformAdapterDiscord) SetEnable(enable bool) {
 	} else {
 		pa.EndPoint.State = 0
 		pa.EndPoint.Enable = false
-		_ = pa.IntentSession.Close()
+		if pa.IntentSession != nil {
+			_ = pa.IntentSession.Close()
+		}
 	}
 	d := pa.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -20,8 +20,8 @@ import (
 
 type PlatformAdapterDodo struct {
 	Session           *IMSession                                              `json:"-"        yaml:"-"`
-	ClientID          string                                                  `json:"clientID" yaml:"clientID"`
-	Token             string                                                  `json:"token"    yaml:"token"`
+	ClientID          string                                                  `json:"-" yaml:"clientID"`
+	Token             string                                                  `json:"-"    yaml:"token"`
 	EndPoint          *EndPointInfo                                           `json:"-"        yaml:"-"`
 	Client            client.Client                                           `json:"-"        yaml:"-"`
 	WebSocket         websocket.Client                                        `json:"-"        yaml:"-"`

--- a/dice/platform_adapter_kook.go
+++ b/dice/platform_adapter_kook.go
@@ -129,7 +129,7 @@ type CardMessageModuleFile struct {
 // PlatformAdapterKook 与 PlatformAdapterDiscord 基本相同的实现，因此不详细写注释了，可以去参考隔壁的实现
 type PlatformAdapterKook struct {
 	Session       *IMSession    `json:"-"     yaml:"-"`
-	Token         string        `json:"token" yaml:"token"`
+	Token         string        `json:"-" yaml:"token"`
 	EndPoint      *EndPointInfo `json:"-"     yaml:"-"`
 	IntentSession *kook.Session `json:"-"     yaml:"-"`
 }

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -25,7 +25,7 @@ type PlatformAdapterMilky struct {
 	IntentSession       *milky.Session `json:"-"                     yaml:"-"`
 	WsGateway           string         `json:"ws_gateway"            yaml:"ws_gateway"`
 	RestGateway         string         `json:"rest_gateway"          yaml:"rest_gateway"`
-	Token               string         `json:"token"                 yaml:"token"`
+	Token               string         `json:"-"                 yaml:"token"`
 	IgnoreFriendRequest bool           `json:"ignore_friend_request" yaml:"ignore_friend_request"`
 	// 内置
 	// BuiltInMode 留空则视为分离，目前支持的字段为 lagrangeV2

--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -18,8 +18,8 @@ type PlatformAdapterSlack struct {
 	Session   *IMSession    `json:"-"        yaml:"-"`
 	EndPoint  *EndPointInfo `json:"-"        yaml:"-"`
 	Client    *sm.Client    `json:"-"        yaml:"-"`
-	BotToken  string        `json:"botToken" yaml:"botToken"`
-	AppToken  string        `json:"appToken" yaml:"appToken"`
+	BotToken  string        `json:"-" yaml:"botToken"`
+	AppToken  string        `json:"-" yaml:"appToken"`
 	cancel    func()
 	userCache *SyncMap[string, *slack.User]
 	// msgCache  *SyncMap[string, int]

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -32,7 +32,7 @@ func (b *BotLoggerWrapper) Printf(format string, v ...interface{}) {
 
 type PlatformAdapterTelegram struct {
 	Session       *IMSession       `json:"-"        yaml:"-"`
-	Token         string           `json:"token"    yaml:"token"`
+	Token         string           `json:"-"    yaml:"token"`
 	ProxyURL      string           `json:"proxyURL" yaml:"proxyURL"`
 	EndPoint      *EndPointInfo    `json:"-"        yaml:"-"`
 	IntentSession *tgbotapi.BotAPI `json:"-"        yaml:"-"`


### PR DESCRIPTION
同时为一些 Secret 脱敏

## Summary by Sourcery

修复删除 IM 端点时的持久化问题，并在各平台适配器的 JSON 序列化中屏蔽敏感令牌。

Bug 修复：
- 确保在删除 IM 端点时，会更新“最后更新时间”并保存 Dice 配置。
- 防止在禁用 Discord 时关闭 intent 会话可能导致的空指针崩溃。

增强功能：
- 在多个平台适配器的 JSON 输出中隐藏客户端 ID、令牌及其他凭证，避免暴露机密信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix persistence when deleting IM endpoints and mask sensitive tokens from JSON serialization across platform adapters.

Bug Fixes:
- Ensure deleting an IM endpoint triggers updating the last updated time and saving the Dice configuration.
- Prevent potential nil pointer panics when closing Discord intent sessions on disable.

Enhancements:
- Hide client IDs, tokens, and other credentials from JSON output for multiple platform adapters to avoid exposing secrets.

</details>