### PR TITLE
fix: 修复 内置 Milky 无法禁用的问题

### DIFF
--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -718,6 +718,11 @@ func (pa *PlatformAdapterMilky) SetEnable(enable bool) {
 			_ = pa.IntentSession.Close()
 		}
 		BuiltinMilkyClientKill(pa.Session.Parent, pa.EndPoint)
+		pa.EndPoint.State = 0
+		pa.EndPoint.Enable = false
+		d := pa.Session.Parent
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
 	}
 }
 


### PR DESCRIPTION
## Summary by Sourcery

确保在禁用 Milky 平台适配器时，其端点和父级会话状态都能被完整更新。

Bug Fixes:
- 通过重置端点状态和启用标志，修复 Milky 内置适配器实际上未被真正禁用的问题。
- 在禁用 Milky 时更新父级会话元数据，以确保该更改被持久化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure disabling a Milky platform adapter fully updates its endpoint and parent session state.

Bug Fixes:
- Fix Milky built-in adapter not actually disabling by resetting endpoint state and enable flags.
- Update parent session metadata when Milky is disabled so the change is persisted.

</details>