### PR TITLE
fix: 修复发生入群欢迎无法正确 at 的问题

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1577,8 +1577,7 @@ func (s *IMSession) OnGroupMemberJoined(ctx *MsgContext, msg *Message) {
 				}()
 
 				// Ensure context has group set for formatting and attrs access
-				ctx.Group = groupInfo
-				ctx.Player = &GroupPlayerInfo{}
+				ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
 				// VarSetValueStr(ctx, "$t新人昵称", "<"+msgQQ.Sender.Nickname+">")
 				uidRaw := UserIDExtract(msg.Sender.UserID)
 				VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -348,7 +348,6 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.Session, Dice: pa.Session.Parent}
 		uid := FormatDiceIDQQ(strconv.FormatInt(m.InitiatorID, 10))
 		groupId := FormatDiceIDQQGroup(strconv.FormatInt(m.GroupID, 10))
-		pa.GetGroupInfoAsync(groupId)
 		groupName := dm.TryGetGroupName(groupId)
 		userName := dm.TryGetUserName(uid)
 		txt := fmt.Sprintf("收到QQ加群邀请: 群组<%s>(%s) 邀请人:<%s>(%d)", groupName, groupId, userName, m.InitiatorID)


### PR DESCRIPTION
fix #1639 
问题的根源在于 ctx.Player 没有被初始化导致后面的 format 会覆盖变量
顺便修复了 Milky 在真正加群前会 GetGroupInfo 导致 not found 的问题

## Summary by Sourcery

修复在 Milky 适配器中处理群组加入时使用正确的玩家上下文，并避免过早进行群组查询。

Bug 修复：
- 确保群组加入欢迎消息通过 `GetPlayerInfoBySender` 初始化群组和玩家上下文，以确保格式化和提及功能正常工作。
- 在 Milky 适配器中，避免在用户实际加入群组之前调用 `GetGroupInfoAsync`，以防止出现“未找到”错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix group join handling to use proper player context and avoid premature group lookups in the Milky adapter.

Bug Fixes:
- Ensure group join welcome messages initialize group and player context via GetPlayerInfoBySender so formatting and mentions work correctly.
- Stop performing GetGroupInfoAsync before a user has actually joined a group in the Milky adapter to prevent not found errors.

</details>