### PR TITLE
feat: Milky 好友致辞

### DIFF
--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -559,7 +559,7 @@ func (pa *PlatformAdapterMilky) handelFriendRequest(ctx *MsgContext, event *milk
 				doSleepQQ(ctx)
 				pa.SendToPerson(ctx, uid, strings.TrimSpace(i), "")
 			}
-			if groupInfo, ok := ctx.Session.ServiceAtNew.Load(msg.GroupID); ok {
+			if groupInfo, ok := ctx.Session.ServiceAtNew.Load(ctx.Group.GroupID); ok {
 				groupInfo.TriggerExtHook(ctx.Dice, func(ext *ExtInfo) func() {
 					if ext.OnBecomeFriend == nil {
 						return nil

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -6,6 +6,7 @@ import (
 	"math/rand/v2"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -104,19 +105,29 @@ func (pa *PlatformAdapterMilky) GetGroupInfoAsync(groupID string) {
 		log.Errorf("Invalid group ID %s: %v", groupID, err)
 		return
 	}
-	groupInfo, err := pa.IntentSession.GetGroupInfo(id, true)
+	groupInfoMilky, err := pa.IntentSession.GetGroupInfo(id, true)
 	if err != nil {
 		log.Errorf("Failed to get group info for %s: %v", groupID, err)
 		return
 	}
-	if groupInfo == nil {
+	if groupInfoMilky == nil {
 		log.Warnf("Group info for %s is nil", groupID)
 		return
 	}
-	pa.Session.Parent.Parent.GroupNameCache.Store(groupID, &GroupNameCacheItem{
-		Name: groupInfo.Name,
+	dm := pa.Session.Parent.Parent
+	dm.GroupNameCache.Store(groupID, &GroupNameCacheItem{
+		Name: groupInfoMilky.Name,
 		time: time.Now().Unix(),
 	})
+	session := pa.Session
+	groupInfo, ok := session.ServiceAtNew.Load(groupID)
+	if ok {
+		if groupInfoMilky.Name != groupInfo.GroupName {
+			// 更新群名
+			groupInfo.GroupName = groupInfoMilky.Name
+			groupInfo.MarkDirty(session.Parent)
+		}
+	}
 }
 
 func (pa *PlatformAdapterMilky) Serve() int {
@@ -509,6 +520,57 @@ func (pa *PlatformAdapterMilky) handelFriendRequest(ctx *MsgContext, event *milk
 		pa.SetFriendAddRequest(event.InitiatorUID, true, "")
 	} else {
 		pa.SetFriendAddRequest(event.InitiatorUID, false, "验证信息不符")
+	}
+	sendSpeech := func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("好友致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
+			}
+		}()
+
+		// 稍作等待后发好友致辞
+		time.Sleep(2 * time.Second)
+		selfId, err := strconv.ParseInt(ExtractQQUserID(pa.EndPoint.UserID), 10, 64)
+		if err != nil {
+			log.Errorf("好友致辞异常: 无法解析自己的QQ号: %v", err)
+			return
+		}
+		event.InitiatorID = selfId
+		msg := &Message{
+			MessageType: "private",
+			Platform:    "QQ",
+			Sender: SenderBase{
+				UserID: uid,
+			},
+		}
+		ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
+
+		welcome := DiceFormatTmpl(ctx, "核心:骰子成为好友")
+		log.Infof("与 %s 成为好友，发送好友致辞: %s", uid, welcome)
+
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Errorf("好友致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
+				}
+			}()
+
+			for _, i := range ctx.SplitText(welcome) {
+				doSleepQQ(ctx)
+				pa.SendToPerson(ctx, uid, strings.TrimSpace(i), "")
+			}
+			if groupInfo, ok := ctx.Session.ServiceAtNew.Load(msg.GroupID); ok {
+				groupInfo.TriggerExtHook(ctx.Dice, func(ext *ExtInfo) func() {
+					if ext.OnBecomeFriend == nil {
+						return nil
+					}
+					return func() { ext.OnBecomeFriend(ctx, msg) }
+				})
+			}
+		}()
+	}
+	if willAccept {
+		sendSpeech()
 	}
 }
 


### PR DESCRIPTION
## Summary by Sourcery

更新 Milky 平台适配器，以保持群组名称缓存和服务元数据同步，并在接受新好友时添加自动欢迎消息功能。

新功能：
- 在 Milky QQ 平台接受新好友后，发送一组自动欢迎消息序列，并在好友成为事件触发时调用扩展钩子。

增强：
- 在刷新群组信息时，保持 Milky 群组名称缓存与内存中的服务群组元数据同步，按需更新名称并标记为已修改（dirty）。
- 提高好友欢迎处理的健壮性，引入 panic 恢复和日志记录，并包含堆栈跟踪以便调试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Milky platform adapter to keep group name cache and service metadata in sync and add automatic welcome messaging when new friends are accepted.

New Features:
- Send an automatic welcome message sequence after accepting a new friend on the Milky QQ platform, including extension hook invocation for friend-become events.

Enhancements:
- Keep Milky group name cache and in-memory service group metadata synchronized when group information is refreshed, updating names and marking them dirty as needed.
- Improve robustness of friend welcome handling with panic recovery and logging, including stack traces for debugging.

</details>