### PR TITLE
chore: remove gomodguard from golangci configuration

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -73,7 +73,6 @@ enable = [
     # "gocyclo",                   # computes and checks the cyclomatic complexity of functions
     # "godot",                   # checks if comments end in a period
     # "gomoddirectives",           # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
-    "gomodguard",
     "goprintffuncname",          # checks that printf-like functions are named with f at the end
     "gosec",                     # inspects source code for security problems
     "govet",                     # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string


### PR DESCRIPTION
解决以下报错（hopefully）

run golangci-lint
  Running [/home/runner/golangci-lint-2.12.0-linux-amd64/golangci-lint config path] in [/home/runner/work/sealdice-core/sealdice-core] ...
  Running [/home/runner/golangci-lint-2.12.0-linux-amd64/golangci-lint config verify] in [/home/runner/work/sealdice-core/sealdice-core] ...
  Running [/home/runner/golangci-lint-2.12.0-linux-amd64/golangci-lint run  --timeout 9999s] in [/home/runner/work/sealdice-core/sealdice-core] ...
  level=warning msg="The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2."
  panic: reflect.Value.Interface: cannot return value obtained from unexported field or method [recovered, repanicked]

## Summary by Sourcery

Build:
- 更新 golangci-lint 配置，以停止启用已弃用的 gomodguard linter。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update golangci-lint configuration to stop enabling the deprecated gomodguard linter.

</details>