### PR TITLE
feat: 为脚本引擎注入 actor 属性对象，用于在ds中读写卡

### DIFF
--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -825,9 +825,7 @@ func (ctx *MsgContext) CreateVmIfNotExists() {
 	}
 
 	actorObj := newActorNativeObject(ctx, "actor")
-	characterObj := newActorNativeObject(ctx, "character")
 	ctx.vm.Attrs.Store("actor", actorObj)
-	ctx.vm.Attrs.Store("character", characterObj)
 }
 
 func DiceFormatV2(ctx *MsgContext, s string) (string, error) { //nolint:revive

--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -824,9 +824,10 @@ func (ctx *MsgContext) CreateVmIfNotExists() {
 		return value
 	}
 
-	actorObj := newActorNativeObject(ctx, "player")
-	ctx.vm.Attrs.Store("player", actorObj)
+	actorObj := newActorNativeObject(ctx, "actor")
+	characterObj := newActorNativeObject(ctx, "character")
 	ctx.vm.Attrs.Store("actor", actorObj)
+	ctx.vm.Attrs.Store("character", characterObj)
 }
 
 func DiceFormatV2(ctx *MsgContext, s string) (string, error) { //nolint:revive

--- a/dice/rollvm_migrate.go
+++ b/dice/rollvm_migrate.go
@@ -823,6 +823,10 @@ func (ctx *MsgContext) CreateVmIfNotExists() {
 
 		return value
 	}
+
+	actorObj := newActorNativeObject(ctx, "player")
+	ctx.vm.Attrs.Store("player", actorObj)
+	ctx.vm.Attrs.Store("actor", actorObj)
 }
 
 func DiceFormatV2(ctx *MsgContext, s string) (string, error) { //nolint:revive

--- a/dice/rollvm_player_object.go
+++ b/dice/rollvm_player_object.go
@@ -45,10 +45,10 @@ func actorAttrExistsWithTemplateDefault(ctx *MsgContext, canonicalName string) (
 	ctx2 := ctx.ShallowCopy()
 	ctx2.vm = nil
 	ctx2.CreateVmIfNotExists()
-	if ctx.vm != nil {
-		ctx2.vm.UpCtx = ctx.vm
-		ctx2.vm.Attrs = ctx.vm.Attrs
-		ctx2.vm.Config = ctx.vm.Config
+	if parentVM := ctx.vm; parentVM != nil {
+		ctx2.vm.UpCtx = parentVM
+		ctx2.vm.Attrs = parentVM.Attrs
+		ctx2.vm.Config = parentVM.Config
 	}
 
 	if v, _, _, exists := ctx.SystemTemplate.GetDefaultValueEx0(ctx2, canonicalName); exists {
@@ -90,12 +90,14 @@ func actorVisibleKeys(ctx *MsgContext) []string {
 		}
 	}
 
-	if tmpl := ctx.SystemTemplate; tmpl != nil && tmpl.GameSystemTemplateV2 != nil {
-		for key := range tmpl.Attrs.Defaults {
-			keys[key] = struct{}{}
-		}
-		for key := range tmpl.Attrs.DefaultsComputed {
-			keys[key] = struct{}{}
+	if ctx != nil {
+		if tmpl := ctx.SystemTemplate; tmpl != nil && tmpl.GameSystemTemplateV2 != nil {
+			for key := range tmpl.Attrs.Defaults {
+				keys[key] = struct{}{}
+			}
+			for key := range tmpl.Attrs.DefaultsComputed {
+				keys[key] = struct{}{}
+			}
 		}
 	}
 

--- a/dice/rollvm_player_object.go
+++ b/dice/rollvm_player_object.go
@@ -3,7 +3,6 @@ package dice
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	ds "github.com/sealdice/dicescript"
 )
@@ -279,16 +278,12 @@ func newActorNativeObject(ctx *MsgContext, objectName string) *ds.VMValue {
 			return ds.NewIntVal(0)
 		},
 		DirFunc: func(vm *ds.Context) []*ds.VMValue {
-			visible := actorVisibleKeys(ctx)
-			out := make([]*ds.VMValue, 0, len(visible)+len(methods))
+			out := make([]*ds.VMValue, 0, len(methods))
 			for key := range methods {
 				out = append(out, ds.NewStrVal(key))
 			}
-			for _, key := range visible {
-				out = append(out, ds.NewStrVal(key))
-			}
 			sort.Slice(out, func(i, j int) bool {
-				return strings.Compare(out[i].ToString(), out[j].ToString()) < 0
+				return out[i].ToString() < out[j].ToString()
 			})
 			return out
 		},

--- a/dice/rollvm_player_object.go
+++ b/dice/rollvm_player_object.go
@@ -115,6 +115,19 @@ func newActorNativeObject(ctx *MsgContext, objectName string) *ds.VMValue {
 	visibleKeys := func() []string {
 		return actorVisibleKeys(ctx)
 	}
+	resolveVisibleValue := func(vm *ds.Context, key string, isRaw bool) *ds.VMValue {
+		val, exists := loadActorAttrValue(ctx, key)
+		if !exists || val == nil {
+			return nil
+		}
+		if !isRaw && val.TypeId == ds.VMTypeComputedValue {
+			val = val.ComputedExecute(vm, &ds.BufferSpan{})
+			if vm.Error != nil {
+				return nil
+			}
+		}
+		return val
+	}
 	readVisibleValue := func(key string) *ds.VMValue {
 		val, exists := loadActorAttrValue(ctx, key)
 		if !exists || val == nil {
@@ -165,6 +178,46 @@ func newActorNativeObject(ctx *MsgContext, objectName string) *ds.VMValue {
 					return ds.NewIntVal(1)
 				}
 				return ds.NewIntVal(0)
+			},
+		}),
+		"get": ds.NewNativeFunctionVal(&ds.NativeFunctionData{
+			Name:     objectName + ".get",
+			Params:   []string{"key", "default"},
+			Defaults: []*ds.VMValue{nil, ds.NewNullVal()},
+			NativeFunc: func(vm *ds.Context, this *ds.VMValue, params []*ds.VMValue) *ds.VMValue {
+				key, err := params[0].AsDictKey()
+				if err != nil {
+					vm.Error = err
+					return nil
+				}
+				canonicalName := resolveActorAttrName(ctx, key)
+				if val := resolveVisibleValue(vm, canonicalName, false); val != nil {
+					return val
+				}
+				if len(params) > 1 {
+					return params[1]
+				}
+				return ds.NewNullVal()
+			},
+		}),
+		"getRaw": ds.NewNativeFunctionVal(&ds.NativeFunctionData{
+			Name:     objectName + ".getRaw",
+			Params:   []string{"key", "default"},
+			Defaults: []*ds.VMValue{nil, ds.NewNullVal()},
+			NativeFunc: func(vm *ds.Context, this *ds.VMValue, params []*ds.VMValue) *ds.VMValue {
+				key, err := params[0].AsDictKey()
+				if err != nil {
+					vm.Error = err
+					return nil
+				}
+				canonicalName := resolveActorAttrName(ctx, key)
+				if val := resolveVisibleValue(vm, canonicalName, true); val != nil {
+					return val
+				}
+				if len(params) > 1 {
+					return params[1]
+				}
+				return ds.NewNullVal()
 			},
 		}),
 	}

--- a/dice/rollvm_player_object.go
+++ b/dice/rollvm_player_object.go
@@ -1,0 +1,245 @@
+package dice
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	ds "github.com/sealdice/dicescript"
+)
+
+func actorObjectMethod(name string, fn ds.NativeFunctionDef) *ds.VMValue {
+	return ds.NewNativeFunctionVal(&ds.NativeFunctionData{
+		Name:       name,
+		Params:     []string{},
+		Defaults:   nil,
+		NativeFunc: fn,
+	})
+}
+
+func bindActorObjectMethod(object *ds.VMValue, method *ds.VMValue) *ds.VMValue {
+	if method == nil {
+		return nil
+	}
+	fd, ok := method.ReadNativeFunctionData()
+	if !ok {
+		return method
+	}
+	cloned := *fd
+	cloned.Self = object.Clone()
+	return ds.NewNativeFunctionVal(&cloned)
+}
+
+func resolveActorAttrName(ctx *MsgContext, name string) string {
+	if ctx != nil && ctx.SystemTemplate != nil {
+		return ctx.SystemTemplate.GetAlias(name)
+	}
+	return name
+}
+
+func actorAttrExistsWithTemplateDefault(ctx *MsgContext, canonicalName string) (*ds.VMValue, bool) {
+	if ctx == nil || ctx.SystemTemplate == nil {
+		return nil, false
+	}
+
+	ctx2 := ctx.ShallowCopy()
+	ctx2.vm = nil
+	ctx2.CreateVmIfNotExists()
+	if ctx.vm != nil {
+		ctx2.vm.UpCtx = ctx.vm
+		ctx2.vm.Attrs = ctx.vm.Attrs
+		ctx2.vm.Config = ctx.vm.Config
+	}
+
+	if v, _, _, exists := ctx.SystemTemplate.GetDefaultValueEx0(ctx2, canonicalName); exists {
+		return v, true
+	}
+	return nil, false
+}
+
+func loadActorAttrValue(ctx *MsgContext, canonicalName string) (*ds.VMValue, bool) {
+	if ctx == nil || ctx.Dice == nil || ctx.Player == nil {
+		return nil, false
+	}
+
+	attrs, err := ctx.Dice.AttrsManager.LoadByCtx(ctx)
+	if err == nil && attrs != nil {
+		if ctx.SystemTemplate != nil {
+			ctx.syncAttrsForTemplate(attrs, ctx.SystemTemplate.GameSystemTemplateV2)
+		}
+		if v, exists := attrs.LoadX(canonicalName); exists {
+			return v, true
+		}
+	}
+
+	return actorAttrExistsWithTemplateDefault(ctx, canonicalName)
+}
+
+func actorVisibleKeys(ctx *MsgContext) []string {
+	keys := map[string]struct{}{}
+
+	if ctx != nil && ctx.Dice != nil && ctx.Player != nil {
+		if attrs, err := ctx.Dice.AttrsManager.LoadByCtx(ctx); err == nil && attrs != nil {
+			if ctx.SystemTemplate != nil {
+				ctx.syncAttrsForTemplate(attrs, ctx.SystemTemplate.GameSystemTemplateV2)
+			}
+			attrs.Range(func(key string, _ *ds.VMValue) bool {
+				keys[key] = struct{}{}
+				return true
+			})
+		}
+	}
+
+	if tmpl := ctx.SystemTemplate; tmpl != nil && tmpl.GameSystemTemplateV2 != nil {
+		for key := range tmpl.Attrs.Defaults {
+			keys[key] = struct{}{}
+		}
+		for key := range tmpl.Attrs.DefaultsComputed {
+			keys[key] = struct{}{}
+		}
+	}
+
+	delete(keys, attrsTemplateVersionKey)
+
+	out := make([]string, 0, len(keys))
+	for key := range keys {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func newActorNativeObject(ctx *MsgContext, objectName string) *ds.VMValue {
+	visibleKeys := func() []string {
+		return actorVisibleKeys(ctx)
+	}
+	readVisibleValue := func(key string) *ds.VMValue {
+		val, exists := loadActorAttrValue(ctx, key)
+		if !exists || val == nil {
+			return ds.NewIntVal(0)
+		}
+		return val
+	}
+	methods := map[string]*ds.VMValue{
+		"keys": actorObjectMethod(objectName+".keys", func(vm *ds.Context, this *ds.VMValue, _ []*ds.VMValue) *ds.VMValue {
+			keys := visibleKeys()
+			out := make([]*ds.VMValue, 0, len(keys))
+			for _, key := range keys {
+				out = append(out, ds.NewStrVal(key))
+			}
+			return ds.NewArrayValRaw(out)
+		}),
+		"values": actorObjectMethod(objectName+".values", func(vm *ds.Context, this *ds.VMValue, _ []*ds.VMValue) *ds.VMValue {
+			keys := visibleKeys()
+			values := make([]*ds.VMValue, 0, len(keys))
+			for _, key := range keys {
+				values = append(values, readVisibleValue(key))
+			}
+			return ds.NewArrayValRaw(values)
+		}),
+		"items": actorObjectMethod(objectName+".items", func(vm *ds.Context, this *ds.VMValue, _ []*ds.VMValue) *ds.VMValue {
+			keys := visibleKeys()
+			items := make([]*ds.VMValue, 0, len(keys))
+			for _, key := range keys {
+				items = append(items, ds.NewArrayVal(ds.NewStrVal(key), readVisibleValue(key)))
+			}
+			return ds.NewArrayValRaw(items)
+		}),
+		"len": actorObjectMethod(objectName+".len", func(vm *ds.Context, this *ds.VMValue, _ []*ds.VMValue) *ds.VMValue {
+			return ds.NewIntVal(ds.IntType(len(visibleKeys())))
+		}),
+		"has": ds.NewNativeFunctionVal(&ds.NativeFunctionData{
+			Name:     objectName + ".has",
+			Params:   []string{"key"},
+			Defaults: nil,
+			NativeFunc: func(vm *ds.Context, this *ds.VMValue, params []*ds.VMValue) *ds.VMValue {
+				key, err := params[0].AsDictKey()
+				if err != nil {
+					vm.Error = err
+					return nil
+				}
+				canonicalName := resolveActorAttrName(ctx, key)
+				if _, exists := loadActorAttrValue(ctx, canonicalName); exists {
+					return ds.NewIntVal(1)
+				}
+				return ds.NewIntVal(0)
+			},
+		}),
+	}
+
+	var object *ds.VMValue
+	object = ds.NewNativeObjectVal(&ds.NativeObjectData{
+		Name: objectName,
+		AttrSet: func(vm *ds.Context, name string, v *ds.VMValue) {
+			if ctx == nil || ctx.Dice == nil || ctx.Player == nil {
+				vm.Error = fmt.Errorf("%s is unavailable in current context", objectName)
+				return
+			}
+			canonicalName := resolveActorAttrName(ctx, name)
+			attrs, err := ctx.Dice.AttrsManager.LoadByCtx(ctx)
+			if err != nil {
+				vm.Error = err
+				return
+			}
+			attrs.Store(canonicalName, v.Clone())
+		},
+		AttrGet: func(vm *ds.Context, name string) *ds.VMValue {
+			if method, ok := methods[name]; ok {
+				return bindActorObjectMethod(object, method)
+			}
+			canonicalName := resolveActorAttrName(ctx, name)
+			if v, exists := loadActorAttrValue(ctx, canonicalName); exists {
+				return v
+			}
+			return ds.NewIntVal(0)
+		},
+		ItemSet: func(vm *ds.Context, index *ds.VMValue, v *ds.VMValue) {
+			if ctx == nil || ctx.Dice == nil || ctx.Player == nil {
+				vm.Error = fmt.Errorf("%s is unavailable in current context", objectName)
+				return
+			}
+			key, err := index.AsDictKey()
+			if err != nil {
+				vm.Error = err
+				return
+			}
+			canonicalName := resolveActorAttrName(ctx, key)
+			attrs, err := ctx.Dice.AttrsManager.LoadByCtx(ctx)
+			if err != nil {
+				vm.Error = err
+				return
+			}
+			attrs.Store(canonicalName, v.Clone())
+		},
+		ItemGet: func(vm *ds.Context, index *ds.VMValue) *ds.VMValue {
+			key, err := index.AsDictKey()
+			if err != nil {
+				vm.Error = err
+				return nil
+			}
+			canonicalName := resolveActorAttrName(ctx, key)
+			if v, exists := loadActorAttrValue(ctx, canonicalName); exists {
+				return v
+			}
+			return ds.NewIntVal(0)
+		},
+		DirFunc: func(vm *ds.Context) []*ds.VMValue {
+			visible := actorVisibleKeys(ctx)
+			out := make([]*ds.VMValue, 0, len(visible)+len(methods))
+			for key := range methods {
+				out = append(out, ds.NewStrVal(key))
+			}
+			for _, key := range visible {
+				out = append(out, ds.NewStrVal(key))
+			}
+			sort.Slice(out, func(i, j int) bool {
+				return strings.Compare(out[i].ToString(), out[j].ToString()) < 0
+			})
+			return out
+		},
+		ToString: func(vm *ds.Context) string {
+			return fmt.Sprintf("nobject %s", objectName)
+		},
+	})
+	return object
+}

--- a/dice/rollvm_player_object_test.go
+++ b/dice/rollvm_player_object_test.go
@@ -189,7 +189,7 @@ func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
 	for _, item := range dirArr.List {
 		items[item.ToString()] = true
 	}
-	for _, key := range []string{"keys", "values", "items", "len", "has", "力量", "外语"} {
+	for _, key := range []string{"keys", "values", "items", "len", "has", "get", "getRaw", "力量", "外语"} {
 		if !items[key] {
 			t.Fatalf("expected dir(actor) to include %q", key)
 		}
@@ -209,7 +209,7 @@ func TestPlayerObject_DirWithNilContextIsSafe(t *testing.T) {
 		items[item.ToString()] = true
 	}
 
-	for _, key := range []string{"has", "items", "keys", "len", "values"} {
+	for _, key := range []string{"get", "getRaw", "has", "items", "keys", "len", "values"} {
 		if !items[key] {
 			t.Fatalf("expected dir(actor) to include %q with nil context", key)
 		}
@@ -231,6 +231,67 @@ func TestPlayerObject_ProvidesDictStyleMethods(t *testing.T) {
 	}
 	if result.MustReadInt() <= 0 {
 		t.Fatal("expected actor.keys().len() to be greater than 0")
+	}
+}
+
+func TestPlayerObject_GetSupportsAliasDefaultAndTemplateDefault(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"敏捷": ds.NewIntVal(80),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("[actor.get('敏捷'), character.get('DEX'), actor.get('外语'), actor.get('不存在属性', 66)]", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+
+	arr, ok := result.ReadArray()
+	if !ok {
+		t.Fatalf("expected array result, got %s", result.GetTypeName())
+	}
+	if len(arr.List) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(arr.List))
+	}
+	for idx, want := range []string{"80", "80", "1", "66"} {
+		if got := arr.List[idx].ToString(); got != want {
+			t.Fatalf("expected result[%d] = %s, got %s", idx, want, got)
+		}
+	}
+}
+
+func TestPlayerObject_GetReturnsNullForTrulyMissingAttrWithoutDefault(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("character.get('不存在属性')", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if result.TypeId != ds.VMTypeNull {
+		t.Fatalf("expected get() to return null for missing attr, got %s", result.GetTypeName())
+	}
+}
+
+func TestPlayerObject_GetAndGetRawHandleComputedValues(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"力量": ds.NewComputedVal("1+2"),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("actor.get('力量')", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "3" {
+		t.Fatalf("expected computed get() result 3, got %s", got)
+	}
+
+	result = ctx.Eval("typeId(character.getRaw('力量'))", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if result.MustReadInt() != ds.IntType(ds.VMTypeComputedValue) {
+		t.Fatalf("expected getRaw() to preserve computed value type, got %s", result.ToString())
 	}
 }
 
@@ -258,7 +319,7 @@ func TestPlayerObject_KeysDoesNotIncludeInjectedMethods(t *testing.T) {
 	if !items["力量"] || !items["外语"] {
 		t.Fatalf("expected keys() to include visible attrs, got %v", items)
 	}
-	for _, key := range []string{"keys", "values", "items", "len", "has"} {
+	for _, key := range []string{"keys", "values", "items", "len", "has", "get", "getRaw"} {
 		if items[key] {
 			t.Fatalf("did not expect keys() to include injected method %q", key)
 		}

--- a/dice/rollvm_player_object_test.go
+++ b/dice/rollvm_player_object_test.go
@@ -38,25 +38,36 @@ func newPlayerObjectTestCtx(t *testing.T, sheetType string, values map[string]*d
 	return ctx, cleanup
 }
 
-func TestPlayerObject_IsInjectedAsPlayerAndActor(t *testing.T) {
+func TestPlayerObject_IsInjectedAsActorAndCharacter(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
 	ctx.CreateVmIfNotExists()
 
-	playerVal, ok := ctx.vm.Attrs.Load("player")
-	if !ok || playerVal == nil || playerVal.TypeId != ds.VMTypeNativeObject {
-		t.Fatalf("expected native object player, got %v (exists=%v)", playerVal, ok)
-	}
 	actorVal, ok := ctx.vm.Attrs.Load("actor")
 	if !ok || actorVal == nil || actorVal.TypeId != ds.VMTypeNativeObject {
 		t.Fatalf("expected native object actor, got %v (exists=%v)", actorVal, ok)
 	}
+	characterVal, ok := ctx.vm.Attrs.Load("character")
+	if !ok || characterVal == nil || characterVal.TypeId != ds.VMTypeNativeObject {
+		t.Fatalf("expected native object character, got %v (exists=%v)", characterVal, ok)
+	}
 
-	playerObj, _ := playerVal.ReadNativeObjectData()
 	actorObj, _ := actorVal.ReadNativeObjectData()
-	if playerObj != actorObj {
-		t.Fatal("expected player and actor to point to the same native object")
+	characterObj, _ := characterVal.ReadNativeObjectData()
+	if actorObj == nil || characterObj == nil {
+		t.Fatal("expected actor and character to provide native object data")
+	}
+}
+
+func TestPlayerObject_DoesNotInjectLegacyPlayerAlias(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	ctx.CreateVmIfNotExists()
+
+	if playerVal, ok := ctx.vm.Attrs.Load("player"); ok || playerVal != nil {
+		t.Fatalf("expected legacy player alias to be absent, got %v (exists=%v)", playerVal, ok)
 	}
 }
 
@@ -64,7 +75,7 @@ func TestPlayerObject_WriteAndReadCanonicalAttr(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("player.力量 = 70; player.力量", nil)
+	result := ctx.Eval("actor.力量 = 70; actor.力量", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -82,7 +93,7 @@ func TestPlayerObject_AliasWriteStoresCanonicalKey(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("player.DEX = 60; player.敏捷", nil)
+	result := ctx.Eval("actor.DEX = 60; character.敏捷", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -105,7 +116,7 @@ func TestPlayerObject_AliasReadReturnsStoredCanonicalValue(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("player.DEX", nil)
+	result := ctx.Eval("character.DEX", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -118,7 +129,7 @@ func TestPlayerObject_ItemGetAndSetUseAliasResolution(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("player['DEX'] = 55; player['敏捷']", nil)
+	result := ctx.Eval("actor['DEX'] = 55; character['敏捷']", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -136,7 +147,7 @@ func TestPlayerObject_UsesTemplateDefaultWhenAttrMissing(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("player.外语", nil)
+	result := ctx.Eval("actor.外语", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -149,7 +160,7 @@ func TestPlayerObject_ReturnsNullWhenAttrTrulyMissing(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("player.不存在属性", nil)
+	result := ctx.Eval("character.不存在属性", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -164,7 +175,7 @@ func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("dir(player)", nil)
+	result := ctx.Eval("dir(actor)", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -180,13 +191,13 @@ func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
 	}
 	for _, key := range []string{"keys", "values", "items", "len", "has", "力量", "外语"} {
 		if !items[key] {
-			t.Fatalf("expected dir(player) to include %q", key)
+			t.Fatalf("expected dir(actor) to include %q", key)
 		}
 	}
 }
 
 func TestPlayerObject_DirWithNilContextIsSafe(t *testing.T) {
-	object := newActorNativeObject(nil, "player")
+	object := newActorNativeObject(nil, "actor")
 	objectData, ok := object.ReadNativeObjectData()
 	if !ok {
 		t.Fatalf("expected native object, got %s", object.GetTypeName())
@@ -200,7 +211,7 @@ func TestPlayerObject_DirWithNilContextIsSafe(t *testing.T) {
 
 	for _, key := range []string{"has", "items", "keys", "len", "values"} {
 		if !items[key] {
-			t.Fatalf("expected dir(player) to include %q with nil context", key)
+			t.Fatalf("expected dir(actor) to include %q with nil context", key)
 		}
 	}
 }
@@ -211,7 +222,7 @@ func TestPlayerObject_ProvidesDictStyleMethods(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("player.keys().len()", nil)
+	result := ctx.Eval("actor.keys().len()", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -219,7 +230,7 @@ func TestPlayerObject_ProvidesDictStyleMethods(t *testing.T) {
 		t.Fatalf("expected integer len result, got %s", result.GetTypeName())
 	}
 	if result.MustReadInt() <= 0 {
-		t.Fatal("expected player.keys().len() to be greater than 0")
+		t.Fatal("expected actor.keys().len() to be greater than 0")
 	}
 }
 
@@ -229,7 +240,7 @@ func TestPlayerObject_KeysDoesNotIncludeInjectedMethods(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("player.keys()", nil)
+	result := ctx.Eval("character.keys()", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -260,7 +271,7 @@ func TestPlayerObject_HasSupportsCanonicalAliasAndTemplateDefault(t *testing.T) 
 	})
 	defer cleanup()
 
-	result := ctx.Eval("[player.has('敏捷'), player.has('DEX'), player.has('外语')]", nil)
+	result := ctx.Eval("[actor.has('敏捷'), character.has('DEX'), actor.has('外语')]", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -283,7 +294,7 @@ func TestPlayerObject_HasReturnsFalseForTrulyMissingAttr(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("player.has('不存在属性')", nil)
+	result := ctx.Eval("character.has('不存在属性')", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}

--- a/dice/rollvm_player_object_test.go
+++ b/dice/rollvm_player_object_test.go
@@ -1,0 +1,286 @@
+//nolint:testpackage
+package dice
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	ds "github.com/sealdice/dicescript"
+)
+
+func newPlayerObjectTestCtx(t *testing.T, sheetType string, values map[string]*ds.VMValue) (*MsgContext, func()) {
+	t.Helper()
+
+	d, ep, _, cleanup := newExecuteNewTestDice(t)
+
+	groupID := "QQ-Group:2233"
+	userID := "QQ:4455"
+	msg := newGroupMsg(groupID, userID, ".r 1")
+	ctx := CreateTempCtx(ep, msg)
+	group, player := GetPlayerInfoBySender(ctx, msg)
+	group.System = "coc7"
+	player.Name = "Tester"
+	ctx.Group = group
+	ctx.Player = player
+	ctx.IsCompatibilityTest = true
+	ctx.SystemTemplate = group.GetCharTemplate(d)
+
+	attrs := &AttributesItem{
+		ID:        groupID + "-" + userID,
+		valueMap:  &ds.ValueMap{},
+		SheetType: sheetType,
+	}
+	for key, value := range values {
+		attrs.Store(key, value)
+	}
+	d.AttrsManager.m.Store(attrs.ID, attrs)
+
+	return ctx, cleanup
+}
+
+func TestPlayerObject_IsInjectedAsPlayerAndActor(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	ctx.CreateVmIfNotExists()
+
+	playerVal, ok := ctx.vm.Attrs.Load("player")
+	if !ok || playerVal == nil || playerVal.TypeId != ds.VMTypeNativeObject {
+		t.Fatalf("expected native object player, got %v (exists=%v)", playerVal, ok)
+	}
+	actorVal, ok := ctx.vm.Attrs.Load("actor")
+	if !ok || actorVal == nil || actorVal.TypeId != ds.VMTypeNativeObject {
+		t.Fatalf("expected native object actor, got %v (exists=%v)", actorVal, ok)
+	}
+
+	playerObj, _ := playerVal.ReadNativeObjectData()
+	actorObj, _ := actorVal.ReadNativeObjectData()
+	if playerObj != actorObj {
+		t.Fatal("expected player and actor to point to the same native object")
+	}
+}
+
+func TestPlayerObject_WriteAndReadCanonicalAttr(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("player.力量 = 70; player.力量", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "70" {
+		t.Fatalf("expected 70, got %s", got)
+	}
+
+	attrs := lo.Must(ctx.Dice.AttrsManager.LoadByCtx(ctx))
+	if v, exists := attrs.LoadX("力量"); !exists || v.ToString() != "70" {
+		t.Fatalf("expected current attrs to store 力量=70, got %v (exists=%v)", v, exists)
+	}
+}
+
+func TestPlayerObject_AliasWriteStoresCanonicalKey(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("player.DEX = 60; player.敏捷", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "60" {
+		t.Fatalf("expected 60, got %s", got)
+	}
+
+	attrs := lo.Must(ctx.Dice.AttrsManager.LoadByCtx(ctx))
+	if v, exists := attrs.LoadX("敏捷"); !exists || v.ToString() != "60" {
+		t.Fatalf("expected canonical key 敏捷=60, got %v (exists=%v)", v, exists)
+	}
+	if _, exists := attrs.LoadX("DEX"); exists {
+		t.Fatal("did not expect alias key DEX to be written")
+	}
+}
+
+func TestPlayerObject_AliasReadReturnsStoredCanonicalValue(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"敏捷": ds.NewIntVal(70),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("player.DEX", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "70" {
+		t.Fatalf("expected 70, got %s", got)
+	}
+}
+
+func TestPlayerObject_ItemGetAndSetUseAliasResolution(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("player['DEX'] = 55; player['敏捷']", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "55" {
+		t.Fatalf("expected 55, got %s", got)
+	}
+
+	attrs := lo.Must(ctx.Dice.AttrsManager.LoadByCtx(ctx))
+	if v, exists := attrs.LoadX("敏捷"); !exists || v.ToString() != "55" {
+		t.Fatalf("expected canonical key 敏捷=55, got %v (exists=%v)", v, exists)
+	}
+}
+
+func TestPlayerObject_UsesTemplateDefaultWhenAttrMissing(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("player.外语", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "1" {
+		t.Fatalf("expected default value 1, got %s", got)
+	}
+}
+
+func TestPlayerObject_ReturnsNullWhenAttrTrulyMissing(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("player.不存在属性", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if result.VMValue.TypeId != ds.VMTypeInt || result.VMValue.ToString() != "0" {
+		t.Fatalf("expected missing value to be 0, got type %v with value %s", result.VMValue.TypeId, result.ToString())
+	}
+}
+
+func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"力量": ds.NewIntVal(80),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("dir(player)", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+
+	dirArr, ok := result.ReadArray()
+	if !ok {
+		t.Fatalf("expected array result, got %s", result.VMValue.GetTypeName())
+	}
+
+	items := map[string]bool{}
+	for _, item := range dirArr.List {
+		items[item.ToString()] = true
+	}
+	for _, key := range []string{"keys", "values", "items", "len", "has", "力量", "外语"} {
+		if !items[key] {
+			t.Fatalf("expected dir(player) to include %q", key)
+		}
+	}
+}
+
+func TestPlayerObject_ProvidesDictStyleMethods(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"力量": ds.NewIntVal(80),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("player.keys().len()", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if result.VMValue.TypeId != ds.VMTypeInt {
+		t.Fatalf("expected integer len result, got %s", result.VMValue.GetTypeName())
+	}
+	if result.VMValue.MustReadInt() <= 0 {
+		t.Fatal("expected player.keys().len() to be greater than 0")
+	}
+}
+
+func TestPlayerObject_KeysDoesNotIncludeInjectedMethods(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"力量": ds.NewIntVal(80),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("player.keys()", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+
+	keys, ok := result.ReadArray()
+	if !ok {
+		t.Fatalf("expected array result, got %s", result.VMValue.GetTypeName())
+	}
+
+	items := map[string]bool{}
+	for _, item := range keys.List {
+		items[item.ToString()] = true
+	}
+
+	if !items["力量"] || !items["外语"] {
+		t.Fatalf("expected keys() to include visible attrs, got %v", items)
+	}
+	for _, key := range []string{"keys", "values", "items", "len", "has"} {
+		if items[key] {
+			t.Fatalf("did not expect keys() to include injected method %q", key)
+		}
+	}
+}
+
+func TestPlayerObject_HasSupportsCanonicalAliasAndTemplateDefault(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
+		"敏捷": ds.NewIntVal(80),
+	})
+	defer cleanup()
+
+	result := ctx.Eval("[player.has('敏捷'), player.has('DEX'), player.has('外语')]", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+
+	arr, ok := result.ReadArray()
+	if !ok {
+		t.Fatalf("expected array result, got %s", result.VMValue.GetTypeName())
+	}
+	if len(arr.List) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(arr.List))
+	}
+	for idx, want := range []string{"1", "1", "1"} {
+		if got := arr.List[idx].ToString(); got != want {
+			t.Fatalf("expected result[%d] = %s, got %s", idx, want, got)
+		}
+	}
+}
+
+func TestPlayerObject_HasReturnsFalseForTrulyMissingAttr(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("player.has('不存在属性')", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "0" {
+		t.Fatalf("expected has() to return 0 for missing attr, got %s", got)
+	}
+}
+
+func TestPlayerObject_DoesNotChangeTopLevelMissingValueBehavior(t *testing.T) {
+	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
+	defer cleanup()
+
+	result := ctx.Eval("不存在属性", nil)
+	if result.vm.Error != nil {
+		t.Fatalf("Eval returned error: %v", result.vm.Error)
+	}
+	if got := result.ToString(); got != "0" {
+		t.Fatalf("expected top-level missing value to remain 0, got %s", got)
+	}
+}

--- a/dice/rollvm_player_object_test.go
+++ b/dice/rollvm_player_object_test.go
@@ -167,7 +167,7 @@ func TestPlayerObject_ReturnsNullWhenAttrTrulyMissing(t *testing.T) {
 	}
 }
 
-func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
+func TestPlayerObject_DirIncludesMethodsOnly(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", map[string]*ds.VMValue{
 		"力量": ds.NewIntVal(80),
 	})
@@ -187,9 +187,14 @@ func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
 	for _, item := range dirArr.List {
 		items[item.ToString()] = true
 	}
-	for _, key := range []string{"keys", "values", "items", "len", "has", "get", "getRaw", "力量", "外语"} {
+	for _, key := range []string{"keys", "values", "items", "len", "has", "get", "getRaw"} {
 		if !items[key] {
 			t.Fatalf("expected dir(actor) to include %q", key)
+		}
+	}
+	for _, key := range []string{"力量", "外语"} {
+		if items[key] {
+			t.Fatalf("did not expect dir(actor) to include attr %q", key)
 		}
 	}
 }

--- a/dice/rollvm_player_object_test.go
+++ b/dice/rollvm_player_object_test.go
@@ -38,7 +38,7 @@ func newPlayerObjectTestCtx(t *testing.T, sheetType string, values map[string]*d
 	return ctx, cleanup
 }
 
-func TestPlayerObject_IsInjectedAsActorAndCharacter(t *testing.T) {
+func TestPlayerObject_IsInjectedAsActor(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
@@ -48,19 +48,14 @@ func TestPlayerObject_IsInjectedAsActorAndCharacter(t *testing.T) {
 	if !ok || actorVal == nil || actorVal.TypeId != ds.VMTypeNativeObject {
 		t.Fatalf("expected native object actor, got %v (exists=%v)", actorVal, ok)
 	}
-	characterVal, ok := ctx.vm.Attrs.Load("character")
-	if !ok || characterVal == nil || characterVal.TypeId != ds.VMTypeNativeObject {
-		t.Fatalf("expected native object character, got %v (exists=%v)", characterVal, ok)
-	}
 
 	actorObj, _ := actorVal.ReadNativeObjectData()
-	characterObj, _ := characterVal.ReadNativeObjectData()
-	if actorObj == nil || characterObj == nil {
-		t.Fatal("expected actor and character to provide native object data")
+	if actorObj == nil {
+		t.Fatal("expected actor to provide native object data")
 	}
 }
 
-func TestPlayerObject_DoesNotInjectLegacyPlayerAlias(t *testing.T) {
+func TestPlayerObject_DoesNotInjectLegacyAliases(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
@@ -68,6 +63,9 @@ func TestPlayerObject_DoesNotInjectLegacyPlayerAlias(t *testing.T) {
 
 	if playerVal, ok := ctx.vm.Attrs.Load("player"); ok || playerVal != nil {
 		t.Fatalf("expected legacy player alias to be absent, got %v (exists=%v)", playerVal, ok)
+	}
+	if characterVal, ok := ctx.vm.Attrs.Load("character"); ok || characterVal != nil {
+		t.Fatalf("expected legacy character alias to be absent, got %v (exists=%v)", characterVal, ok)
 	}
 }
 
@@ -93,7 +91,7 @@ func TestPlayerObject_AliasWriteStoresCanonicalKey(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("actor.DEX = 60; character.敏捷", nil)
+	result := ctx.Eval("actor.DEX = 60; actor.敏捷", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -116,7 +114,7 @@ func TestPlayerObject_AliasReadReturnsStoredCanonicalValue(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("character.DEX", nil)
+	result := ctx.Eval("actor.DEX", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -129,7 +127,7 @@ func TestPlayerObject_ItemGetAndSetUseAliasResolution(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("actor['DEX'] = 55; character['敏捷']", nil)
+	result := ctx.Eval("actor['DEX'] = 55; actor['敏捷']", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -160,7 +158,7 @@ func TestPlayerObject_ReturnsNullWhenAttrTrulyMissing(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("character.不存在属性", nil)
+	result := ctx.Eval("actor.不存在属性", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -240,7 +238,7 @@ func TestPlayerObject_GetSupportsAliasDefaultAndTemplateDefault(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("[actor.get('敏捷'), character.get('DEX'), actor.get('外语'), actor.get('不存在属性', 66)]", nil)
+	result := ctx.Eval("[actor.get('敏捷'), actor.get('DEX'), actor.get('外语'), actor.get('不存在属性', 66)]", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -263,7 +261,7 @@ func TestPlayerObject_GetReturnsNullForTrulyMissingAttrWithoutDefault(t *testing
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("character.get('不存在属性')", nil)
+	result := ctx.Eval("actor.get('不存在属性')", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -286,7 +284,7 @@ func TestPlayerObject_GetAndGetRawHandleComputedValues(t *testing.T) {
 		t.Fatalf("expected computed get() result 3, got %s", got)
 	}
 
-	result = ctx.Eval("typeId(character.getRaw('力量'))", nil)
+	result = ctx.Eval("typeId(actor.getRaw('力量'))", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -301,7 +299,7 @@ func TestPlayerObject_KeysDoesNotIncludeInjectedMethods(t *testing.T) {
 	})
 	defer cleanup()
 
-	result := ctx.Eval("character.keys()", nil)
+	result := ctx.Eval("actor.keys()", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -332,7 +330,7 @@ func TestPlayerObject_HasSupportsCanonicalAliasAndTemplateDefault(t *testing.T) 
 	})
 	defer cleanup()
 
-	result := ctx.Eval("[actor.has('敏捷'), character.has('DEX'), actor.has('外语')]", nil)
+	result := ctx.Eval("[actor.has('敏捷'), actor.has('DEX'), actor.has('外语')]", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
@@ -355,7 +353,7 @@ func TestPlayerObject_HasReturnsFalseForTrulyMissingAttr(t *testing.T) {
 	ctx, cleanup := newPlayerObjectTestCtx(t, "coc7", nil)
 	defer cleanup()
 
-	result := ctx.Eval("character.has('不存在属性')", nil)
+	result := ctx.Eval("actor.has('不存在属性')", nil)
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}

--- a/dice/rollvm_player_object_test.go
+++ b/dice/rollvm_player_object_test.go
@@ -153,8 +153,8 @@ func TestPlayerObject_ReturnsNullWhenAttrTrulyMissing(t *testing.T) {
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
-	if result.VMValue.TypeId != ds.VMTypeInt || result.VMValue.ToString() != "0" {
-		t.Fatalf("expected missing value to be 0, got type %v with value %s", result.VMValue.TypeId, result.ToString())
+	if result.TypeId != ds.VMTypeInt || result.ToString() != "0" {
+		t.Fatalf("expected missing value to be 0, got type %v with value %s", result.TypeId, result.ToString())
 	}
 }
 
@@ -171,7 +171,7 @@ func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
 
 	dirArr, ok := result.ReadArray()
 	if !ok {
-		t.Fatalf("expected array result, got %s", result.VMValue.GetTypeName())
+		t.Fatalf("expected array result, got %s", result.GetTypeName())
 	}
 
 	items := map[string]bool{}
@@ -181,6 +181,26 @@ func TestPlayerObject_DirIncludesMethodsAndVisibleKeys(t *testing.T) {
 	for _, key := range []string{"keys", "values", "items", "len", "has", "力量", "外语"} {
 		if !items[key] {
 			t.Fatalf("expected dir(player) to include %q", key)
+		}
+	}
+}
+
+func TestPlayerObject_DirWithNilContextIsSafe(t *testing.T) {
+	object := newActorNativeObject(nil, "player")
+	objectData, ok := object.ReadNativeObjectData()
+	if !ok {
+		t.Fatalf("expected native object, got %s", object.GetTypeName())
+	}
+
+	dir := objectData.DirFunc(ds.NewVM())
+	items := map[string]bool{}
+	for _, item := range dir {
+		items[item.ToString()] = true
+	}
+
+	for _, key := range []string{"has", "items", "keys", "len", "values"} {
+		if !items[key] {
+			t.Fatalf("expected dir(player) to include %q with nil context", key)
 		}
 	}
 }
@@ -195,10 +215,10 @@ func TestPlayerObject_ProvidesDictStyleMethods(t *testing.T) {
 	if result.vm.Error != nil {
 		t.Fatalf("Eval returned error: %v", result.vm.Error)
 	}
-	if result.VMValue.TypeId != ds.VMTypeInt {
-		t.Fatalf("expected integer len result, got %s", result.VMValue.GetTypeName())
+	if result.TypeId != ds.VMTypeInt {
+		t.Fatalf("expected integer len result, got %s", result.GetTypeName())
 	}
-	if result.VMValue.MustReadInt() <= 0 {
+	if result.MustReadInt() <= 0 {
 		t.Fatal("expected player.keys().len() to be greater than 0")
 	}
 }
@@ -216,7 +236,7 @@ func TestPlayerObject_KeysDoesNotIncludeInjectedMethods(t *testing.T) {
 
 	keys, ok := result.ReadArray()
 	if !ok {
-		t.Fatalf("expected array result, got %s", result.VMValue.GetTypeName())
+		t.Fatalf("expected array result, got %s", result.GetTypeName())
 	}
 
 	items := map[string]bool{}
@@ -247,7 +267,7 @@ func TestPlayerObject_HasSupportsCanonicalAliasAndTemplateDefault(t *testing.T) 
 
 	arr, ok := result.ReadArray()
 	if !ok {
-		t.Fatalf("expected array result, got %s", result.VMValue.GetTypeName())
+		t.Fatalf("expected array result, got %s", result.GetTypeName())
 	}
 	if len(arr.List) != 3 {
 		t.Fatalf("expected 3 results, got %d", len(arr.List))

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/samber/lo v1.52.0
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083
-	github.com/sealdice/dicescript v0.0.0-20260103130502-bd5621347a4e
+	github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070
 	github.com/slack-go/slack v0.17.3
 	github.com/sunshineplan/imgconv v1.1.14
 	github.com/tailscale/hujson v0.0.0-20250605163823-992244df8c5a

--- a/go.sum
+++ b/go.sum
@@ -487,6 +487,8 @@ github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083 h1:s/jzCGYlM/0+TYTX
 github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083/go.mod h1:MGtR0REQDslBwQE+Rln4P9iDjH/ZInlu5qzOLdvBWJU=
 github.com/sealdice/dicescript v0.0.0-20260103130502-bd5621347a4e h1:Skv3TeB0vmvWN9SDhBmRWfsgudvXDkMyFhTgYpnQUoQ=
 github.com/sealdice/dicescript v0.0.0-20260103130502-bd5621347a4e/go.mod h1:uof752qJvEQ4Kze+NVag+RKGgj5C4K3kMHoK3e2vOLg=
+github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070 h1:C5zwdWiRpgMl3g3Q68csBaDWJLdUhYKfPGwJUkHXed0=
+github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070/go.mod h1:uof752qJvEQ4Kze+NVag+RKGgj5C4K3kMHoK3e2vOLg=
 github.com/sealdice/kook v0.0.3 h1:STMtiKRMFjhSFmUxi0BU5ktNkCQ8qi7Y5EEfrmYKvWY=
 github.com/sealdice/kook v0.0.3/go.mod h1:WjHC7AmbmNjInT/U/etBVOmAw7T6EqdCwApceRGs1sk=
 github.com/sergeymakinen/go-bmp v1.0.0 h1:SdGTzp9WvCV0A1V0mBeaS7kQAwNLdVJbmHlqNWq0R+M=


### PR DESCRIPTION
效果如图

<img width="758" height="884" alt="image" src="https://github.com/user-attachments/assets/818eb318-8adb-4c2d-a2f4-64f4bb79f163" />
<img width="758" height="884" alt="image" src="https://github.com/user-attachments/assets/734acefc-6790-4bd3-b639-c1770eeed99d" />

## Summary by Sourcery

向脚本 VM 注入一个玩家/角色属性对象，使骰子脚本能够通过别名解析和模板默认值来读取和写入人物卡数值。

New Features:
- 在脚本 VM 中暴露一个原生的玩家/角色对象，通过属性和索引器访问和修改玩家属性。
- 在脚本中读取角色属性时，支持基于别名的属性名解析以及模板默认值。
- 在玩家/角色对象上提供字典风格的辅助方法（`keys`、`values`、`items`、`len`、`has`）用于检查可用属性。

Tests:
- 添加全面的测试，覆盖玩家/角色对象的注入、属性读写行为、别名解析、模板默认值处理以及字典风格辅助方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject a player/actor attribute object into the script VM to allow dice scripts to read and write character sheet values with alias resolution and template defaults.

New Features:
- Expose a native player/actor object in the script VM for accessing and mutating player attributes via properties and indexers.
- Support alias-based attribute name resolution and template default values when reading character attributes from scripts.
- Provide dict-style helper methods (keys, values, items, len, has) on the player/actor object for inspecting available attributes.

Tests:
- Add comprehensive tests covering player/actor object injection, attribute read/write behavior, alias resolution, template default handling, and dict-style helper methods.

</details>