### PR TITLE
fix: 修复无法正确获取群名称的问题

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1170,7 +1170,7 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 		}
 	}
 	// 重新赋值
-	if groupInfo != nil {
+	if groupInfo != nil && msg.GroupName != "" {
 		groupInfo.GroupName = msg.GroupName
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PaienNate/pineutil v0.0.0-20251018153346-e4acff10b752
 	github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a
 	github.com/Szzrain/DingTalk-go v0.0.8-alpha
-	github.com/Szzrain/Milky-go-sdk v1.0.1
+	github.com/Szzrain/Milky-go-sdk v1.0.2
 	github.com/Szzrain/dodo-open-go v0.2.8
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a h1:NPnGVq
 github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a/go.mod h1:5LI6VqIHoGmWsR0EJLbct5bBrtM/0pTonaAyGKmFk9U=
 github.com/Szzrain/DingTalk-go v0.0.8-alpha h1:mSR/ORDDjtndoR12WrEdd3hdxxXXm9VMQ/r75NJkkkE=
 github.com/Szzrain/DingTalk-go v0.0.8-alpha/go.mod h1:j2+BnL67DfiCu6E1rhJDHy4up2drtGXJOrRohIHg5uo=
-github.com/Szzrain/Milky-go-sdk v1.0.1 h1:dsKIUtW7lI7RGLOuNut2ChxqQpM+bqd+3AafCIIhYRc=
-github.com/Szzrain/Milky-go-sdk v1.0.1/go.mod h1:vyl5G/6TQha+Ygf9ZWkDN//7dJFq2V0ezdk3Rm2kDKQ=
+github.com/Szzrain/Milky-go-sdk v1.0.2 h1:Vee6yAeWsZWkTv4mX1YBR3AvEaOrQ1FeJfjziORuBIs=
+github.com/Szzrain/Milky-go-sdk v1.0.2/go.mod h1:vyl5G/6TQha+Ygf9ZWkDN//7dJFq2V0ezdk3Rm2kDKQ=
 github.com/Szzrain/dodo-open-go v0.2.8 h1:a5p2/XOOyKZNFfowEdD7VsFaOClwIX6JziBpNIyzkvo=
 github.com/Szzrain/dodo-open-go v0.2.8/go.mod h1:Nk7ozwqQVvuQW2KubsVVXLM8fFqDo0TwN5UX7F4AR2w=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=


### PR DESCRIPTION
## Summary by Sourcery

确保群组会话处理保留已有的群组名称，并更新外部 SDK 依赖。

Bug 修复：
- 当收到的消息缺少有效的群组名称时，防止覆盖已存储的群组名称。

构建：
- 将 Milky-go-sdk 依赖从 v1.0.1 升级到 v1.0.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure group session handling preserves existing group names and update external SDK dependency.

Bug Fixes:
- Prevent overwriting stored group names when incoming messages lack a valid group name.

Build:
- Bump Milky-go-sdk dependency from v1.0.1 to v1.0.2.

</details>