### PR TITLE
fix(store): 分离商店后端与核心后端地址，修复日志上传问题

### DIFF
--- a/dice/seal_backend.go
+++ b/dice/seal_backend.go
@@ -21,7 +21,9 @@ func _tryGetBackendBase(url string) string {
 }
 
 var BackendUrls = []string{
-	"https://repo-test.sealdice.com",
+	"http://api.weizaima.com",
+	"http://dice.weizaima.com",
+	"http://api.sealdice.com",
 }
 
 func TryGetBackendURL() {

--- a/dice/store.go
+++ b/dice/store.go
@@ -23,6 +23,8 @@ import (
 var (
 	// OfficialStorePublicKey 官方商店公钥。
 	OfficialStorePublicKey = ``
+
+	officialStoreBackendBaseURL = "https://repo-test.sealdice.com"
 )
 
 type StoreBackendType string
@@ -259,10 +261,7 @@ func removeStoreBackendURL(urls []string, rawURL string) []string {
 }
 
 func officialStoreBackendURL() (string, error) {
-	if len(BackendUrls) == 0 {
-		return "", errors.New("未配置官方扩展商店后端")
-	}
-	baseURL := strings.TrimRight(strings.TrimSpace(BackendUrls[0]), "/")
+	baseURL := strings.TrimRight(strings.TrimSpace(officialStoreBackendBaseURL), "/")
 	if baseURL == "" {
 		return "", errors.New("官方扩展商店后端地址为空")
 	}

--- a/dice/store_test.go
+++ b/dice/store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -12,6 +13,42 @@ import (
 
 	"sealdice-core/dice/sealpack"
 )
+
+func withOfficialStoreBackendBaseURL(t *testing.T, rawURL string) {
+	t.Helper()
+	oldURL := officialStoreBackendBaseURL
+	officialStoreBackendBaseURL = rawURL
+	t.Cleanup(func() { officialStoreBackendBaseURL = oldURL })
+}
+
+func TestCoreBackendUrlsDefaultRestored(t *testing.T) {
+	want := []string{
+		"http://api.weizaima.com",
+		"http://dice.weizaima.com",
+		"http://api.sealdice.com",
+	}
+	if !reflect.DeepEqual(BackendUrls, want) {
+		t.Fatalf("BackendUrls = %#v, want %#v", BackendUrls, want)
+	}
+}
+
+func TestOfficialStoreBackendURLUsesDedicatedStoreBaseURL(t *testing.T) {
+	oldBackendURLs := BackendUrls
+	BackendUrls = []string{"https://core-backend.example"}
+	t.Cleanup(func() { BackendUrls = oldBackendURLs })
+	withOfficialStoreBackendBaseURL(t, "https://store-backend.example/")
+
+	got, err := officialStoreBackendURL()
+	if err != nil {
+		t.Fatalf("officialStoreBackendURL() error = %v", err)
+	}
+	if got != "https://store-backend.example/dice/api/store" {
+		t.Fatalf("officialStoreBackendURL() = %q", got)
+	}
+	if !reflect.DeepEqual(BackendUrls, []string{"https://core-backend.example"}) {
+		t.Fatalf("BackendUrls changed unexpectedly: %#v", BackendUrls)
+	}
+}
 
 func TestParseStorePackageFullID(t *testing.T) {
 	pkgID, version, err := ParseStorePackageFullID("alice/demo@1.2.3")
@@ -181,9 +218,7 @@ func TestStoreQueryPageUsesSingleResolvedBackend(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = []string{server.URL}
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, server.URL)
 
 	manager := NewStoreManager(&Dice{})
 	page, err := manager.StoreQueryPage(StoreQueryPageParams{PageNum: 1, PageSize: 20})
@@ -214,9 +249,7 @@ func TestStoreManagerFindPackageMatchesByIDAndVersionAfterRefreshInstalled(t *te
 	}))
 	defer server.Close()
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = []string{server.URL}
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, server.URL)
 
 	manager := NewStoreManager(&Dice{})
 	page, err := manager.StoreQueryPage(StoreQueryPageParams{PageNum: 1, PageSize: 20})
@@ -249,9 +282,7 @@ func TestStoreQueryRecommendCachesBackendInfo(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = []string{server.URL}
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, server.URL)
 
 	manager := NewStoreManager(&Dice{})
 	firstPackages, err := manager.StoreQueryRecommend()
@@ -293,9 +324,7 @@ func TestStoreQueryUploadInfoAllowsExtensionFields(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = []string{server.URL}
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, server.URL)
 
 	manager := NewStoreManager(&Dice{})
 	info, err := manager.StoreQueryUploadInfo()
@@ -318,9 +347,7 @@ func TestStoreBackendListReturnsEnabledAndDisabledBackends(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = []string{server.URL}
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, server.URL)
 
 	enabledURL := server.URL + "/dice/api/store"
 	disabledURL := server.URL + "/disabled/dice/api/store"
@@ -386,9 +413,7 @@ func TestStoreSetBackendEnabledRejectsDisablingOnlyCustomBackendWithoutOfficial(
 	defer server.Close()
 	customURL := server.URL + "/dice/api/store"
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = nil
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, "")
 
 	manager := NewStoreManager(&Dice{Config: Config{StoreConfig: StoreConfig{
 		BackendUrls: []string{customURL},
@@ -414,9 +439,7 @@ func TestStoreSetBackendEnabledAllowsDisablingOnlyCustomBackendWithOfficial(t *t
 	defer server.Close()
 	customURL := server.URL + "/dice/api/store"
 
-	oldBackendURLs := BackendUrls
-	BackendUrls = []string{"https://official.example"}
-	defer func() { BackendUrls = oldBackendURLs }()
+	withOfficialStoreBackendBaseURL(t, "https://official.example")
 
 	manager := NewStoreManager(&Dice{Config: Config{StoreConfig: StoreConfig{
 		BackendUrls: []string{customURL},


### PR DESCRIPTION
## Summary by Sourcery

将官方商店后端基础 URL 与核心后端 URL 分离，并确保默认配置和测试反映这一拆分。

Bug Fixes（错误修复）:
- 防止官方商店后端 URL 解析过程修改或依赖核心后端 URL 配置。
- 恢复用于后端解析的正确默认核心后端 URL 列表。

Enhancements（增强）:
- 引入专用配置变量用于官方商店后端基础 URL，并通过辅助方法更新商店相关测试以使用该变量。

Tests（测试）:
- 新增测试以验证默认核心后端 URL，以及官方商店后端在不修改核心后端 URL 的前提下使用其专用基础 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Separate official store backend base URL from core backend URLs and ensure defaults and tests reflect this split.

Bug Fixes:
- Prevent official store backend URL resolution from mutating or depending on core backend URL configuration.
- Restore correct default core backend URL list used for backend resolution.

Enhancements:
- Introduce a dedicated configuration variable for the official store backend base URL and update store tests to use it via a helper.

Tests:
- Add tests verifying default core backend URLs and that the official store backend uses its dedicated base URL without altering core backend URLs.

</details>