### PR TITLE
feat: 指令测试接口支持回复分段设置

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -280,15 +280,54 @@ var (
 	lastGroupExecTime   int64
 )
 
+func isValidUITestReplySplitLen(splitLen int) bool {
+	switch splitLen {
+	case dice.UITestReplySplitLenShort,
+		dice.UITestReplySplitLenQQ,
+		dice.UITestReplySplitLenUnlimited:
+		return true
+	default:
+		return false
+	}
+}
+
+func DiceExecSplitOptions(c echo.Context) error {
+	if !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+
+	return c.JSON(200, map[string]interface{}{
+		"defaultKey": "short",
+		"options": []map[string]interface{}{
+			{
+				"key":             "short",
+				"label":           fmt.Sprintf("短分段 %d", dice.UITestReplySplitLenShort),
+				"messageSplitLen": dice.UITestReplySplitLenShort,
+			},
+			{
+				"key":             "qq",
+				"label":           fmt.Sprintf("QQ 分段 %d", dice.UITestReplySplitLenQQ),
+				"messageSplitLen": dice.UITestReplySplitLenQQ,
+			},
+			{
+				"key":             "unlimited",
+				"label":           "无限",
+				"messageSplitLen": dice.UITestReplySplitLenUnlimited,
+			},
+		},
+	})
+}
+
 func DiceExec(c echo.Context) error {
 	if !doAuth(c) {
 		return c.JSON(http.StatusForbidden, nil)
 	}
 
 	v := struct {
-		ID          string `form:"id"          json:"id"`
-		Message     string `form:"message"`
-		MessageType string `form:"messageType"`
+		ID              string `form:"id"              json:"id"`
+		Message         string `form:"message"`
+		MessageType     string `form:"messageType"`
+		MessageSplitLen *int   `form:"messageSplitLen" json:"messageSplitLen"`
 	}{}
 	err := c.Bind(&v)
 	if err != nil {
@@ -296,6 +335,9 @@ func DiceExec(c echo.Context) error {
 	}
 	if v.Message == "" {
 		return c.JSON(400, "格式错误")
+	}
+	if v.MessageSplitLen != nil && !isValidUITestReplySplitLen(*v.MessageSplitLen) {
+		return c.JSON(400, "分段长度无效")
 	}
 	timeNeed := int64(500)
 	if dm.JustForTest {
@@ -325,10 +367,17 @@ func DiceExec(c echo.Context) error {
 		lastPrivateExecTime = now
 	}
 
+	var uiTestReplySplitLen *int
+	if v.MessageSplitLen != nil {
+		splitLen := *v.MessageSplitLen
+		uiTestReplySplitLen = &splitLen
+	}
+
 	msg := &dice.Message{
-		MessageType: messageType,
-		Message:     v.Message,
-		Platform:    "UI",
+		MessageType:         messageType,
+		Message:             v.Message,
+		Platform:            "UI",
+		UITestReplySplitLen: uiTestReplySplitLen,
 		Sender: dice.SenderBase{
 			Nickname:  "User",
 			UserID:    userID,
@@ -604,6 +653,7 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.GET(prefix+"/dice/config/advanced/get", DiceAdvancedConfigGet)
 	e.POST(prefix+"/dice/config/advanced/set", DiceAdvancedConfigSet)
 	e.POST(prefix+"/dice/config/mail_test", DiceMailTest)
+	e.GET(prefix+"/dice/exec/split_options", DiceExecSplitOptions)
 	e.POST(prefix+"/dice/exec", DiceExec)
 	e.GET(prefix+"/dice/recentMessage", DiceRecentMessage)
 	e.GET(prefix+"/dice/cmdList", DiceAllCommand)

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -367,17 +367,11 @@ func DiceExec(c echo.Context) error {
 		lastPrivateExecTime = now
 	}
 
-	var uiTestReplySplitLen *int
-	if v.MessageSplitLen != nil {
-		splitLen := *v.MessageSplitLen
-		uiTestReplySplitLen = &splitLen
-	}
-
 	msg := &dice.Message{
 		MessageType:         messageType,
 		Message:             v.Message,
 		Platform:            "UI",
-		UITestReplySplitLen: uiTestReplySplitLen,
+		UITestReplySplitLen: v.MessageSplitLen,
 		Sender: dice.SenderBase{
 			Nickname:  "User",
 			UserID:    userID,

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -297,7 +297,7 @@ func DiceExecSplitOptions(c echo.Context) error {
 	}
 
 	return c.JSON(200, map[string]interface{}{
-		"defaultKey": "short",
+		"defaultKey": "qq",
 		"options": []map[string]interface{}{
 			{
 				"key":             "short",

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -44,17 +44,18 @@ type SenderBase struct {
 // 人物(是谁发的)
 // 内容
 type Message struct {
-	Time        int64       `jsbind:"time"        json:"time"`        // 发送时间
-	MessageType string      `jsbind:"messageType" json:"messageType"` // group private
-	GroupID     string      `jsbind:"groupId"     json:"groupId"`     // 群号，如果是群聊消息
-	GuildID     string      `jsbind:"guildId"     json:"guildId"`     // 服务器群组号，会在discord,kook,dodo等平台见到
-	ChannelID   string      `jsbind:"channelId"   json:"channelId"`
-	Sender      SenderBase  `jsbind:"sender"      json:"sender"`   // 发送者
-	Message     string      `jsbind:"message"     json:"message"`  // 消息内容
-	RawID       interface{} `jsbind:"rawId"       json:"rawId"`    // 原始信息ID，用于处理撤回等
-	Platform    string      `jsbind:"platform"    json:"platform"` // 当前平台
-	GroupName   string      `json:"groupName"`
-	TmpUID      string      `json:"-"             yaml:"-"`
+	Time                int64       `jsbind:"time"        json:"time"`        // 发送时间
+	MessageType         string      `jsbind:"messageType" json:"messageType"` // group private
+	GroupID             string      `jsbind:"groupId"     json:"groupId"`     // 群号，如果是群聊消息
+	GuildID             string      `jsbind:"guildId"     json:"guildId"`     // 服务器群组号，会在discord,kook,dodo等平台见到
+	ChannelID           string      `jsbind:"channelId"   json:"channelId"`
+	Sender              SenderBase  `jsbind:"sender"      json:"sender"`   // 发送者
+	Message             string      `jsbind:"message"     json:"message"`  // 消息内容
+	RawID               interface{} `jsbind:"rawId"       json:"rawId"`    // 原始信息ID，用于处理撤回等
+	Platform            string      `jsbind:"platform"    json:"platform"` // 当前平台
+	GroupName           string      `json:"groupName"`
+	TmpUID              string      `json:"-"             yaml:"-"`
+	UITestReplySplitLen *int        `json:"-"             yaml:"-"`
 	// Note(Szzrain): 这里是消息段，为了支持多种消息类型，目前只有 Milky 支持，其他平台也应该尽快迁移支持，并使用 Session.ExecuteNew 方法
 	Segment []message.IMessageElement `jsbind:"segment" json:"-" yaml:"-"`
 }
@@ -664,13 +665,14 @@ type MsgContext struct {
 	DelegateText    string      `jsbind:"delegateText"`  // 代骰附加文本
 	AliasPrefixText string      `json:"aliasPrefixText"` // 快捷指令回复前缀文本
 
-	deckDepth         int                                         // 抽牌递归深度
-	DeckPools         map[*DeckInfo]map[string]*ShuffleRandomPool // 不放回抽取的缓存
-	diceExprOverwrite string                                      // 默认骰表达式覆盖
-	SystemTemplate    *GameSystemTemplate
-	Censored          bool // 已检查过敏感词
-	SpamCheckedGroup  bool
-	SpamCheckedPerson bool
+	deckDepth           int                                         // 抽牌递归深度
+	DeckPools           map[*DeckInfo]map[string]*ShuffleRandomPool // 不放回抽取的缓存
+	diceExprOverwrite   string                                      // 默认骰表达式覆盖
+	SystemTemplate      *GameSystemTemplate
+	Censored            bool // 已检查过敏感词
+	SpamCheckedGroup    bool
+	SpamCheckedPerson   bool
+	UITestReplySplitLen *int
 
 	splitKeyMu sync.RWMutex
 	splitKey   string
@@ -731,6 +733,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 	mctx.IsPrivate = mctx.MessageType == "private"
 	mctx.Session = s
 	mctx.EndPoint = ep
+	mctx.UITestReplySplitLen = msg.UITestReplySplitLen
 	log := d.Logger
 
 	// 处理命令
@@ -1104,6 +1107,7 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 	mctx.IsPrivate = mctx.MessageType == "private"
 	mctx.Session = s
 	mctx.EndPoint = ep
+	mctx.UITestReplySplitLen = msg.UITestReplySplitLen
 	log := d.Logger
 
 	// 处理消息段，如果 2.0 要完全抛弃依赖 Message.Message 的字符串解析，把这里删掉
@@ -2523,6 +2527,7 @@ func (ctx *MsgContext) ShallowCopy() *MsgContext {
 		Censored:            ctx.Censored,
 		SpamCheckedGroup:    ctx.SpamCheckedGroup,
 		SpamCheckedPerson:   ctx.SpamCheckedPerson,
+		UITestReplySplitLen: ctx.UITestReplySplitLen,
 		vm:                  ctx.vm,
 		_v1Rand:             ctx._v1Rand,
 	}

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -8,6 +8,12 @@ import (
 	"sealdice-core/utils"
 )
 
+const (
+	UITestReplySplitLenShort     = 300
+	UITestReplySplitLenQQ        = 2000
+	UITestReplySplitLenUnlimited = 0
+)
+
 type HTTPSimpleMessage struct {
 	UID         string `json:"uid"`
 	Message     string `json:"message"`
@@ -38,8 +44,15 @@ func (pa *PlatformAdapterHTTP) DoRelogin() bool {
 
 func (pa *PlatformAdapterHTTP) SetEnable(_ bool) {}
 
+func getUITestReplySplitLen(ctx *MsgContext) int {
+	if ctx == nil || ctx.UITestReplySplitLen == nil {
+		return UITestReplySplitLenShort
+	}
+	return *ctx.UITestReplySplitLen
+}
+
 func (pa *PlatformAdapterHTTP) SendToPerson(ctx *MsgContext, uid string, text string, flag string) {
-	sp := utils.SplitLongText(text, 300, utils.DefaultSplitPaginationHint)
+	sp := utils.SplitLongText(text, getUITestReplySplitLen(ctx), utils.DefaultSplitPaginationHint)
 	for _, sub := range sp {
 		pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, sub, "private"})
 	}
@@ -55,7 +68,7 @@ func (pa *PlatformAdapterHTTP) SendToPerson(ctx *MsgContext, uid string, text st
 }
 
 func (pa *PlatformAdapterHTTP) SendToGroup(ctx *MsgContext, uid string, text string, flag string) {
-	sp := utils.SplitLongText(text, 300, utils.DefaultSplitPaginationHint)
+	sp := utils.SplitLongText(text, getUITestReplySplitLen(ctx), utils.DefaultSplitPaginationHint)
 	for _, sub := range sp {
 		pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, sub, "group"})
 	}

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -46,7 +46,7 @@ func (pa *PlatformAdapterHTTP) SetEnable(_ bool) {}
 
 func getUITestReplySplitLen(ctx *MsgContext) int {
 	if ctx == nil || ctx.UITestReplySplitLen == nil {
-		return UITestReplySplitLenShort
+		return UITestReplySplitLenQQ
 	}
 	return *ctx.UITestReplySplitLen
 }

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	UITestReplySplitLenShort     = 300
-	UITestReplySplitLenQQ        = 2000
+	UITestReplySplitLenShort = 300
+	UITestReplySplitLenQQ    = 2000
+	// SplitLongText treats maxLen <= 0 as no split.
 	UITestReplySplitLenUnlimited = 0
 )
 


### PR DESCRIPTION
<img width="573" height="462" alt="image" src="https://github.com/user-attachments/assets/45018466-b2fe-4993-a563-3b7d8963657e" />

## Summary by Sourcery

为 UI 命令测试界面添加可配置的回复拆分功能，并将拆分长度在消息处理链路中向下传递到 HTTP 平台适配器。

新功能:
- 暴露一个需身份验证的 API 端点，用于获取命令测试界面可用的 UI 测试回复拆分长度选项及其默认值。
- 允许 dice exec API 接受一个可选的消息拆分长度参数用于 UI 测试，并将其附加到消息上以供后续处理使用。

增强改进:
- 扩展消息和消息上下文结构，以携带一个可选的 UI 测试回复拆分长度，并确保其在各执行路径中得以保留。
- 更新 HTTP 平台适配器，使其使用带可配置预设的集中式回复拆分长度辅助工具，而不再使用固定拆分大小。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable reply splitting for the UI command testing interface and propagate the split length through message handling to the HTTP platform adapter.

New Features:
- Expose an authenticated API endpoint to retrieve available UI test reply split-length options and defaults for the command testing interface.
- Allow the dice exec API to accept an optional message split length parameter for UI tests and attach it to messages for downstream handling.

Enhancements:
- Extend message and message-context structures to carry an optional UI test reply split length and ensure it is preserved across execution paths.
- Update the HTTP platform adapter to use a centralized reply split length helper with configurable presets instead of a fixed split size.

</details>