### PR TITLE
chore: remove gocq

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -1015,7 +1015,6 @@ func ImConnectionsAddBuiltinLagrange(c echo.Context) error {
 		Account           string `json:"account"           yaml:"account"`
 		SignServerName    string `json:"signServerName"    yaml:"signServerName"`
 		SignServerVersion string `json:"signServerVersion" yaml:"signServerVersion"`
-		IsGocq            bool   `json:"isGocq"            yaml:"isGocq"`
 	}{}
 	err := c.Bind(&v)
 	if err == nil {
@@ -1024,7 +1023,7 @@ func ImConnectionsAddBuiltinLagrange(c echo.Context) error {
 			return nil
 		}
 
-		conn := dice.NewLagrangeConnectInfoItem(v.Account, v.IsGocq)
+		conn := dice.NewLagrangeConnectInfoItem(v.Account)
 		conn.UserID = dice.FormatDiceIDQQ(uid)
 		conn.Session = myDice.ImSession
 		pa := conn.Adapter.(*dice.PlatformAdapterGocq)

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -416,7 +416,7 @@ func (pa *PlatformAdapterGocq) SendSegmentToPerson(ctx *MsgContext, userID strin
 }
 
 func (pa *PlatformAdapterGocq) Serve() int {
-	if pa.BuiltinMode == "lagrange" || pa.BuiltinMode == "lagrange-gocq" {
+	if pa.BuiltinMode == "lagrange" {
 		pa.Implementation = "lagrange"
 	} else {
 		pa.Implementation = "gocq"
@@ -1207,7 +1207,7 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 		if pa.InPackGoCqhttpDisconnectedCH != nil {
 			pa.InPackGoCqhttpDisconnectedCH <- -1
 		}
-		if pa.BuiltinMode == "lagrange" || pa.BuiltinMode == "lagrange-gocq" {
+		if pa.BuiltinMode == "lagrange" {
 			myDice.Logger.Infof("重新启动 lagrange 进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
 			pa.CurLoginIndex++
 			pa.GoCqhttpState = StateCodeInit
@@ -1254,7 +1254,7 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 		c.Enable = true
 
 		if pa.UseInPackClient {
-			if pa.BuiltinMode == "lagrange" || pa.BuiltinMode == "lagrange-gocq" {
+			if pa.BuiltinMode == "lagrange" {
 				BuiltinQQServeProcessKill(d, c)
 				time.Sleep(1 * time.Second)
 				LagrangeServe(d, c, LagrangeLoginInfo{

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -326,8 +326,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 		pa.GoCqhttpLoginSucceeded = true
 		dice.Save(false)
 		go ServeQQ(dice, conn)
-	} else if pa.BuiltinMode == "lagrange-gocq" {
-		helper.Error("onebot: 尝试启动内置gocq，但内置gocq已废弃，不再尝试启动。建议使用内置Milky")
 	}
 }
 

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -37,7 +37,7 @@ func lagrangeGetWorkDir(dice *Dice, conn *EndPointInfo) string {
 	return workDir
 }
 
-func NewLagrangeConnectInfoItem(account string, isGocq bool) *EndPointInfo {
+func NewLagrangeConnectInfoItem(account string) *EndPointInfo {
 	conn := new(EndPointInfo)
 	conn.ID = uuid.New().String()
 	conn.Platform = "QQ"
@@ -49,11 +49,6 @@ func NewLagrangeConnectInfoItem(account string, isGocq bool) *EndPointInfo {
 		UseInPackClient: true,
 		BuiltinMode:     "lagrange",
 	}
-
-	if isGocq {
-		conn.RelWorkDir = "extra/lagrange-gocq-qq" + account
-		conn.Adapter.(*PlatformAdapterGocq).BuiltinMode = "lagrange-gocq"
-	}
 	return conn
 }
 
@@ -63,15 +58,11 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 	pa.CurLoginIndex++
 	loginIndex := pa.CurLoginIndex
 	pa.GoCqhttpState = StateCodeInLogin
-
-	if pa.UseInPackClient && (pa.BuiltinMode == "lagrange" || pa.BuiltinMode == "lagrange-gocq") { //nolint:nestif
-		helper := zap.S().Named(logger.LogKeyAdapter)
-
+	helper := zap.S().Named(logger.LogKeyAdapter)
+	if pa.UseInPackClient && (pa.BuiltinMode == "lagrange") { //nolint:nestif
 		if dice.ContainerMode {
 			if pa.BuiltinMode == "lagrange" {
 				helper.Warn("onebot: 尝试启动内置客户端，但内置客户端在容器模式下被禁用")
-			} else {
-				helper.Warn("onebot: 尝试启动内置gocq，但内置gocq在容器模式下被禁用")
 			}
 			conn.State = 3
 			pa.GoCqhttpState = StateCodeLoginFailed
@@ -86,13 +77,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 		qrcodeFilePath := filepath.Join(workDir, fmt.Sprintf("qr-%s.png", conn.UserID[3:]))
 		configFilePath := filepath.Join(workDir, "appsettings.json")
 		appinfoFilePath := filepath.Join(workDir, "appinfo.json")
-
-		if pa.BuiltinMode == "lagrange-gocq" {
-			exeFilePath, _ = filepath.Abs(filepath.Join(wd, "lagrange/go-cqhttp"))
-			qrcodeFilePath = filepath.Join(workDir, "qrcode.png")
-			configFilePath = filepath.Join(workDir, "config.yml")
-			appinfoFilePath = filepath.Join(workDir, "data/versions/7.json")
-		}
 
 		exeFilePath = filepath.ToSlash(exeFilePath) // windows平台需要这个替换
 		if runtime.GOOS == "windows" {
@@ -197,11 +181,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 				qrcodeSignal := "QrCode Fetched"
 				onlineSignal := "Bot Online: "
 				qrcodeExpiredSignal := "QrCode Expired, Please Fetch QrCode Again"
-				if pa.BuiltinMode == "lagrange-gocq" {
-					qrcodeSignal = "请使用手机QQ扫描二维码"
-					onlineSignal = "登录成功"
-					qrcodeExpiredSignal = "二维码过期"
-				}
 				// 读取二维码
 				if strings.Contains(line, qrcodeSignal) {
 					chQrCode <- 1
@@ -347,6 +326,8 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 		pa.GoCqhttpLoginSucceeded = true
 		dice.Save(false)
 		go ServeQQ(dice, conn)
+	} else if pa.BuiltinMode == "lagrange-gocq" {
+		helper.Error("onebot: 尝试启动内置gocq，但内置gocq已废弃，不再尝试启动。建议使用内置Milky")
 	}
 }
 
@@ -357,7 +338,6 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 func GenerateLagrangeConfig(port int, signServerName string, signServerVersion string, dice *Dice, info *EndPointInfo) ([]byte, []byte) {
 	var appinfo []byte
 	var signServerUrl string
-	pa := info.Adapter.(*PlatformAdapterGocq)
 	if signServerVersion == "自定义" {
 		appinfo, _ = lagrangeGetAppinfoFromSignServer(signServerName)
 		signServerUrl = signServerName
@@ -368,9 +348,6 @@ func GenerateLagrangeConfig(port int, signServerName string, signServerVersion s
 		appinfo, signServerUrl = lagrangeGetSignSeverFromInfo(signServerVersion, signServerName)
 	}
 	conf := strings.ReplaceAll(defaultLagrangeConfig, "{WS端口}", strconv.Itoa(port))
-	if pa.BuiltinMode == "lagrange-gocq" {
-		conf = strings.ReplaceAll(defaultLagrangeGocqConfig, "{WS端口}", strconv.Itoa(port))
-	}
 	conf = strings.ReplaceAll(conf, "{NTSignServer地址}", signServerUrl)
 	conf = strings.ReplaceAll(conf, "{账号UIN}", info.UserID[3:])
 	return appinfo, []byte(conf)
@@ -699,64 +676,3 @@ var defaultLagrangeConfig = `
 		]
 	}
 	`
-var defaultLagrangeGocqConfig = `
-account:
-  uin: {账号UIN}
-  password: ''
-  encrypt: false
-  status: 0
-  relogin:
-    delay: 3
-    interval: 3
-    max-times: 0 
-  use-sso-address: true
-  allow-temp-session: false
-  sign-servers:
-    - url: '{NTSignServer地址}'
-  max-check-count: 0
-  sign-server-timeout: 60
-
-heartbeat:
-  interval: 5
-
-message:
-  post-format: array
-  ignore-invalid-cqcode: false
-  force-fragment: false
-  fix-url: false
-  proxy-rewrite: ''
-  report-self-message: false
-  remove-reply-at: false
-  extra-reply-data: false
-  skip-mime-scan: false
-  convert-webp-image: false
-  http-timeout: 15
-
-output:
-  log-level: warn
-  log-aging: 15
-  log-force-new: true
-  log-colorful: true
-  debug: false
-
-default-middlewares: &default
-  access-token: ''
-  filter: ''
-  rate-limit:
-    enabled: false
-    frequency: 1
-    bucket: 1
-
-database:
-  leveldb:
-    enable: true
-  sqlite3:
-    enable: false
-    cachettl: 3600000000000
-
-servers:
-  - ws:
-      address: 127.0.0.1:{WS端口}
-      middlewares:
-        <<: *default
-`

--- a/main.go
+++ b/main.go
@@ -518,21 +518,13 @@ func diceServe(d *dice.Dice) {
 					}
 					if conn.ProtocolType == "onebot" {
 						pa := conn.Adapter.(*dice.PlatformAdapterGocq)
-						if pa.BuiltinMode == "lagrange" || pa.BuiltinMode == "lagrange-gocq" {
+						if pa.BuiltinMode == "lagrange" {
 							dice.LagrangeServe(d, conn, dice.LagrangeLoginInfo{
 								IsAsyncRun: true,
 							})
 							return
-						} else {
-							dice.GoCqhttpServe(d, conn, dice.GoCqhttpLoginInfo{
-								Password:         pa.InPackGoCqhttpPassword,
-								Protocol:         pa.InPackGoCqhttpProtocol,
-								AppVersion:       pa.InPackGoCqhttpAppVersion,
-								IsAsyncRun:       true,
-								UseSignServer:    pa.UseSignServer,
-								SignServerConfig: pa.SignServerConfig,
-							})
 						}
+						log.Errorf("不支持或已经废弃的内置适配器模式: %s", pa.BuiltinMode)
 					}
 					if conn.ProtocolType == "red" {
 						dice.ServeRed(d, conn)


### PR DESCRIPTION
前端: sealdice/sealdice-ui#287

## Summary by Sourcery

弃用并移除对内置的基于 gocq 的 Lagrange 适配器的支持，仅保留标准的 Lagrange 模式，并在使用已弃用模式时抛出错误。

Enhancements:
- 通过移除 gocq 专用的分支逻辑和配置模板，简化 Lagrange 连接设置和配置生成流程。
- 当尝试使用已弃用的 `lagrange-gocq` 内置模式时记录明确的错误日志，而不是静默尝试启动它。

Chores:
- 移除与 `lagrange-gocq` 模式相关的 API 和结构体参数，包括 `isGocq` 标志以及相关的工作目录和二维码处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deprecate and remove support for the built-in gocq-based Lagrange adapter, leaving only the standard Lagrange mode and surfacing errors when deprecated modes are used.

Enhancements:
- Simplify Lagrange connection setup and configuration generation by dropping gocq-specific branches and config templates.
- Log explicit errors when attempting to use the deprecated lagrange-gocq built-in mode instead of silently trying to start it.

Chores:
- Remove API and struct parameters related to the lagrange-gocq mode, including the isGocq flag and associated workdir and QR handling logic.

</details>