### PR TITLE
feat: 允许黑名单用户使用 .help 骰主

### DIFF
--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -19,6 +20,8 @@ const (
 	BanRankNormal  BanRankType = 0
 	BanRankTrusted BanRankType = 30
 )
+
+const blacklistedHelpMasterCooldown = time.Hour
 
 type BanListInfoItem struct {
 	ID      string      `jsbind:"id"      json:"ID"`
@@ -73,7 +76,9 @@ type BanListInfo struct {
 	JointScorePercentOfGroup   float64 `json:"jointScorePercentOfGroup"   yaml:"jointScorePercentOfGroup"`   // 群组连带责任
 	JointScorePercentOfInviter float64 `json:"jointScorePercentOfInviter" yaml:"jointScorePercentOfInviter"` // 邀请人连带责任
 
-	cronID cron.EntryID
+	helpMasterReplyMu sync.Mutex
+	helpMasterReplyAt int64
+	cronID            cron.EntryID
 }
 
 func (i *BanListInfo) Init() {
@@ -93,6 +98,19 @@ func (i *BanListInfo) Init() {
 	i.JointScorePercentOfGroup = 0.5
 	i.JointScorePercentOfInviter = 0.3
 	i.Map = new(SyncMap[string, *BanListInfoItem])
+}
+
+func (i *BanListInfo) CanReplyBlacklistedHelpMaster(_ string, now time.Time) bool {
+	i.helpMasterReplyMu.Lock()
+	defer i.helpMasterReplyMu.Unlock()
+
+	nowUnix := now.Unix()
+	if nowUnix-i.helpMasterReplyAt < int64(blacklistedHelpMasterCooldown/time.Second) {
+		return false
+	}
+
+	i.helpMasterReplyAt = nowUnix
+	return true
 }
 
 func (i *BanListInfo) Loads() {

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -21,7 +21,7 @@ const (
 	BanRankTrusted BanRankType = 30
 )
 
-const blacklistedHelpMasterCooldown = time.Hour
+const defaultBlacklistedHelpMasterCooldown = time.Hour
 
 type BanListInfoItem struct {
 	ID      string      `jsbind:"id"      json:"ID"`
@@ -68,10 +68,11 @@ type BanListInfo struct {
 	ThresholdBan                           int64                              `json:"thresholdBan"                           yaml:"thresholdBan"`                           // 错误阈值
 	AutoBanMinutes                         int64                              `json:"autoBanMinutes"                         yaml:"autoBanMinutes"`                         // 自动禁止时长
 
-	ScoreReducePerMinute int64 `json:"scoreReducePerMinute" yaml:"scoreReducePerMinute"` // 每分钟下降
-	ScoreGroupMuted      int64 `json:"scoreGroupMuted"      yaml:"scoreGroupMuted"`      // 群组禁言
-	ScoreGroupKicked     int64 `json:"scoreGroupKicked"     yaml:"scoreGroupKicked"`     // 群组踢出
-	ScoreTooManyCommand  int64 `json:"scoreTooManyCommand"  yaml:"scoreTooManyCommand"`  // 刷指令
+	ScoreReducePerMinute      int64 `json:"scoreReducePerMinute" yaml:"scoreReducePerMinute"`           // 每分钟下降
+	ScoreGroupMuted           int64 `json:"scoreGroupMuted"      yaml:"scoreGroupMuted"`                // 群组禁言
+	ScoreGroupKicked          int64 `json:"scoreGroupKicked"     yaml:"scoreGroupKicked"`               // 群组踢出
+	ScoreTooManyCommand       int64 `json:"scoreTooManyCommand"  yaml:"scoreTooManyCommand"`            // 刷指令
+	HelpMasterCooldownMinutes int64 `json:"helpMasterCooldownMinutes" yaml:"helpMasterCooldownMinutes"` // 黑名单用户使用.help 骰主的冷却分钟数
 
 	JointScorePercentOfGroup   float64 `json:"jointScorePercentOfGroup"   yaml:"jointScorePercentOfGroup"`   // 群组连带责任
 	JointScorePercentOfInviter float64 `json:"jointScorePercentOfInviter" yaml:"jointScorePercentOfInviter"` // 邀请人连带责任
@@ -94,11 +95,27 @@ func (i *BanListInfo) Init() {
 	i.ScoreGroupMuted = 100
 	i.ScoreGroupKicked = 200
 	i.ScoreTooManyCommand = 100
+	i.HelpMasterCooldownMinutes = int64(defaultBlacklistedHelpMasterCooldown / time.Minute)
 
 	i.JointScorePercentOfGroup = 0.5
 	i.JointScorePercentOfInviter = 0.3
 	i.Map = new(SyncMap[string, *BanListInfoItem])
 	i.helpMasterReplyAt = map[string]time.Time{}
+}
+
+func (i *BanListInfo) BlacklistedHelpMasterCooldown() time.Duration {
+	if i.HelpMasterCooldownMinutes <= 0 {
+		return defaultBlacklistedHelpMasterCooldown
+	}
+	return time.Duration(i.HelpMasterCooldownMinutes) * time.Minute
+}
+
+func (i *BanListInfo) cleanupBlacklistedHelpMasterReplyAtLocked(now time.Time, cooldown time.Duration) {
+	for userID, replyAt := range i.helpMasterReplyAt {
+		if now.Sub(replyAt) >= cooldown {
+			delete(i.helpMasterReplyAt, userID)
+		}
+	}
 }
 
 func (i *BanListInfo) CanReplyBlacklistedHelpMaster(userID string, now time.Time) bool {
@@ -108,8 +125,10 @@ func (i *BanListInfo) CanReplyBlacklistedHelpMaster(userID string, now time.Time
 	if i.helpMasterReplyAt == nil {
 		i.helpMasterReplyAt = map[string]time.Time{}
 	}
+	cooldown := i.BlacklistedHelpMasterCooldown()
+	i.cleanupBlacklistedHelpMasterReplyAtLocked(now, cooldown)
 
-	if lastReplyAt, ok := i.helpMasterReplyAt[userID]; ok && now.Sub(lastReplyAt) < blacklistedHelpMasterCooldown {
+	if lastReplyAt, ok := i.helpMasterReplyAt[userID]; ok && now.Sub(lastReplyAt) < cooldown {
 		return false
 	}
 
@@ -124,6 +143,10 @@ func (i *BanListInfo) AfterLoads() {
 	// 加载完成了
 	d := i.Parent
 	i.cronID, _ = d.Parent.Cron.AddFunc("@every 1m", func() {
+		i.helpMasterReplyMu.Lock()
+		i.cleanupBlacklistedHelpMasterReplyAtLocked(time.Now(), i.BlacklistedHelpMasterCooldown())
+		i.helpMasterReplyMu.Unlock()
+
 		if d.DBOperator == nil {
 			return
 		}

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -76,7 +76,7 @@ type BanListInfo struct {
 	JointScorePercentOfGroup   float64 `json:"jointScorePercentOfGroup"   yaml:"jointScorePercentOfGroup"`   // 群组连带责任
 	JointScorePercentOfInviter float64 `json:"jointScorePercentOfInviter" yaml:"jointScorePercentOfInviter"` // 邀请人连带责任
 
-	helpMasterReplyMu sync.Mutex          `json:"-" yaml:"-"`
+	helpMasterReplyMu sync.Mutex           `json:"-" yaml:"-"`
 	helpMasterReplyAt map[string]time.Time `json:"-" yaml:"-"`
 	cronID            cron.EntryID         `json:"-" yaml:"-"`
 }

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -77,7 +77,7 @@ type BanListInfo struct {
 	JointScorePercentOfInviter float64 `json:"jointScorePercentOfInviter" yaml:"jointScorePercentOfInviter"` // 邀请人连带责任
 
 	helpMasterReplyMu sync.Mutex
-	helpMasterReplyAt int64
+	helpMasterReplyAt map[string]time.Time
 	cronID            cron.EntryID
 }
 
@@ -98,18 +98,22 @@ func (i *BanListInfo) Init() {
 	i.JointScorePercentOfGroup = 0.5
 	i.JointScorePercentOfInviter = 0.3
 	i.Map = new(SyncMap[string, *BanListInfoItem])
+	i.helpMasterReplyAt = map[string]time.Time{}
 }
 
-func (i *BanListInfo) CanReplyBlacklistedHelpMaster(_ string, now time.Time) bool {
+func (i *BanListInfo) CanReplyBlacklistedHelpMaster(userID string, now time.Time) bool {
 	i.helpMasterReplyMu.Lock()
 	defer i.helpMasterReplyMu.Unlock()
 
-	nowUnix := now.Unix()
-	if nowUnix-i.helpMasterReplyAt < int64(blacklistedHelpMasterCooldown/time.Second) {
+	if i.helpMasterReplyAt == nil {
+		i.helpMasterReplyAt = map[string]time.Time{}
+	}
+
+	if lastReplyAt, ok := i.helpMasterReplyAt[userID]; ok && now.Sub(lastReplyAt) < blacklistedHelpMasterCooldown {
 		return false
 	}
 
-	i.helpMasterReplyAt = nowUnix
+	i.helpMasterReplyAt[userID] = now
 	return true
 }
 

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -76,9 +76,9 @@ type BanListInfo struct {
 	JointScorePercentOfGroup   float64 `json:"jointScorePercentOfGroup"   yaml:"jointScorePercentOfGroup"`   // 群组连带责任
 	JointScorePercentOfInviter float64 `json:"jointScorePercentOfInviter" yaml:"jointScorePercentOfInviter"` // 邀请人连带责任
 
-	helpMasterReplyMu sync.Mutex
-	helpMasterReplyAt map[string]time.Time
-	cronID            cron.EntryID
+	helpMasterReplyMu sync.Mutex          `json:"-" yaml:"-"`
+	helpMasterReplyAt map[string]time.Time `json:"-" yaml:"-"`
+	cronID            cron.EntryID         `json:"-" yaml:"-"`
 }
 
 func (i *BanListInfo) Init() {

--- a/dice/dice_ban_test.go
+++ b/dice/dice_ban_test.go
@@ -10,6 +10,7 @@ import (
 func TestCanReplyBlacklistedHelpMasterPerUserCooldown(t *testing.T) {
 	var banList dice.BanListInfo
 	banList.Init()
+	banList.HelpMasterCooldownMinutes = 10
 
 	base := time.Unix(1_700_000_000, 0)
 
@@ -17,15 +18,15 @@ func TestCanReplyBlacklistedHelpMasterPerUserCooldown(t *testing.T) {
 		t.Fatal("expected first help-master reply for user to be allowed")
 	}
 
-	if banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(30*time.Minute)) {
+	if banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(5*time.Minute)) {
 		t.Fatal("expected same user to be throttled within cooldown")
 	}
 
-	if !banList.CanReplyBlacklistedHelpMaster("QQ:1002", base.Add(30*time.Minute)) {
+	if !banList.CanReplyBlacklistedHelpMaster("QQ:1002", base.Add(5*time.Minute)) {
 		t.Fatal("expected different user to bypass another user's cooldown")
 	}
 
-	if !banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(time.Hour+time.Minute)) {
+	if !banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(11*time.Minute)) {
 		t.Fatal("expected same user to be allowed after cooldown elapsed")
 	}
 }

--- a/dice/dice_ban_test.go
+++ b/dice/dice_ban_test.go
@@ -1,12 +1,14 @@
-package dice
+package dice_test
 
 import (
 	"testing"
 	"time"
+
+	"sealdice-core/dice"
 )
 
 func TestCanReplyBlacklistedHelpMasterPerUserCooldown(t *testing.T) {
-	var banList BanListInfo
+	var banList dice.BanListInfo
 	banList.Init()
 
 	base := time.Unix(1_700_000_000, 0)
@@ -23,7 +25,7 @@ func TestCanReplyBlacklistedHelpMasterPerUserCooldown(t *testing.T) {
 		t.Fatal("expected different user to bypass another user's cooldown")
 	}
 
-	if !banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(blacklistedHelpMasterCooldown+time.Minute)) {
+	if !banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(time.Hour+time.Minute)) {
 		t.Fatal("expected same user to be allowed after cooldown elapsed")
 	}
 }

--- a/dice/dice_ban_test.go
+++ b/dice/dice_ban_test.go
@@ -1,0 +1,29 @@
+package dice
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCanReplyBlacklistedHelpMasterPerUserCooldown(t *testing.T) {
+	var banList BanListInfo
+	banList.Init()
+
+	base := time.Unix(1_700_000_000, 0)
+
+	if !banList.CanReplyBlacklistedHelpMaster("QQ:1001", base) {
+		t.Fatal("expected first help-master reply for user to be allowed")
+	}
+
+	if banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(30*time.Minute)) {
+		t.Fatal("expected same user to be throttled within cooldown")
+	}
+
+	if !banList.CanReplyBlacklistedHelpMaster("QQ:1002", base.Add(30*time.Minute)) {
+		t.Fatal("expected different user to bypass another user's cooldown")
+	}
+
+	if !banList.CanReplyBlacklistedHelpMaster("QQ:1001", base.Add(blacklistedHelpMasterCooldown+time.Minute)) {
+		t.Fatal("expected same user to be allowed after cooldown elapsed")
+	}
+}

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -343,6 +343,45 @@ func TestExecuteNew_PrivateCommand_Roll(t *testing.T) {
 	}
 }
 
+func TestExecuteNew_BlacklistedHelpMasterAllowedOnce(t *testing.T) {
+	d, ep, adapter, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	d.Config.BanList.Map.Store("QQ:999", &BanListInfoItem{ID: "QQ:999", Rank: BanRankBanned})
+
+	d.ImSession.ExecuteNew(ep, newPrivateMsg("QQ:999", ".help 骰主"))
+
+	got, ok := adapter.waitForMsg(2 * time.Second)
+	if !ok {
+		t.Fatal("timeout: expected blacklisted user to receive help-master reply")
+	}
+	if !strings.Contains(got, "骰主") {
+		t.Fatalf("unexpected help reply: %q", got)
+	}
+
+	d.ImSession.ExecuteNew(ep, newPrivateMsg("QQ:999", ".help 骰主"))
+
+	select {
+	case unexpected := <-adapter.msgCh:
+		t.Fatalf("expected cooldown to suppress repeated reply, got %q", unexpected)
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	d.ImSession.ExecuteNew(ep, newPrivateMsg("QQ:999", ".help 协议"))
+	select {
+	case unexpected := <-adapter.msgCh:
+		t.Fatalf("expected other help topics to stay silent, got %q", unexpected)
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	d.ImSession.ExecuteNew(ep, newPrivateMsg("QQ:999", ".r 1d6"))
+	select {
+	case unexpected := <-adapter.msgCh:
+		t.Fatalf("expected other commands to stay silent, got %q", unexpected)
+	case <-time.After(400 * time.Millisecond):
+	}
+}
+
 // TestExecuteNew_GroupMessage_NonCommand verifies that a plain chat message
 // (no command prefix) does NOT produce a bot reply.
 func TestExecuteNew_GroupMessage_NonCommand(t *testing.T) {

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -365,6 +366,17 @@ func TestExecuteNew_BlacklistedHelpMasterAllowedOnce(t *testing.T) {
 	case unexpected := <-adapter.msgCh:
 		t.Fatalf("expected cooldown to suppress repeated reply, got %q", unexpected)
 	case <-time.After(400 * time.Millisecond):
+	}
+
+	d.Config.BanList.Map.Store("QQ:1000", &BanListInfoItem{ID: "QQ:1000", Rank: BanRankBanned})
+	d.ImSession.ExecuteNew(ep, newPrivateMsg("QQ:1000", ".help 骰主"))
+
+	got, ok = adapter.waitForMsg(2 * time.Second)
+	if !ok {
+		t.Fatal("timeout: expected a different blacklisted user to receive help-master reply")
+	}
+	if !strings.Contains(got, "骰主") {
+		t.Fatalf("unexpected help reply for second user: %q", got)
 	}
 
 	d.ImSession.ExecuteNew(ep, newPrivateMsg("QQ:999", ".help 协议"))

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1792,6 +1792,23 @@ func FormatBlacklistReasons(v *BanListInfoItem) string {
 	return reasontext
 }
 
+func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message) bool {
+	cmdArgs := CommandParse(msg.Message, []string{"help"}, ctx.Dice.CommandPrefix, msg.Platform, false)
+	if cmdArgs == nil || !strings.EqualFold(cmdArgs.Command, "help") {
+		return false
+	}
+	if len(cmdArgs.Args) != 1 || !cmdArgs.IsArgEqual(1, "骰主") {
+		return false
+	}
+	if !ctx.Dice.Config.BanList.CanReplyBlacklistedHelpMaster(msg.Sender.UserID, time.Now()) {
+		return true
+	}
+
+	ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:骰子帮助文本_骰主"))
+	ctx.Dice.Logger.Infof("响应黑名单用户 .help 骰主 请求: <%s>(%s)", msg.Sender.Nickname, msg.Sender.UserID)
+	return true
+}
+
 // checkBan 黑名单拦截
 func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 	d := ctx.Dice
@@ -1875,6 +1892,9 @@ func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 				banQuitGroup()
 			}
 		} else if d.Config.BanList.BanBehaviorRefuseReply {
+			if tryHandleBlacklistedHelpMasterRequest(ctx, msg) {
+				return true
+			}
 			notReply = true
 			// 黑名单用户 - 拒绝回复
 			log.Infof("忽略黑名单用户信息: 来自群(%s)内<%s>(%s): %s", msg.GroupID, msg.Sender.Nickname, msg.Sender.UserID, msg.Message)

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1814,6 +1814,79 @@ func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message, now ti
 	return true
 }
 
+func handleBlacklistedUserQuitIfAdmin(ctx *MsgContext, msg *Message, isWhiteGroup bool, banQuitGroup func()) bool {
+	d := ctx.Dice
+	log := d.Logger
+	banListInfoItem, _ := d.Config.BanList.GetByID(msg.Sender.UserID)
+	reasontext := FormatBlacklistReasons(banListInfoItem)
+	groupID := msg.GroupID
+
+	if ctx.GroupRoleLevel >= 40 {
+		if isWhiteGroup {
+			log.Infof("收到群(%s)内邀请者以上权限黑名单用户<%s>(%s)的消息，但在信任群所以不尝试退群", groupID, msg.Sender.Nickname, msg.Sender.UserID)
+			return true
+		}
+
+		text := fmt.Sprintf("警告: <%s>(%s)是黑名单用户，将对骰主进行通知并退群。", msg.Sender.Nickname, msg.Sender.UserID)
+		ReplyGroupRaw(ctx, &Message{GroupID: groupID}, text, "")
+
+		noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是管理以上权限，执行通告后自动退群\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
+		log.Info(noticeMsg)
+		ctx.Notice(noticeMsg)
+		banQuitGroup()
+		return true
+	}
+
+	if isWhiteGroup {
+		log.Infof("收到群(%s)内普通群员黑名单用户<%s>(%s)的消息，但在信任群所以不做其他操作", groupID, msg.Sender.Nickname, msg.Sender.UserID)
+		return true
+	}
+
+	if d.Config.BanList.BanBehaviorQuitIfAdmin {
+		noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是普通群员，进行群内通告\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
+		log.Info(noticeMsg)
+
+		text := fmt.Sprintf("警告: <%s>(%s)是黑名单用户，将对骰主进行通知。", msg.Sender.Nickname, msg.Sender.UserID)
+		ReplyGroupRaw(ctx, &Message{GroupID: groupID}, text, "")
+
+		ctx.Notice(noticeMsg)
+		return true
+	}
+
+	noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是普通群员，忽略黑名单用户信息，不做其他操作\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
+	log.Info(noticeMsg)
+	return true
+}
+
+func handleBlacklistedUser(ctx *MsgContext, msg *Message, isWhiteGroup bool, now time.Time, banQuitGroup func()) bool {
+	d := ctx.Dice
+	log := d.Logger
+
+	if (d.Config.BanList.BanBehaviorQuitIfAdmin || d.Config.BanList.BanBehaviorQuitIfAdminSilentIfNotAdmin) && msg.MessageType == "group" {
+		return handleBlacklistedUserQuitIfAdmin(ctx, msg, isWhiteGroup, banQuitGroup)
+	}
+
+	if d.Config.BanList.BanBehaviorQuitPlaceImmediately && msg.MessageType == "group" {
+		groupID := msg.GroupID
+		if isWhiteGroup {
+			log.Infof("收到群(%s)内黑名单用户<%s>(%s)的消息，但在信任群所以不尝试退群", groupID, msg.Sender.Nickname, msg.Sender.UserID)
+			return true
+		}
+		banQuitGroup()
+		return true
+	}
+
+	if d.Config.BanList.BanBehaviorRefuseReply {
+		if tryHandleBlacklistedHelpMasterRequest(ctx, msg, now) {
+			return true
+		}
+		log.Infof("忽略黑名单用户信息: 来自群(%s)内<%s>(%s): %s", msg.GroupID, msg.Sender.Nickname, msg.Sender.UserID, msg.Message)
+		return true
+	}
+
+	return false
+}
+
 // checkBan 黑名单拦截
 func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 	d := ctx.Dice
@@ -1850,61 +1923,7 @@ func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 	}
 
 	if ctx.PrivilegeLevel == -30 {
-		groupLevel := ctx.GroupRoleLevel
-		if (d.Config.BanList.BanBehaviorQuitIfAdmin || d.Config.BanList.BanBehaviorQuitIfAdminSilentIfNotAdmin) && msg.MessageType == "group" {
-			// 黑名单用户 - 立即退出所在群
-			banListInfoItem, _ := ctx.Dice.Config.BanList.GetByID(msg.Sender.UserID)
-			reasontext := FormatBlacklistReasons(banListInfoItem)
-			groupID := msg.GroupID
-			notReply = true
-			if groupLevel >= 40 {
-				if isWhiteGroup {
-					log.Infof("收到群(%s)内邀请者以上权限黑名单用户<%s>(%s)的消息，但在信任群所以不尝试退群", groupID, msg.Sender.Nickname, msg.Sender.UserID)
-				} else {
-					text := fmt.Sprintf("警告: <%s>(%s)是黑名单用户，将对骰主进行通知并退群。", msg.Sender.Nickname, msg.Sender.UserID)
-					ReplyGroupRaw(ctx, &Message{GroupID: groupID}, text, "")
-
-					noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是管理以上权限，执行通告后自动退群\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
-					log.Info(noticeMsg)
-					ctx.Notice(noticeMsg)
-					banQuitGroup()
-				}
-			} else {
-				if isWhiteGroup {
-					log.Infof("收到群(%s)内普通群员黑名单用户<%s>(%s)的消息，但在信任群所以不做其他操作", groupID, msg.Sender.Nickname, msg.Sender.UserID)
-				} else {
-					notReply = true
-					if d.Config.BanList.BanBehaviorQuitIfAdmin {
-						noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是普通群员，进行群内通告\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
-						log.Info(noticeMsg)
-
-						text := fmt.Sprintf("警告: <%s>(%s)是黑名单用户，将对骰主进行通知。", msg.Sender.Nickname, msg.Sender.UserID)
-						ReplyGroupRaw(ctx, &Message{GroupID: groupID}, text, "")
-
-						ctx.Notice(noticeMsg)
-					} else {
-						noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是普通群员，忽略黑名单用户信息，不做其他操作\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
-						log.Info(noticeMsg)
-					}
-				}
-			}
-		} else if d.Config.BanList.BanBehaviorQuitPlaceImmediately && msg.MessageType == "group" {
-			notReply = true
-			// 黑名单用户 - 立即退出所在群
-			groupID := msg.GroupID
-			if isWhiteGroup {
-				log.Infof("收到群(%s)内黑名单用户<%s>(%s)的消息，但在信任群所以不尝试退群", groupID, msg.Sender.Nickname, msg.Sender.UserID)
-			} else {
-				banQuitGroup()
-			}
-		} else if d.Config.BanList.BanBehaviorRefuseReply {
-			if tryHandleBlacklistedHelpMasterRequest(ctx, msg, now) {
-				return true
-			}
-			notReply = true
-			// 黑名单用户 - 拒绝回复
-			log.Infof("忽略黑名单用户信息: 来自群(%s)内<%s>(%s): %s", msg.GroupID, msg.Sender.Nickname, msg.Sender.UserID, msg.Message)
-		}
+		return handleBlacklistedUser(ctx, msg, isWhiteGroup, now, banQuitGroup)
 	} else if isBanGroup {
 		if d.Config.BanList.BanBehaviorQuitPlaceImmediately && !isWhiteGroup {
 			notReply = true

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1799,10 +1799,7 @@ func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message, now ti
 	} else {
 		cmdArgs = CommandParse(msg.Message, []string{"help"}, ctx.Dice.CommandPrefix, msg.Platform, false)
 	}
-	if cmdArgs == nil || !strings.EqualFold(cmdArgs.Command, "help") {
-		return false
-	}
-	if len(cmdArgs.Args) != 1 || !cmdArgs.IsArgEqual(1, "骰主") {
+	if !isBlacklistedHelpMasterRequest(cmdArgs) {
 		return false
 	}
 	if !ctx.Dice.Config.BanList.CanReplyBlacklistedHelpMaster(msg.Sender.UserID, now) {
@@ -1812,6 +1809,13 @@ func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message, now ti
 	ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:骰子帮助文本_骰主"))
 	ctx.Dice.Logger.Infof("响应黑名单用户 .help 骰主 请求: <%s>(%s)", msg.Sender.Nickname, msg.Sender.UserID)
 	return true
+}
+
+func isBlacklistedHelpMasterRequest(cmdArgs *CmdArgs) bool {
+	if cmdArgs == nil || !strings.EqualFold(cmdArgs.Command, "help") {
+		return false
+	}
+	return len(cmdArgs.Args) == 1 && cmdArgs.IsArgEqual(1, "骰主")
 }
 
 func handleBlacklistedUserQuitIfAdmin(ctx *MsgContext, msg *Message, isWhiteGroup bool, banQuitGroup func()) bool {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1792,7 +1792,7 @@ func FormatBlacklistReasons(v *BanListInfoItem) string {
 	return reasontext
 }
 
-func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message) bool {
+func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message, now time.Time) bool {
 	var cmdArgs *CmdArgs
 	if len(msg.Segment) > 0 {
 		cmdArgs = CommandParseNew(ctx, msg)
@@ -1805,7 +1805,7 @@ func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message) bool {
 	if len(cmdArgs.Args) != 1 || !cmdArgs.IsArgEqual(1, "骰主") {
 		return false
 	}
-	if !ctx.Dice.Config.BanList.CanReplyBlacklistedHelpMaster(msg.Sender.UserID, time.Now()) {
+	if !ctx.Dice.Config.BanList.CanReplyBlacklistedHelpMaster(msg.Sender.UserID, now) {
 		return true
 	}
 
@@ -1818,6 +1818,7 @@ func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message) bool {
 func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 	d := ctx.Dice
 	log := d.Logger
+	now := time.Now()
 	var isBanGroup, isWhiteGroup bool
 	// log.Info("check ban ", msg.MessageType, " ", msg.GroupID, " ", ctx.PrivilegeLevel)
 	if msg.MessageType == "group" {
@@ -1897,7 +1898,7 @@ func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 				banQuitGroup()
 			}
 		} else if d.Config.BanList.BanBehaviorRefuseReply {
-			if tryHandleBlacklistedHelpMasterRequest(ctx, msg) {
+			if tryHandleBlacklistedHelpMasterRequest(ctx, msg, now) {
 				return true
 			}
 			notReply = true

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1793,7 +1793,12 @@ func FormatBlacklistReasons(v *BanListInfoItem) string {
 }
 
 func tryHandleBlacklistedHelpMasterRequest(ctx *MsgContext, msg *Message) bool {
-	cmdArgs := CommandParse(msg.Message, []string{"help"}, ctx.Dice.CommandPrefix, msg.Platform, false)
+	var cmdArgs *CmdArgs
+	if len(msg.Segment) > 0 {
+		cmdArgs = CommandParseNew(ctx, msg)
+	} else {
+		cmdArgs = CommandParse(msg.Message, []string{"help"}, ctx.Dice.CommandPrefix, msg.Platform, false)
+	}
 	if cmdArgs == nil || !strings.EqualFold(cmdArgs.Command, "help") {
 		return false
 	}


### PR DESCRIPTION
## 由 Sourcery 总结

允许被拉黑的用户在每个冷却周期内调用一次 `.help 骰主` 命令，同时仍然禁止其使用其他命令。

新功能：
- 引入一个特殊处理逻辑，当被拉黑用户请求 `.help 骰主` 时进行回复，并记录这些请求日志。

改进：
- 添加冷却机制，限制被拉黑用户获取 `.help 骰主` 回复的频率。
- 扩展封禁列表状态，用于记录上一次向被拉黑用户发送 help-master 回复的时间。

测试：
- 添加测试，用于覆盖被拉黑用户请求 `.help 骰主` 的新行为，包括冷却机制以及对非 help 命令的拦截。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

允许被拉黑用户在保持其他指令被阻止的前提下，以“每用户冷却时间”的方式接收 `.help 骰主` 的帮助响应，并据此重构黑名单处理逻辑。

New Features:
- 允许被拉黑用户调用 `.help 骰主`，并在每个冷却周期内收到一次骰主帮助回复，同时仍然阻止其使用其他指令。

Enhancements:
- 引入集中式的黑名单行为处理器，包括管理员/退出逻辑，以及对被拉黑用户的帮助请求进行特殊处理。
- 在封禁列表状态中添加按用户记录的冷却追踪器，用于限制向被拉黑用户发送骰主帮助回复的频率。

Tests:
- 添加集成测试，覆盖被拉黑用户接收 `.help 骰主` 回复、冷却行为以及其他指令持续被阻止的场景。
- 为封禁列表组件中的“按用户骰主帮助冷却逻辑”添加单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow blacklisted users to receive the `.help 骰主` help response under a per-user cooldown while keeping other commands blocked and refactor blacklist handling logic accordingly.

New Features:
- Permit blacklisted users to invoke `.help 骰主` and receive the dice-master help reply once per cooldown period while remaining blocked from other commands.

Enhancements:
- Introduce centralized handlers for blacklist behaviors, including admin/quit logic and special-casing help requests for blacklisted users.
- Add a per-user cooldown tracker in the ban list state to throttle help-master responses to blacklisted users.

Tests:
- Add integration-style tests covering blacklisted users receiving `.help 骰主` replies, cooldown behavior, and continued blocking of other commands.
- Add unit tests for the per-user help-master cooldown logic in the ban list component.

</details>

</details>