### PR TITLE
feat: milky internal token

### DIFF
--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -88,7 +88,7 @@ var defaultLagrangeV2Config = `{
         // "Prefix": "/",
 
         // Token for verification, Set to null to disable
-        // "AccessToken": null
+        "AccessToken": "{访问Token}",
 
         // Whether to enable WebSocket service
         // "EnabledWebSocket": true,
@@ -251,7 +251,9 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", p)
 		pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", p)
 		// 生成配置写入文件
-		c := GenerateMilkyConfig(p, SealSignV3Url, ep)
+		accessToken := uuid.NewString()
+		pa.Token = accessToken
+		c := GenerateMilkyConfig(p, SealSignV3Url, accessToken, ep)
 		_ = os.WriteFile(configFilePath, c, 0o644)
 	}
 	command := fmt.Sprintf(`"%s"`, milkyExePath)
@@ -364,13 +366,14 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 }
 
 // GenerateMilkyConfig 似乎暂时不需要 APPInfo, 如果以后需要了再改成双返回值
-func GenerateMilkyConfig(port int, signServerUrl string, info *EndPointInfo) []byte {
+func GenerateMilkyConfig(port int, signServerUrl string, accessToken string, info *EndPointInfo) []byte {
 	pa := info.Adapter.(*PlatformAdapterMilky)
 	switch pa.BuiltInMode {
 	case "lagrangeV2":
 		conf := strings.ReplaceAll(defaultLagrangeV2Config, "{WS端口}", strconv.Itoa(port))
 		conf = strings.ReplaceAll(conf, "{NTSignServer地址}", signServerUrl)
 		conf = strings.ReplaceAll(conf, "{账号UIN}", info.UserID[3:])
+		conf = strings.ReplaceAll(conf, "{访问Token}", accessToken)
 		return []byte(conf)
 	default:
 		return nil

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -254,7 +254,10 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		accessToken := uuid.NewString()
 		pa.Token = accessToken
 		c := GenerateMilkyConfig(p, SealSignV3Url, accessToken, ep)
-		_ = os.WriteFile(configFilePath, c, 0o644)
+		err = os.WriteFile(configFilePath, c, 0o644)
+		if err != nil {
+			log.Errorf("写入 Milky 配置文件失败: %s", err)
+		}
 	}
 	command := fmt.Sprintf(`"%s"`, milkyExePath)
 	p := procs.NewProcess(command)


### PR DESCRIPTION
尽管内置 Milky 监听的是127，但还是增加一点安全性比较好

## Summary by Sourcery

为内置的 Milky 适配器配置生成并注入实例级别的访问令牌，以提升安全性。

新功能：
- 为内置的 Milky 适配器自动生成唯一的访问令牌，并将其注入到生成的配置中。

改进：
- 更新默认的 LagrangeV2 Milky 配置模板，将访问令牌字段改为默认启用，而不是保持注释状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Generate and inject a per-instance access token into the built-in Milky adapter configuration for added security.

New Features:
- Add automatic generation of a unique access token for the built-in Milky adapter and wire it into the generated configuration.

Enhancements:
- Update the default LagrangeV2 Milky configuration template to include an access token field instead of leaving it commented out.

</details>