### PR TITLE
fix: 修复即使关闭了自动激活却依然错误激活插件的问题

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -2464,6 +2464,7 @@ func (d *Dice) ApplyExtDefaultSettings() {
 			v.ExtItem = extInfo
 			v.Loaded = true
 			extInfo.DefaultSetting = v
+			extInfo.AutoActive = v.AutoActive
 
 			// 为了避免锁问题，这里做一个新的map
 			m := map[string]bool{}

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -38,10 +38,6 @@ const (
 // ActiveWithGraph 描述扩展伴随关系：A -> [B,C] 表示激活 A 时需要附带 B、C。
 type ActiveWithGraph map[string][]string
 
-func shouldAutoActivateExt(ext *ExtInfo) bool {
-	return ext != nil && ext.AutoActive
-}
-
 func (d *Dice) rebuildActiveWithGraph() {
 	d.ActiveWithGraphMu.Lock()
 	defer d.ActiveWithGraphMu.Unlock()
@@ -623,7 +619,7 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 			continue
 		}
 		// 非首次加载，根据 AutoActive 决定
-		if shouldAutoActivateExt(ext) {
+		if ext != nil && ext.AutoActive {
 			group.extActivateInternal(ext, ActivateReasonFirstMessage)
 			known[ext.Name] = struct{}{}
 		} else {
@@ -759,7 +755,7 @@ func (group *GroupInfo) SyncExtensionsOnMessage(d *Dice) {
 		if _, exists := known[ext.Name]; exists {
 			continue
 		}
-		if shouldAutoActivateExt(ext) {
+		if ext != nil && ext.AutoActive {
 			group.extActivateInternal(ext, ActivateReasonFirstMessage)
 		} else {
 			group.AddToInactivated(ext.Name)

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -38,6 +38,16 @@ const (
 // ActiveWithGraph 描述扩展伴随关系：A -> [B,C] 表示激活 A 时需要附带 B、C。
 type ActiveWithGraph map[string][]string
 
+func shouldAutoActivateExt(ext *ExtInfo) bool {
+	if ext == nil {
+		return false
+	}
+	if ext.DefaultSetting != nil {
+		return ext.DefaultSetting.AutoActive
+	}
+	return ext.AutoActive
+}
+
 func (d *Dice) rebuildActiveWithGraph() {
 	d.ActiveWithGraphMu.Lock()
 	defer d.ActiveWithGraphMu.Unlock()
@@ -619,7 +629,7 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 			continue
 		}
 		// 非首次加载，根据 AutoActive 决定
-		if ext.AutoActive || (ext.DefaultSetting != nil && ext.DefaultSetting.AutoActive) {
+		if shouldAutoActivateExt(ext) {
 			group.extActivateInternal(ext, ActivateReasonFirstMessage)
 			known[ext.Name] = struct{}{}
 		} else {
@@ -755,7 +765,7 @@ func (group *GroupInfo) SyncExtensionsOnMessage(d *Dice) {
 		if _, exists := known[ext.Name]; exists {
 			continue
 		}
-		if ext.AutoActive || (ext.DefaultSetting != nil && ext.DefaultSetting.AutoActive) {
+		if shouldAutoActivateExt(ext) {
 			group.extActivateInternal(ext, ActivateReasonFirstMessage)
 		} else {
 			group.AddToInactivated(ext.Name)

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -39,13 +39,7 @@ const (
 type ActiveWithGraph map[string][]string
 
 func shouldAutoActivateExt(ext *ExtInfo) bool {
-	if ext == nil {
-		return false
-	}
-	if ext.DefaultSetting != nil {
-		return ext.DefaultSetting.AutoActive
-	}
-	return ext.AutoActive
+	return ext != nil && ext.AutoActive
 }
 
 func (d *Dice) rebuildActiveWithGraph() {

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -618,8 +618,7 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 			known[ext.Name] = struct{}{}
 			continue
 		}
-		// 非首次加载，根据 AutoActive 决定
-		if ext != nil && ext.AutoActive {
+		if ext.AutoActive {
 			group.extActivateInternal(ext, ActivateReasonFirstMessage)
 			known[ext.Name] = struct{}{}
 		} else {

--- a/dice/ext_self_test.go
+++ b/dice/ext_self_test.go
@@ -775,6 +775,55 @@ func TestReopenMainExtensionReopensCompanion(t *testing.T) {
 	t.Logf("✓ 重新开启主扩展成功重新激活伴随扩展")
 }
 
+func TestGetActivatedExtListRespectsDefaultSettingOverride(t *testing.T) {
+	ext := &ExtInfo{
+		Name:       "builtin-like",
+		AutoActive: true,
+		DefaultSetting: &ExtDefaultSettingItem{
+			Name:       "builtin-like",
+			AutoActive: false,
+		},
+	}
+	dice := newTestDice([]*ExtInfo{ext})
+	dice.ExtUpdateTime = 1
+
+	group := &GroupInfo{
+		InactivatedExtSet: make(StringSet),
+	}
+
+	got := group.GetActivatedExtList(dice)
+	if len(got) != 0 {
+		t.Fatalf("配置关闭的扩展不应在延迟初始化时被自动激活: got %v", extListToNames(got))
+	}
+	if !group.IsExtInactivated(ext.Name) {
+		t.Fatalf("配置关闭的扩展应被记录到 InactivatedExtSet")
+	}
+}
+
+func TestSyncExtensionsOnMessageRespectsDefaultSettingOverride(t *testing.T) {
+	ext := &ExtInfo{
+		Name:       "builtin-like",
+		AutoActive: true,
+		DefaultSetting: &ExtDefaultSettingItem{
+			Name:       "builtin-like",
+			AutoActive: false,
+		},
+	}
+	dice := newTestDice([]*ExtInfo{ext})
+	dice.ExtRegistryVersion = 1
+
+	group := newTestGroupInfo()
+	group.SyncExtensionsOnMessage(dice)
+
+	got := group.GetActivatedExtListRaw()
+	if len(got) != 0 {
+		t.Fatalf("配置关闭的扩展不应在同步阶段被自动激活: got %v", extListToNames(got))
+	}
+	if !group.IsExtInactivated(ext.Name) {
+		t.Fatalf("配置关闭的扩展应在同步阶段被记录到 InactivatedExtSet")
+	}
+}
+
 // 辅助函数：比较两个字符串切片是否相等
 func stringSliceEqual(a, b []string) bool {
 	if len(a) != len(b) {

--- a/dice/ext_self_test.go
+++ b/dice/ext_self_test.go
@@ -775,16 +775,46 @@ func TestReopenMainExtensionReopensCompanion(t *testing.T) {
 	t.Logf("✓ 重新开启主扩展成功重新激活伴随扩展")
 }
 
-func TestGetActivatedExtListRespectsDefaultSettingOverride(t *testing.T) {
+func TestApplyExtDefaultSettingsSyncsAutoActiveToExtInfo(t *testing.T) {
 	ext := &ExtInfo{
 		Name:       "builtin-like",
 		AutoActive: true,
-		DefaultSetting: &ExtDefaultSettingItem{
-			Name:       "builtin-like",
-			AutoActive: false,
-		},
+		CmdMap:     CmdMapCls{},
 	}
 	dice := newTestDice([]*ExtInfo{ext})
+	dice.Config.ExtDefaultSettings = []*ExtDefaultSettingItem{
+		{
+			Name:            "builtin-like",
+			AutoActive:      false,
+			DisabledCommand: map[string]bool{},
+		},
+	}
+
+	dice.ApplyExtDefaultSettings()
+
+	if ext.DefaultSetting == nil {
+		t.Fatalf("ApplyExtDefaultSettings 后应绑定 DefaultSetting")
+	}
+	if ext.AutoActive {
+		t.Fatalf("ApplyExtDefaultSettings 后 ext.AutoActive 应与配置同步为 false")
+	}
+}
+
+func TestGetActivatedExtListRespectsAppliedAutoActive(t *testing.T) {
+	ext := &ExtInfo{
+		Name:       "builtin-like",
+		AutoActive: true,
+		CmdMap:     CmdMapCls{},
+	}
+	dice := newTestDice([]*ExtInfo{ext})
+	dice.Config.ExtDefaultSettings = []*ExtDefaultSettingItem{
+		{
+			Name:            "builtin-like",
+			AutoActive:      false,
+			DisabledCommand: map[string]bool{},
+		},
+	}
+	dice.ApplyExtDefaultSettings()
 	dice.ExtUpdateTime = 1
 
 	group := &GroupInfo{
@@ -800,16 +830,21 @@ func TestGetActivatedExtListRespectsDefaultSettingOverride(t *testing.T) {
 	}
 }
 
-func TestSyncExtensionsOnMessageRespectsDefaultSettingOverride(t *testing.T) {
+func TestSyncExtensionsOnMessageRespectsAppliedAutoActive(t *testing.T) {
 	ext := &ExtInfo{
 		Name:       "builtin-like",
 		AutoActive: true,
-		DefaultSetting: &ExtDefaultSettingItem{
-			Name:       "builtin-like",
-			AutoActive: false,
-		},
+		CmdMap:     CmdMapCls{},
 	}
 	dice := newTestDice([]*ExtInfo{ext})
+	dice.Config.ExtDefaultSettings = []*ExtDefaultSettingItem{
+		{
+			Name:            "builtin-like",
+			AutoActive:      false,
+			DisabledCommand: map[string]bool{},
+		},
+	}
+	dice.ApplyExtDefaultSettings()
 	dice.ExtRegistryVersion = 1
 
 	group := newTestGroupInfo()

--- a/dice/im_helpers.go
+++ b/dice/im_helpers.go
@@ -248,7 +248,7 @@ func SetBotOnAtGroup(ctx *MsgContext, groupID string) *GroupInfo {
 		var extLst []*ExtInfo
 		for _, i := range session.Parent.Config.ExtDefaultSettings {
 			if i.ExtItem != nil {
-				if i.AutoActive {
+				if shouldAutoActivateExt(i.ExtItem) {
 					extLst = append(extLst, i.ExtItem)
 				}
 			}

--- a/dice/im_helpers.go
+++ b/dice/im_helpers.go
@@ -248,7 +248,7 @@ func SetBotOnAtGroup(ctx *MsgContext, groupID string) *GroupInfo {
 		var extLst []*ExtInfo
 		for _, i := range session.Parent.Config.ExtDefaultSettings {
 			if i.ExtItem != nil {
-				if shouldAutoActivateExt(i.ExtItem) {
+				if i.AutoActive {
 					extLst = append(extLst, i.ExtItem)
 				}
 			}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -169,7 +169,7 @@ func (g *GroupInfo) GetActivatedExtList(d *Dice) []*ExtInfo {
 			continue
 		}
 		// 新扩展：根据 AutoActive 决定是否激活
-		if ext != nil && ext.AutoActive {
+		if ext.AutoActive {
 			newList = append([]*ExtInfo{ext}, newList...) // 插入头部
 			activated[ext.Name] = true
 			newExtCount++

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -169,7 +169,7 @@ func (g *GroupInfo) GetActivatedExtList(d *Dice) []*ExtInfo {
 			continue
 		}
 		// 新扩展：根据 AutoActive 决定是否激活
-		if shouldAutoActivateExt(ext) {
+		if ext != nil && ext.AutoActive {
 			newList = append([]*ExtInfo{ext}, newList...) // 插入头部
 			activated[ext.Name] = true
 			newExtCount++

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -169,7 +169,7 @@ func (g *GroupInfo) GetActivatedExtList(d *Dice) []*ExtInfo {
 			continue
 		}
 		// 新扩展：根据 AutoActive 决定是否激活
-		if ext.AutoActive || (ext.DefaultSetting != nil && ext.DefaultSetting.AutoActive) {
+		if shouldAutoActivateExt(ext) {
 			newList = append([]*ExtInfo{ext}, newList...) // 插入头部
 			activated[ext.Name] = true
 			newExtCount++

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/blevesearch/bleve_index_api v1.2.11
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/bytedance/sonic v1.14.1
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/danielgtaylor/huma/v2 v2.34.1
 	github.com/dop251/goja v0.0.0-20260216154549-8b74ce4618c5
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
@@ -55,6 +56,7 @@ require (
 	github.com/mroth/weightedrand v1.0.0
 	github.com/ncruces/go-sqlite3 v0.32.0
 	github.com/ncruces/go-sqlite3/gormlite v0.24.0
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/open-dingtalk/dingtalk-stream-sdk-go v0.9.1
 	github.com/otiai10/copy v1.14.1
 	github.com/panjf2000/ants/v2 v2.11.3
@@ -125,7 +127,6 @@ require (
 	github.com/blevesearch/zapx/v16 v16.2.8 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dolthub/maphash v0.1.0 // indirect
@@ -177,7 +178,6 @@ require (
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
-	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pdfcpu/pdfcpu v0.11.0 // indirect


### PR DESCRIPTION
## Summary by Sourcery

确保扩展的自动激活遵循已应用的默认设置，并在所有激活路径中保持一致的判定逻辑。

Bug Fixes:
- 防止在扩展的默认设置中已禁用自动激活时仍被自动激活，涵盖延迟初始化和基于消息同步（sync-on-message）流程。

Enhancements:
- 将扩展自动激活逻辑集中到一个共享的辅助函数中，并使 `ExtInfo.AutoActive` 与已配置的默认设置保持同步。
- 在 `go.mod` 中将 `xxhash` 和 `ulid` 依赖从间接依赖提升为直接依赖。

Tests:
- 添加回归测试，以验证默认自动激活设置是否正确应用于扩展，并在激活和同步流程中得到遵守。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure extension auto-activation respects applied default settings and is consistently determined across activation paths.

Bug Fixes:
- Prevent extensions from being auto-activated when their default settings disable auto-activation, both during delayed initialization and sync-on-message flows.

Enhancements:
- Centralize extension auto-activation logic in a shared helper and synchronize ExtInfo.AutoActive with configured default settings.
- Promote xxhash and ulid dependencies from indirect to direct in go.mod.

Tests:
- Add regression tests to verify default auto-activation settings are applied to extensions and respected during activation and synchronization flows.

</details>