### PR TITLE
fix(log): 调整上传文件命名并增加哈希取日志方案

### DIFF
--- a/api/story_log.go
+++ b/api/story_log.go
@@ -131,7 +131,7 @@ func storyUploadLog(c echo.Context) error {
 	}
 	v := &model.LogInfo{}
 	_ = c.Bind(&v)
-	unofficial, url, err := logSendToBackend(v.GroupID, v.Name)
+	unofficial, url, notice, err := logSendToBackend(v.GroupID, v.Name)
 	if err != nil {
 		myDice.Logger.Error("storyUploadLog", err)
 		return c.JSON(http.StatusInternalServerError, err.Error())
@@ -139,6 +139,9 @@ func storyUploadLog(c echo.Context) error {
 	ret := fmt.Sprintf("跑团日志已上传服务器，链接如下：<br/>%s", url)
 	if unofficial {
 		ret += "<br/>[注意：该链接非海豹官方染色器]"
+	}
+	if notice != "" {
+		ret += "<br/>" + notice
 	}
 	return c.JSON(http.StatusOK, ret)
 }
@@ -187,7 +190,7 @@ func storyBatchDeleteLogBackup(c echo.Context) error {
 	return Success(&c, Response{})
 }
 
-func logSendToBackend(groupID string, logName string) (bool, string, error) {
+func logSendToBackend(groupID string, logName string) (bool, string, string, error) {
 	ctx := &dice.MsgContext{
 		Dice:     myDice,
 		EndPoint: myDice.UIEndpoint,

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -22,7 +22,6 @@ import (
 	"sealdice-core/dice/service"
 	"sealdice-core/dice/storylog"
 	"sealdice-core/model"
-	"sealdice-core/utils"
 )
 
 var ErrGroupCardOverlong = errors.New("群名片长度超过限制")
@@ -168,19 +167,38 @@ func RegisterBuiltinExtLog(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 
+			resolveLogNameWithReply := func(groupID, name string) (string, bool) {
+				resolved, err := resolveLogNameForGroup(ctx.Dice.DBOperator, groupID, name)
+				if err != nil {
+					ReplyToSender(ctx, msg, "获取记录出错: "+err.Error())
+					return "", false
+				}
+				return resolved, true
+			}
+
+			logKeyHintText := func() string {
+				return "\n可先使用 .log list 查看对应的【key】: 日志名"
+			}
+
 			getAndUpload := func(gid, lname string) {
-				unofficial, fn, err := LogSendToBackend(ctx, gid, lname)
+				unofficial, fn, notice, err := LogSendToBackend(ctx, gid, lname)
 				if err != nil {
 					reason := strings.TrimPrefix(err.Error(), "#")
 					VarSetValueStr(ctx, "$t错误原因", reason)
 
 					tmpl := DiceFormatTmpl(ctx, "日志:记录_上传_失败")
+					if strings.Contains(reason, "此log不存在") || strings.Contains(reason, "名字是否正确") {
+						tmpl += logKeyHintText()
+					}
 					ReplyToSenderRaw(ctx, msg, tmpl, "skip")
 				} else {
 					VarSetValueStr(ctx, "$t日志链接", fn)
 					tmpl := DiceFormatTmpl(ctx, "日志:记录_上传_成功")
 					if unofficial {
 						tmpl += "\n[注意：该链接非海豹官方染色器]"
+					}
+					if notice != "" {
+						tmpl += "\n" + notice
 					}
 					ReplyToSenderRaw(ctx, msg, tmpl, "skip")
 				}
@@ -202,6 +220,13 @@ func RegisterBuiltinExtLog(self *Dice) {
 				name := cmdArgs.GetArgN(2)
 				if name == "" {
 					name = group.LogCurName
+				}
+				if name != "" {
+					var ok bool
+					name, ok = resolveLogNameWithReply(group.GroupID, name)
+					if !ok {
+						return CmdExecuteResult{Matched: true, Solved: true}
+					}
 				}
 
 				if name != "" {
@@ -243,6 +268,11 @@ func RegisterBuiltinExtLog(self *Dice) {
 				name := cmdArgs.GetArgN(2)
 				if name == "" {
 					return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
+				}
+				var ok bool
+				name, ok = resolveLogNameWithReply(group.GroupID, name)
+				if !ok {
+					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
 				VarSetValueStr(ctx, "$t记录名称", name)
@@ -340,14 +370,13 @@ func RegisterBuiltinExtLog(self *Dice) {
 				var text strings.Builder
 				text.WriteString(DiceFormatTmpl(ctx, "日志:记录_列出_导入语"))
 				text.WriteString("\n")
-				lst, err := service.LogGetList(ctx.Dice.DBOperator, groupID)
+				index, err := buildLogNameAliasIndex(ctx.Dice.DBOperator, groupID)
 				if err == nil {
-					for _, i := range lst {
-						text.WriteString("- ")
-						text.WriteString(i)
+					for _, entry := range index.entries {
+						text.WriteString(formatLogNameListLine(entry))
 						text.WriteString("\n")
 					}
-					if len(lst) == 0 {
+					if len(index.entries) == 0 {
 						text.WriteString("暂无记录")
 					}
 				} else {
@@ -391,6 +420,13 @@ func RegisterBuiltinExtLog(self *Dice) {
 			} else if cmdArgs.IsArgEqual(1, "stat") {
 				// group := ctx.Group
 				_, name := getLogName(ctx, msg, cmdArgs, 2)
+				if name != "" {
+					var ok bool
+					name, ok = resolveLogNameWithReply(group.GroupID, name)
+					if !ok {
+						return CmdExecuteResult{Matched: true, Solved: true}
+					}
+				}
 				items, err := service.LogGetCommandInfoStrList(ctx.Dice.DBOperator, group.GroupID, name)
 				if err == nil && len(items) > 0 {
 					// showDetail := cmdArgs.GetKwarg("detail")
@@ -439,15 +475,24 @@ func RegisterBuiltinExtLog(self *Dice) {
 					ReplyToSenderRaw(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_导出_未指定记录"), "skip")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
+				var ok bool
+				logName, ok = resolveLogNameWithReply(group.GroupID, logName)
+				if !ok {
+					return CmdExecuteResult{Matched: true, Solved: true}
+				}
 
 				now := carbon.Now()
 				VarSetValueStr(ctx, "$t记录名", logName)
 				VarSetValueStr(ctx, "$t日期", now.ToShortDateString())
 				VarSetValueStr(ctx, "$t时间", now.ToShortTimeString())
 				logFileNamePrefix := DiceFormatTmpl(ctx, "日志:记录_导出_文件名前缀")
-				logFile, err := GetLogTxt(ctx, group.GroupID, logName, logFileNamePrefix)
+				logFile, notice, err := GetLogTxt(ctx, group.GroupID, logName, logFileNamePrefix)
 				if err != nil {
-					ReplyToSenderRaw(ctx, msg, err.Error(), "skip")
+					reply := err.Error()
+					if strings.Contains(reply, "此log不存在") || strings.Contains(reply, "名字是否正确") {
+						reply += logKeyHintText()
+					}
+					ReplyToSenderRaw(ctx, msg, reply, "skip")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 				defer os.Remove(logFile)
@@ -490,7 +535,11 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 				SendFileToSenderRaw(ctx, msg, uri, "skip")
 				VarSetValueStr(ctx, "$t文件名字", logFileNamePrefix)
-				ReplyToSenderRaw(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_导出_成功"), "skip")
+				reply := DiceFormatTmpl(ctx, "日志:记录_导出_成功")
+				if notice != "" {
+					reply += "\n" + notice
+				}
+				ReplyToSenderRaw(ctx, msg, reply, "skip")
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else {
 				return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
@@ -512,6 +561,14 @@ func RegisterBuiltinExtLog(self *Dice) {
 			case "log":
 				group := ctx.Group
 				_, name := getLogName(ctx, msg, cmdArgs, 2)
+				if name != "" {
+					resolved, err := resolveLogNameForGroup(ctx.Dice.DBOperator, group.GroupID, name)
+					if err != nil {
+						ReplyToSender(ctx, msg, "获取记录出错: "+err.Error())
+						return CmdExecuteResult{Matched: true, Solved: true}
+					}
+					name = resolved
+				}
 				items, err := service.LogGetCommandInfoStrList(ctx.Dice.DBOperator, group.GroupID, name)
 				if err == nil && len(items) > 0 {
 					// showDetail := cmdArgs.GetKwarg("detail")
@@ -980,14 +1037,12 @@ func LogEditByID(ctx *MsgContext, groupID, logName, content string, messageID in
 	return true
 }
 
-func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix string) (string, error) {
+func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix string) (string, string, error) {
 	// 创建临时文件
-	tempLog, err := os.CreateTemp("", fmt.Sprintf(
-		"%s(*).txt",
-		utils.FilenameClean(fileNamePrefix),
-	))
+	tempPattern, notice := storylog.BuildTempPattern(fileNamePrefix)
+	tempLog, err := os.CreateTemp("", tempPattern)
 	if err != nil {
-		return "", errors.New("log导出出现未知错误")
+		return "", notice, errors.New("log导出出现未知错误")
 	}
 	defer func() {
 		_ = tempLog.Close()
@@ -1025,12 +1080,16 @@ func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix s
 				for _, line := range cursorLines {
 					timeTxt := time.Unix(line.Time, 0).Format("2006-01-02 15:04:05")
 					text := fmt.Sprintf("%s(%v) %s\n%s\n\n", line.Nickname, line.IMUserID, timeTxt, line.Message)
-					_, _ = tempLog.WriteString(text)
+					if _, err = tempLog.WriteString(text); err != nil {
+						resultCh <- fmt.Errorf("写入日志导出临时文件失败: %w", err)
+						return
+					}
 					counter++
 				}
 				// ========== 新增：每批写入后强制同步 ==========
 				if err := tempLog.Sync(); err != nil { // 确保批次数据落盘
 					resultCh <- fmt.Errorf("批次同步失败: %w", err)
+					return
 				}
 
 				// 如果没有下一页，则成功完成
@@ -1047,24 +1106,32 @@ func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix s
 
 	// 等待 goroutine 完成或超时
 	if err := <-resultCh; err != nil {
-		return "", err
+		return "", notice, err
 	}
 	// 2. 确保文件指针回到开头
 	if _, err := tempLog.Seek(0, 0); err != nil {
-		return "", fmt.Errorf("重置文件指针失败: %w", err)
+		return "", notice, fmt.Errorf("重置文件指针失败: %w", err)
 	}
 
 	// 如果没有任何数据，返回错误
 	if counter == 0 {
-		return "", errors.New("此log不存在，或条目数为空，名字是否正确？")
+		return "", notice, errors.New("此log不存在，或条目数为空，名字是否正确？")
 	}
 
-	return tempLog.Name(), nil
+	return tempLog.Name(), notice, nil
 }
 
-func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (bool, string, error) {
+func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (bool, string, string, error) {
 	dice := ctx.Dice
 	dirPath := filepath.Join(dice.BaseConfig.DataDir, "log-exports")
+
+	resolvedName, err := resolveLogNameForGroup(dice.DBOperator, groupID, logName)
+	if err != nil {
+		return false, "", "", err
+	}
+	if resolvedName != "" {
+		logName = resolvedName
+	}
 
 	var sealBackends []string
 	for _, sealBackend := range BackendUrls {
@@ -1102,14 +1169,14 @@ func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (bool, st
 		}
 	}
 
-	url, err := storylog.Upload(uploadCtx)
+	url, notice, err := storylog.Upload(uploadCtx)
 	if err != nil {
-		return unofficial, "", err
+		return unofficial, "", notice, err
 	}
 	if len(url) == 0 {
-		return unofficial, "", errors.New("上传 log 到服务器失败，未能获取染色器链接")
+		return unofficial, "", notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
-	return unofficial, url, nil
+	return unofficial, url, notice, nil
 }
 
 // LogRollBriefByPCV2 根据log生成骰点简报 采用gjson进行解析 拒绝一次性加载所有数据库数据

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -167,13 +167,29 @@ func RegisterBuiltinExtLog(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 
+			logNameAliasIndexCache := map[string]*logNameAliasIndex{}
+			getLogNameAliasIndex := func(groupID string) (*logNameAliasIndex, error) {
+				if index, exists := logNameAliasIndexCache[groupID]; exists {
+					return index, nil
+				}
+				index, err := buildLogNameAliasIndex(ctx.Dice.DBOperator, groupID)
+				if err != nil {
+					return nil, err
+				}
+				logNameAliasIndexCache[groupID] = index
+				return index, nil
+			}
+
 			resolveLogNameWithReply := func(groupID, name string) (string, bool) {
-				resolved, err := resolveLogNameForGroup(ctx.Dice.DBOperator, groupID, name)
+				index, err := getLogNameAliasIndex(groupID)
 				if err != nil {
 					ReplyToSender(ctx, msg, "获取记录出错: "+err.Error())
 					return "", false
 				}
-				return resolved, true
+				if resolved, ok := index.Resolve(name); ok {
+					return resolved, true
+				}
+				return name, true
 			}
 
 			logKeyHintText := func() string {
@@ -181,7 +197,14 @@ func RegisterBuiltinExtLog(self *Dice) {
 			}
 
 			getAndUpload := func(gid, lname string) {
-				unofficial, fn, notice, err := LogSendToBackend(ctx, gid, lname)
+				if lname != "" {
+					var ok bool
+					lname, ok = resolveLogNameWithReply(gid, lname)
+					if !ok {
+						return
+					}
+				}
+				unofficial, fn, notice, err := logSendToBackend(ctx, gid, lname, true)
 				if err != nil {
 					reason := strings.TrimPrefix(err.Error(), "#")
 					VarSetValueStr(ctx, "$t错误原因", reason)
@@ -370,7 +393,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 				var text strings.Builder
 				text.WriteString(DiceFormatTmpl(ctx, "日志:记录_列出_导入语"))
 				text.WriteString("\n")
-				index, err := buildLogNameAliasIndex(ctx.Dice.DBOperator, groupID)
+				index, err := getLogNameAliasIndex(groupID)
 				if err == nil {
 					for _, entry := range index.entries {
 						text.WriteString(formatLogNameListLine(entry))
@@ -1122,15 +1145,21 @@ func GetLogTxt(ctx *MsgContext, groupID string, logName string, fileNamePrefix s
 }
 
 func LogSendToBackend(ctx *MsgContext, groupID string, logName string) (bool, string, string, error) {
+	return logSendToBackend(ctx, groupID, logName, false)
+}
+
+func logSendToBackend(ctx *MsgContext, groupID string, logName string, skipResolve bool) (bool, string, string, error) {
 	dice := ctx.Dice
 	dirPath := filepath.Join(dice.BaseConfig.DataDir, "log-exports")
 
-	resolvedName, err := resolveLogNameForGroup(dice.DBOperator, groupID, logName)
-	if err != nil {
-		return false, "", "", err
-	}
-	if resolvedName != "" {
-		logName = resolvedName
+	if !skipResolve {
+		resolvedName, err := resolveLogNameForGroup(dice.DBOperator, groupID, logName)
+		if err != nil {
+			return false, "", "", err
+		}
+		if resolvedName != "" {
+			logName = resolvedName
+		}
 	}
 
 	var sealBackends []string

--- a/dice/ext_log_alias.go
+++ b/dice/ext_log_alias.go
@@ -1,0 +1,148 @@
+package dice
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/cespare/xxhash/v2"
+
+	"sealdice-core/dice/service"
+	engine "sealdice-core/utils/dboperator/engine"
+)
+
+const minLogAliasKeyLength = 8
+
+type logNameAliasEntry struct {
+	Name     string
+	FullHash string
+	Key      string
+}
+
+type logNameAliasIndex struct {
+	entries []logNameAliasEntry
+	byKey   map[string]string
+	byName  map[string]string
+}
+
+func buildLogNameAliasIndex(operator engine.DatabaseOperator, groupID string) (*logNameAliasIndex, error) {
+	names, err := service.LogGetList(operator, groupID)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := buildLogNameAliasEntries(names, minLogAliasKeyLength)
+	if err != nil {
+		return nil, err
+	}
+
+	index := &logNameAliasIndex{
+		entries: entries,
+		byKey:   map[string]string{},
+		byName:  map[string]string{},
+	}
+	for _, entry := range entries {
+		index.byKey[entry.Key] = entry.Name
+		index.byName[entry.Name] = entry.Name
+	}
+	return index, nil
+}
+
+func buildLogNameAliasEntries(names []string, minPrefixLen int) ([]logNameAliasEntry, error) {
+	if minPrefixLen < 1 {
+		minPrefixLen = 1
+	}
+
+	entries := make([]logNameAliasEntry, len(names))
+	keyLens := make([]int, len(names))
+	for i, name := range names {
+		fullHash := logNameHashHex(name)
+		if minPrefixLen > len(fullHash) {
+			keyLens[i] = len(fullHash)
+		} else {
+			keyLens[i] = minPrefixLen
+		}
+		entries[i] = logNameAliasEntry{
+			Name:     name,
+			FullHash: fullHash,
+		}
+	}
+
+	for {
+		counts := map[string]int{}
+		for i, entry := range entries {
+			counts[entry.FullHash[:keyLens[i]]]++
+		}
+
+		changed := false
+		for i, entry := range entries {
+			key := entry.FullHash[:keyLens[i]]
+			if counts[key] <= 1 {
+				continue
+			}
+			if keyLens[i] >= len(entry.FullHash) {
+				return nil, fmt.Errorf("日志 hash 键冲突，请改用原始名称")
+			}
+			keyLens[i]++
+			changed = true
+		}
+
+		if !changed {
+			break
+		}
+	}
+
+	for i, entry := range entries {
+		entry.Key = entry.FullHash[:keyLens[i]]
+		entries[i] = entry
+	}
+	return entries, nil
+}
+
+func logNameHashHex(name string) string {
+	return fmt.Sprintf("%016x", xxhash.Sum64String(name))
+}
+
+func (index *logNameAliasIndex) Resolve(input string) (string, bool) {
+	if input == "" {
+		return "", false
+	}
+	if name, exists := index.byName[input]; exists {
+		return name, true
+	}
+	if name, exists := index.byKey[strings.ToLower(input)]; exists {
+		return name, true
+	}
+	return "", false
+}
+
+func resolveLogNameForGroup(operator engine.DatabaseOperator, groupID, input string) (string, error) {
+	if input == "" {
+		return "", nil
+	}
+	index, err := buildLogNameAliasIndex(operator, groupID)
+	if err != nil {
+		return "", err
+	}
+	if resolved, ok := index.Resolve(input); ok {
+		return resolved, nil
+	}
+	return input, nil
+}
+
+func formatLogNameForDisplay(name string) string {
+	if strings.TrimSpace(name) != name {
+		return strconv.Quote(name)
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return strconv.Quote(name)
+		}
+	}
+	return name
+}
+
+func formatLogNameListLine(entry logNameAliasEntry) string {
+	return fmt.Sprintf("- 【%s】: %s", entry.Key, formatLogNameForDisplay(entry.Name))
+}

--- a/dice/ext_log_alias.go
+++ b/dice/ext_log_alias.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -82,7 +83,7 @@ func buildLogNameAliasEntries(names []string, minPrefixLen int) ([]logNameAliasE
 				continue
 			}
 			if keyLens[i] >= len(entry.FullHash) {
-				return nil, fmt.Errorf("日志 hash 键冲突，请改用原始名称")
+				return nil, errors.New("日志 hash 键冲突，请改用原始名称")
 			}
 			keyLens[i]++
 			changed = true

--- a/dice/ext_log_alias_test.go
+++ b/dice/ext_log_alias_test.go
@@ -1,0 +1,220 @@
+package dice
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	sealdiceLogger "sealdice-core/logger"
+	"sealdice-core/model"
+	"sealdice-core/utils/constant"
+)
+
+func newLogAliasTestDB(t *testing.T) *mockDatabaseOperator {
+	t.Helper()
+
+	mockDB, err := newMockDatabaseOperator(filepath.Join(t.TempDir(), "logs.db"))
+	if err != nil {
+		t.Fatalf("newMockDatabaseOperator: %v", err)
+	}
+	t.Cleanup(mockDB.Close)
+
+	db := mockDB.GetLogDB(constant.WRITE)
+	if err := db.AutoMigrate(&model.LogInfo{}, &model.LogOneItem{}); err != nil {
+		t.Fatalf("AutoMigrate: %v", err)
+	}
+	return mockDB
+}
+
+func appendTestLog(t *testing.T, mockDB *mockDatabaseOperator, groupID, logName string) {
+	t.Helper()
+
+	ok := LogAppend(&MsgContext{Dice: &Dice{DBOperator: mockDB}}, groupID, logName, &model.LogOneItem{
+		Nickname: "tester",
+		IMUserID: "user",
+		Message:  "line",
+	})
+	if !ok {
+		t.Fatalf("LogAppend failed for %q", logName)
+	}
+}
+
+func TestBuildLogNameAliasIndexUsesWrappedKeysAndResolvesInput(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1001"
+
+	appendTestLog(t, mockDB, groupID, "normal-log")
+	appendTestLog(t, mockDB, groupID, " spaced\nname ")
+
+	index, err := buildLogNameAliasIndex(mockDB, groupID)
+	if err != nil {
+		t.Fatalf("buildLogNameAliasIndex: %v", err)
+	}
+	if len(index.entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(index.entries))
+	}
+
+	for _, entry := range index.entries {
+		if len(entry.Key) < 8 {
+			t.Fatalf("key %q shorter than 8 chars", entry.Key)
+		}
+		if entry.Name == "normal-log" {
+			if got, ok := index.Resolve(entry.Key); !ok || got != entry.Name {
+				t.Fatalf("Resolve(%q) = (%q, %v), want (%q, true)", entry.Key, got, ok, entry.Name)
+			}
+		}
+	}
+
+	if got := formatLogNameForDisplay(" spaced\nname "); got != strconv.Quote(" spaced\nname ") {
+		t.Fatalf("formatLogNameForDisplay() = %q", got)
+	}
+	if got := formatLogNameListLine(logNameAliasEntry{Key: "deadbeef", Name: "normal-log"}); got != "- 【deadbeef】: normal-log" {
+		t.Fatalf("formatLogNameListLine() = %q", got)
+	}
+}
+
+func TestBuildLogNameAliasEntriesExtendsConflictingPrefixes(t *testing.T) {
+	buckets := map[byte][]string{}
+	for i := 0; i < 4096; i++ {
+		name := fmt.Sprintf("log-%d", i)
+		hash := logNameHashHex(name)
+		prefix := hash[0]
+		buckets[prefix] = append(buckets[prefix], name)
+		if len(buckets[prefix]) >= 2 {
+			break
+		}
+	}
+
+	var names []string
+	for _, candidates := range buckets {
+		if len(candidates) >= 2 {
+			names = candidates[:2]
+			break
+		}
+	}
+	if len(names) != 2 {
+		t.Fatal("failed to generate colliding 1-char hash prefixes")
+	}
+
+	entries, err := buildLogNameAliasEntries(names, 1)
+	if err != nil {
+		t.Fatalf("buildLogNameAliasEntries: %v", err)
+	}
+
+	keys := map[string]struct{}{}
+	grew := false
+	for _, entry := range entries {
+		if _, exists := keys[entry.Key]; exists {
+			t.Fatalf("duplicate key %q", entry.Key)
+		}
+		keys[entry.Key] = struct{}{}
+		if len(entry.Key) > 1 {
+			grew = true
+		}
+	}
+	if !grew {
+		t.Fatal("expected at least one conflicting prefix to grow beyond min length")
+	}
+}
+
+func TestResolveLogNameForGroupPrefersExactNameBeforeAlias(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1002"
+
+	appendTestLog(t, mockDB, groupID, "abcdef12")
+	appendTestLog(t, mockDB, groupID, "other-log")
+
+	index, err := buildLogNameAliasIndex(mockDB, groupID)
+	if err != nil {
+		t.Fatalf("buildLogNameAliasIndex: %v", err)
+	}
+
+	var alias string
+	for _, entry := range index.entries {
+		if entry.Name == "other-log" {
+			alias = entry.Key
+			break
+		}
+	}
+	if alias == "" {
+		t.Fatal("expected alias for other-log")
+	}
+	if strings.EqualFold(alias, "abcdef12") {
+		t.Fatal("test setup produced ambiguous exact-name collision")
+	}
+
+	got, err := resolveLogNameForGroup(mockDB, groupID, "abcdef12")
+	if err != nil {
+		t.Fatalf("resolveLogNameForGroup exact: %v", err)
+	}
+	if got != "abcdef12" {
+		t.Fatalf("resolve exact = %q, want %q", got, "abcdef12")
+	}
+}
+
+func TestLogSendToBackendAcceptsAliasKey(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1003"
+	logName := "special name"
+	appendTestLog(t, mockDB, groupID, logName)
+
+	index, err := buildLogNameAliasIndex(mockDB, groupID)
+	if err != nil {
+		t.Fatalf("buildLogNameAliasIndex: %v", err)
+	}
+	var alias string
+	for _, entry := range index.entries {
+		if entry.Name == logName {
+			alias = entry.Key
+			break
+		}
+	}
+	if alias == "" {
+		t.Fatal("expected alias for special name")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/dice/api/log" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm: %v", err)
+		}
+		if got := r.FormValue("name"); got != logName {
+			t.Fatalf("uploaded name = %q, want %q", got, logName)
+		}
+		_, _ = w.Write([]byte(`{"url":"https://example.com/log"}`))
+	}))
+	defer server.Close()
+
+	oldBackends := BackendUrls
+	BackendUrls = []string{server.URL}
+	t.Cleanup(func() { BackendUrls = oldBackends })
+
+	ctx := &MsgContext{
+		Dice: &Dice{
+			BaseConfig: BaseConfig{DataDir: t.TempDir()},
+			DBOperator: mockDB,
+			Logger:     sealdiceLogger.M(),
+		},
+		EndPoint: &EndPointInfo{EndPointInfoBase: EndPointInfoBase{UserID: "UI:1000"}},
+	}
+
+	unofficial, url, notice, err := LogSendToBackend(ctx, groupID, alias)
+	if err != nil {
+		t.Fatalf("LogSendToBackend: %v", err)
+	}
+	if unofficial {
+		t.Fatal("expected official backend path")
+	}
+	if notice != "" {
+		t.Fatalf("unexpected notice %q", notice)
+	}
+	if url != "https://example.com/log" {
+		t.Fatalf("url = %q", url)
+	}
+}

--- a/dice/ext_log_alias_test.go
+++ b/dice/ext_log_alias_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package dice
 
 import (
@@ -79,7 +80,7 @@ func TestBuildLogNameAliasIndexUsesWrappedKeysAndResolvesInput(t *testing.T) {
 
 func TestBuildLogNameAliasEntriesExtendsConflictingPrefixes(t *testing.T) {
 	buckets := map[byte][]string{}
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		name := fmt.Sprintf("log-%d", i)
 		hash := logNameHashHex(name)
 		prefix := hash[0]
@@ -181,8 +182,8 @@ func TestLogSendToBackendAcceptsAliasKey(t *testing.T) {
 		if r.URL.Path != "/dice/api/log" {
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
-		if err := r.ParseMultipartForm(1 << 20); err != nil {
-			t.Fatalf("ParseMultipartForm: %v", err)
+		if parseErr := r.ParseMultipartForm(1 << 20); parseErr != nil {
+			t.Fatalf("ParseMultipartForm: %v", parseErr)
 		}
 		if got := r.FormValue("name"); got != logName {
 			t.Fatalf("uploaded name = %q, want %q", got, logName)

--- a/dice/storylog/filename.go
+++ b/dice/storylog/filename.go
@@ -1,0 +1,117 @@
+package storylog
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+const (
+	maxExportFilenameBytes = 240
+	maxTempPatternBytes    = 128
+	fileNameFallbackNotice = "日志名不适合作为文件名，已改用哈希文件名保存/上传，不影响日志内容与查询。"
+)
+
+var invalidFilenameCharsRe = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1f]`)
+
+func buildLogBackupFilename(groupID, logName string, now time.Time) (string, string) {
+	groupPart, ok := sanitizeFilenameComponent(groupID)
+	if !ok {
+		groupPart = "group"
+	}
+	groupPart = trimUTF8ByBytes(groupPart, 48)
+
+	logPart, logOK := sanitizeFilenameComponent(logName)
+	timestamp := now.Format("060102150405")
+	if logOK {
+		name := fmt.Sprintf("%s_%s.%s.zip", groupPart, logPart, timestamp)
+		if len([]byte(name)) <= maxExportFilenameBytes {
+			return name, ""
+		}
+	}
+
+	hashPart := hashHex(logName)
+	name := fmt.Sprintf("%s_%s.%s.zip", groupPart, hashPart, timestamp)
+	if len([]byte(name)) <= maxExportFilenameBytes {
+		return name, fileNameFallbackNotice
+	}
+
+	return fmt.Sprintf("log_%s.%s.zip", hashPart, timestamp), fileNameFallbackNotice
+}
+
+func buildTempPattern(prefix string) (string, string) {
+	cleanPrefix, ok := sanitizeFilenameComponent(prefix)
+	if ok {
+		if len([]byte(cleanPrefix+"-*.txt")) <= maxTempPatternBytes {
+			pattern := cleanPrefix + "-*.txt"
+			return pattern, ""
+		}
+	}
+
+	pattern := "log-export-" + hashHex(prefix) + "-*.txt"
+	if len([]byte(pattern)) > maxTempPatternBytes {
+		pattern = trimUTF8ByBytes(pattern, maxTempPatternBytes)
+		if !strings.Contains(pattern, "*") {
+			pattern = "log-" + hashHex(prefix)[:8] + "-*.txt"
+		}
+	}
+	return pattern, fileNameFallbackNotice
+}
+
+func BuildTempPattern(prefix string) (string, string) {
+	return buildTempPattern(prefix)
+}
+
+func sanitizeFilenameComponent(name string) (string, bool) {
+	name = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, name)
+	name = invalidFilenameCharsRe.ReplaceAllString(name, "")
+	name = strings.Trim(name, ". ")
+	if name == "" || name == "." || name == ".." || isWindowsReservedFilename(name) {
+		return "", false
+	}
+	return name, true
+}
+
+func isWindowsReservedFilename(name string) bool {
+	base := strings.ToUpper(strings.TrimSpace(name))
+	switch base {
+	case "CON", "PRN", "AUX", "NUL",
+		"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+		"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+		return true
+	default:
+		return false
+	}
+}
+
+func trimUTF8ByBytes(s string, maxBytes int) string {
+	if len([]byte(s)) <= maxBytes {
+		return s
+	}
+	var builder strings.Builder
+	builder.Grow(maxBytes)
+	size := 0
+	for _, r := range s {
+		runeSize := utf8.RuneLen(r)
+		if size+runeSize > maxBytes {
+			break
+		}
+		builder.WriteRune(r)
+		size += runeSize
+	}
+	return builder.String()
+}
+
+func hashHex(text string) string {
+	return fmt.Sprintf("%016x", xxhash.Sum64String(text))
+}

--- a/dice/storylog/filename_test.go
+++ b/dice/storylog/filename_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package storylog
 
 import (

--- a/dice/storylog/filename_test.go
+++ b/dice/storylog/filename_test.go
@@ -1,0 +1,54 @@
+package storylog
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildLogBackupFilenameKeepsCleanName(t *testing.T) {
+	name, notice := buildLogBackupFilename("QQ-Group:12345", "normal-log", time.Unix(0, 0))
+	if notice != "" {
+		t.Fatalf("unexpected notice %q", notice)
+	}
+	if !strings.Contains(name, "normal-log") {
+		t.Fatalf("filename %q does not contain original name", name)
+	}
+	if !strings.HasSuffix(name, ".zip") {
+		t.Fatalf("filename %q does not end with .zip", name)
+	}
+}
+
+func TestBuildLogBackupFilenameFallsBackToHashForInvalidName(t *testing.T) {
+	name, notice := buildLogBackupFilename("QQ-Group:12345", "..", time.Unix(0, 0))
+	if notice == "" {
+		t.Fatal("expected notice for invalid filename")
+	}
+	if strings.Contains(name, "..") {
+		t.Fatalf("filename %q still contains invalid name", name)
+	}
+}
+
+func TestBuildLogBackupFilenameFallsBackToHashForLongName(t *testing.T) {
+	longName := strings.Repeat("测", 200)
+	name, notice := buildLogBackupFilename("QQ-Group:12345", longName, time.Unix(0, 0))
+	if notice == "" {
+		t.Fatal("expected notice for long filename")
+	}
+	if len([]byte(name)) > maxExportFilenameBytes {
+		t.Fatalf("filename too long: %d bytes", len([]byte(name)))
+	}
+}
+
+func TestBuildTempPatternFallsBackForLongPrefix(t *testing.T) {
+	pattern, notice := buildTempPattern(strings.Repeat("prefix-", 200))
+	if notice == "" {
+		t.Fatal("expected notice for long temp prefix")
+	}
+	if len([]byte(pattern)) > maxTempPatternBytes {
+		t.Fatalf("pattern too long: %d bytes", len([]byte(pattern)))
+	}
+	if !strings.Contains(pattern, "*") {
+		t.Fatalf("pattern %q does not contain wildcard", pattern)
+	}
+}

--- a/dice/storylog/storylog.go
+++ b/dice/storylog/storylog.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 
@@ -27,18 +28,33 @@ type UploadEnv struct {
 	GroupID   string
 	Token     string
 
-	lines []*model.LogOneItem
-	data  *[]byte
+	lines  []*model.LogOneItem
+	data   *[]byte
+	Notice string
 }
 
-func Upload(env UploadEnv) (string, error) {
+func (env *UploadEnv) appendNotice(notice string) {
+	if notice == "" {
+		return
+	}
+	if env.Notice == "" {
+		env.Notice = notice
+		return
+	}
+	if strings.Contains(env.Notice, notice) {
+		return
+	}
+	env.Notice += "\n" + notice
+}
+
+func Upload(env UploadEnv) (string, string, error) {
 	if env.Version == StoryVersionV1 {
 		return uploadV1(env)
 	}
 	if env.Version == StoryVersionV105 {
 		return uploadV105(env)
 	}
-	return "", errors.New("未指定日志版本")
+	return "", "", errors.New("未指定日志版本")
 }
 
 func uploadToBackend(env UploadEnv, backend string, data io.Reader) string {

--- a/dice/storylog/upload_v1.go
+++ b/dice/storylog/upload_v1.go
@@ -99,21 +99,21 @@ func formatAndBackup(env *UploadEnv) error {
 	}
 
 	{
-		wr, err := writer.Create(ExportReadmeFilename)
-		if err != nil {
-			return fmt.Errorf("创建README失败: %w", err)
+		readmeWriter, createErr := writer.Create(ExportReadmeFilename)
+		if createErr != nil {
+			return fmt.Errorf("创建README失败: %w", createErr)
 		}
-		if _, err = wr.Write([]byte(ExportReadmeContent)); err != nil {
-			return fmt.Errorf("写入README失败: %w", err)
+		if _, writeErr := readmeWriter.Write([]byte(ExportReadmeContent)); writeErr != nil {
+			return fmt.Errorf("写入README失败: %w", writeErr)
 		}
 	}
 	{
-		fileWriter, err := writer.Create(ExportTxtFilename)
-		if err != nil {
-			return fmt.Errorf("创建文本日志文件失败: %w", err)
+		textWriter, createErr := writer.Create(ExportTxtFilename)
+		if createErr != nil {
+			return fmt.Errorf("创建文本日志文件失败: %w", createErr)
 		}
-		if _, err = fileWriter.Write([]byte(text.String())); err != nil {
-			return fmt.Errorf("写入文本日志文件失败: %w", err)
+		if _, writeErr := textWriter.Write([]byte(text.String())); writeErr != nil {
+			return fmt.Errorf("写入文本日志文件失败: %w", writeErr)
 		}
 	}
 

--- a/dice/storylog/upload_v1.go
+++ b/dice/storylog/upload_v1.go
@@ -14,10 +14,9 @@ import (
 	"time"
 
 	"sealdice-core/dice/service"
-	"sealdice-core/utils"
 )
 
-func uploadV1(env UploadEnv) (string, error) {
+func uploadV1(env UploadEnv) (string, string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
@@ -30,7 +29,7 @@ func uploadV1(env UploadEnv) (string, error) {
 			time.Unix(updateTS, 0).Format("2006-01-02 15:04:05"),
 			url,
 		)
-		return url, nil
+		return url, env.Notice, nil
 	}
 	if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
@@ -45,44 +44,53 @@ func uploadV1(env UploadEnv) (string, error) {
 
 	lines, err := service.LogGetAllLines(env.Db, env.GroupID, env.LogName)
 	if err != nil {
-		return "", err
+		return "", env.Notice, err
 	}
 	if len(lines) == 0 {
-		return "", errors.New("此log不存在，或条目数为空，名字是否正确？")
+		return "", env.Notice, errors.New("此log不存在，或条目数为空，名字是否正确？")
 	}
 	env.lines = lines
 
 	err = formatAndBackup(&env)
 	if err != nil {
-		return "", err
+		return "", env.Notice, err
 	}
 
 	var zlibBuffer bytes.Buffer
 	w := zlib.NewWriter(&zlibBuffer)
-	_, _ = w.Write(*env.data)
-	_ = w.Close()
+	if _, err = w.Write(*env.data); err != nil {
+		_ = w.Close()
+		return "", env.Notice, err
+	}
+	if err = w.Close(); err != nil {
+		return "", env.Notice, err
+	}
 
 	url = uploadToSealBackends(env, &zlibBuffer)
 	if errDB := service.LogSetUploadInfo(env.Db, env.GroupID, env.LogName, url); errDB != nil {
 		env.Log.Errorf("记录Log上传信息失败: %v", errDB)
 	}
 	if len(url) == 0 {
-		return "", errors.New("上传 log 到服务器失败，未能获取染色器链接")
+		return "", env.Notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
-	return url, nil
+	return url, env.Notice, nil
 }
 
 // formatAndBackup 将导出的日志序列化到 env.data 并存储为本地 zip
 func formatAndBackup(env *UploadEnv) error {
-	fzip, _ := os.OpenFile(
-		filepath.Join(env.Dir, utils.FilenameClean(fmt.Sprintf(
-			"%s_%s.%s.zip",
-			env.GroupID, env.LogName, time.Now().Format("060102150405"),
-		))),
+	filename, notice := buildLogBackupFilename(env.GroupID, env.LogName, time.Now())
+	env.appendNotice(notice)
+	fzip, err := os.OpenFile(
+		filepath.Join(env.Dir, filename),
 		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 		0o600,
 	)
+	if err != nil {
+		return fmt.Errorf("创建日志备份文件失败: %w", err)
+	}
+	defer func() { _ = fzip.Close() }()
 	writer := zip.NewWriter(fzip)
+	defer func() { _ = writer.Close() }()
 
 	var text strings.Builder
 	for _, i := range env.lines {
@@ -91,28 +99,43 @@ func formatAndBackup(env *UploadEnv) error {
 	}
 
 	{
-		wr, _ := writer.Create(ExportReadmeFilename)
-		_, _ = wr.Write([]byte(ExportReadmeContent))
+		wr, err := writer.Create(ExportReadmeFilename)
+		if err != nil {
+			return fmt.Errorf("创建README失败: %w", err)
+		}
+		if _, err = wr.Write([]byte(ExportReadmeContent)); err != nil {
+			return fmt.Errorf("写入README失败: %w", err)
+		}
 	}
 	{
-		fileWriter, _ := writer.Create(ExportTxtFilename)
-		_, _ = fileWriter.Write([]byte(text.String()))
+		fileWriter, err := writer.Create(ExportTxtFilename)
+		if err != nil {
+			return fmt.Errorf("创建文本日志文件失败: %w", err)
+		}
+		if _, err = fileWriter.Write([]byte(text.String())); err != nil {
+			return fmt.Errorf("写入文本日志文件失败: %w", err)
+		}
 	}
 
 	data, err := json.Marshal(map[string]interface{}{
 		"version": StoryVersionV1,
 		"items":   env.lines,
 	})
-	if err == nil {
-		fileWriter2, _ := writer.Create(ExportJsonFilename)
-		_, _ = fileWriter2.Write(data)
-		env.data = &data
+	if err != nil {
+		return err
 	}
-
-	_ = writer.Close()
-	_ = fzip.Close()
-
-	return err
+	fileWriter2, err := writer.Create(ExportJsonFilename)
+	if err != nil {
+		return fmt.Errorf("创建JSON日志文件失败: %w", err)
+	}
+	if _, err = fileWriter2.Write(data); err != nil {
+		return fmt.Errorf("写入JSON日志文件失败: %w", err)
+	}
+	if err = writer.Close(); err != nil {
+		return fmt.Errorf("关闭日志压缩文件失败: %w", err)
+	}
+	env.data = &data
+	return nil
 }
 
 func uploadToSealBackends(env UploadEnv, data io.Reader) string {

--- a/dice/storylog/upload_v1.go
+++ b/dice/storylog/upload_v1.go
@@ -77,7 +77,7 @@ func uploadV1(env UploadEnv) (string, string, error) {
 }
 
 // formatAndBackup 将导出的日志序列化到 env.data 并存储为本地 zip
-func formatAndBackup(env *UploadEnv) error {
+func formatAndBackup(env *UploadEnv) (err error) {
 	filename, notice := buildLogBackupFilename(env.GroupID, env.LogName, time.Now())
 	env.appendNotice(notice)
 	fzip, err := os.OpenFile(
@@ -88,9 +88,15 @@ func formatAndBackup(env *UploadEnv) error {
 	if err != nil {
 		return fmt.Errorf("创建日志备份文件失败: %w", err)
 	}
-	defer func() { _ = fzip.Close() }()
 	writer := zip.NewWriter(fzip)
-	defer func() { _ = writer.Close() }()
+	defer func() {
+		if closeErr := writer.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("关闭日志压缩文件失败: %w", closeErr)
+		}
+		if closeErr := fzip.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("关闭日志备份文件失败: %w", closeErr)
+		}
+	}()
 
 	var text strings.Builder
 	for _, i := range env.lines {
@@ -130,9 +136,6 @@ func formatAndBackup(env *UploadEnv) error {
 	}
 	if _, err = fileWriter2.Write(data); err != nil {
 		return fmt.Errorf("写入JSON日志文件失败: %w", err)
-	}
-	if err = writer.Close(); err != nil {
-		return fmt.Errorf("关闭日志压缩文件失败: %w", err)
 	}
 	env.data = &data
 	return nil

--- a/dice/storylog/upload_v105.go
+++ b/dice/storylog/upload_v105.go
@@ -183,7 +183,7 @@ func uploadV105(env UploadEnv) (string, string, error) {
 }
 
 // formatAndBackup 将导出的日志序列化到 env.data 并存储为本地 zip
-func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Buffer) error {
+func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Buffer) (err error) {
 	filename, notice := buildLogBackupFilename(env.GroupID, env.LogName, time.Now())
 	env.appendNotice(notice)
 	fzip, err := os.OpenFile(
@@ -194,9 +194,15 @@ func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Bu
 	if err != nil {
 		return fmt.Errorf("创建日志备份文件失败: %w", err)
 	}
-	defer func() { _ = fzip.Close() }()
 	writer := zip.NewWriter(fzip)
-	defer func() { _ = writer.Close() }()
+	defer func() {
+		if closeErr := writer.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("关闭日志压缩文件失败: %w", closeErr)
+		}
+		if closeErr := fzip.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("关闭日志备份文件失败: %w", closeErr)
+		}
+	}()
 	// 写入README文件
 	{
 		readmeWriter, createErr := writer.Create(ExportReadmeFilename)
@@ -224,10 +230,6 @@ func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Bu
 	}
 	if _, err = parquetWriter.Write(parquetFile.Bytes()); err != nil {
 		return fmt.Errorf("写入Parquet文件失败: %w", err)
-	}
-
-	if err = writer.Close(); err != nil {
-		return fmt.Errorf("关闭日志压缩文件失败: %w", err)
 	}
 	return nil
 }

--- a/dice/storylog/upload_v105.go
+++ b/dice/storylog/upload_v105.go
@@ -199,12 +199,12 @@ func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Bu
 	defer func() { _ = writer.Close() }()
 	// 写入README文件
 	{
-		wr, err := writer.Create(ExportReadmeFilename)
-		if err != nil {
-			return fmt.Errorf("创建README失败: %w", err)
+		readmeWriter, createErr := writer.Create(ExportReadmeFilename)
+		if createErr != nil {
+			return fmt.Errorf("创建README失败: %w", createErr)
 		}
-		if _, err = wr.Write([]byte(ExportReadmeContent)); err != nil {
-			return fmt.Errorf("写入README失败: %w", err)
+		if _, writeErr := readmeWriter.Write([]byte(ExportReadmeContent)); writeErr != nil {
+			return fmt.Errorf("写入README失败: %w", writeErr)
 		}
 	}
 	// 写入文本TXT文件

--- a/dice/storylog/upload_v105.go
+++ b/dice/storylog/upload_v105.go
@@ -21,7 +21,6 @@ import (
 
 	"sealdice-core/dice/service"
 	"sealdice-core/model"
-	"sealdice-core/utils"
 )
 
 func GetLogTxtAndParquetFile(env UploadEnv) (*os.File, *bytes.Buffer, error) {
@@ -34,10 +33,8 @@ func GetLogTxtAndParquetFile(env UploadEnv) (*os.File, *bytes.Buffer, error) {
 			),
 		))
 	buf := new(bytes.Buffer)
-	tempLog, err := os.CreateTemp("", fmt.Sprintf(
-		"%s(*).txt",
-		utils.FilenameClean("sealdice_v105_prefix_"),
-	))
+	tempPattern, _ := buildTempPattern("sealdice_v105_prefix")
+	tempLog, err := os.CreateTemp("", tempPattern)
 	if err != nil {
 		return nil, nil, errors.New("log导出出现未知错误")
 	}
@@ -76,12 +73,16 @@ func GetLogTxtAndParquetFile(env UploadEnv) (*os.File, *bytes.Buffer, error) {
 				for _, line := range cursorLines {
 					timeTxt := time.Unix(line.Time, 0).Format("2006-01-02 15:04:05")
 					text := fmt.Sprintf("%s(%v) %s\n%s\n\n", line.Nickname, line.IMUserID, timeTxt, line.Message)
-					_, _ = tempLog.WriteString(text)
+					if _, err0 = tempLog.WriteString(text); err0 != nil {
+						resultCh <- fmt.Errorf("写入日志导出临时文件失败: %w", err0)
+						return
+					}
 					counter++
 				}
 				// ========== 新增：每批写入后强制同步 ==========
 				if err = tempLog.Sync(); err != nil { // 确保批次数据落盘
 					resultCh <- fmt.Errorf("批次同步失败: %w", err)
+					return
 				}
 
 				_, err0 = parquetBuffer.Write(cursorLines)
@@ -132,7 +133,7 @@ func GetLogTxtAndParquetFile(env UploadEnv) (*os.File, *bytes.Buffer, error) {
 }
 
 // 一个不那么激进的改版
-func uploadV105(env UploadEnv) (string, error) {
+func uploadV105(env UploadEnv) (string, string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
@@ -145,7 +146,7 @@ func uploadV105(env UploadEnv) (string, error) {
 			time.Unix(updateTS, 0).Format("2006-01-02 15:04:05"),
 			url,
 		)
-		return url, nil
+		return url, env.Notice, nil
 	}
 	if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
@@ -160,11 +161,15 @@ func uploadV105(env UploadEnv) (string, error) {
 
 	file, b, err := GetLogTxtAndParquetFile(env)
 	if err != nil {
-		return "", err
+		return "", env.Notice, err
 	}
+	defer func() {
+		_ = file.Close()
+		_ = os.Remove(file.Name())
+	}()
 	err = formatAndBackupV105(&env, file, b)
 	if err != nil {
-		return "", err
+		return "", env.Notice, err
 	}
 
 	url = parquetUploadToSealBackends(env, b)
@@ -172,31 +177,42 @@ func uploadV105(env UploadEnv) (string, error) {
 		env.Log.Errorf("记录Log上传信息失败: %v", errDB)
 	}
 	if len(url) == 0 {
-		return "", errors.New("上传 log 到服务器失败，未能获取染色器链接")
+		return "", env.Notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
-	return url, nil
+	return url, env.Notice, nil
 }
 
 // formatAndBackup 将导出的日志序列化到 env.data 并存储为本地 zip
 func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Buffer) error {
-	fzip, _ := os.OpenFile(
-		filepath.Join(env.Dir, utils.FilenameClean(fmt.Sprintf(
-			"%s_%s.%s.zip",
-			env.GroupID, env.LogName, time.Now().Format("060102150405"),
-		))),
+	filename, notice := buildLogBackupFilename(env.GroupID, env.LogName, time.Now())
+	env.appendNotice(notice)
+	fzip, err := os.OpenFile(
+		filepath.Join(env.Dir, filename),
 		os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
 		0o600,
 	)
+	if err != nil {
+		return fmt.Errorf("创建日志备份文件失败: %w", err)
+	}
+	defer func() { _ = fzip.Close() }()
 	writer := zip.NewWriter(fzip)
-	var err error
+	defer func() { _ = writer.Close() }()
 	// 写入README文件
 	{
-		wr, _ := writer.Create(ExportReadmeFilename)
-		_, _ = wr.Write([]byte(ExportReadmeContent))
+		wr, err := writer.Create(ExportReadmeFilename)
+		if err != nil {
+			return fmt.Errorf("创建README失败: %w", err)
+		}
+		if _, err = wr.Write([]byte(ExportReadmeContent)); err != nil {
+			return fmt.Errorf("写入README失败: %w", err)
+		}
 	}
 	// 写入文本TXT文件
 
-	fileWriter, _ := writer.Create(ExportTxtFilename)
+	fileWriter, err := writer.Create(ExportTxtFilename)
+	if err != nil {
+		return fmt.Errorf("创建文本日志文件失败: %w", err)
+	}
 	if _, err = io.Copy(fileWriter, tempLog); err != nil {
 		return fmt.Errorf("写入文本日志文件失败: %w", err)
 	}
@@ -210,10 +226,10 @@ func formatAndBackupV105(env *UploadEnv, tempLog *os.File, parquetFile *bytes.Bu
 		return fmt.Errorf("写入Parquet文件失败: %w", err)
 	}
 
-	_ = writer.Close()
-	_ = fzip.Close()
-
-	return err
+	if err = writer.Close(); err != nil {
+		return fmt.Errorf("关闭日志压缩文件失败: %w", err)
+	}
+	return nil
 }
 
 func parquetUploadToSealBackends(env UploadEnv, data io.Reader) string {


### PR DESCRIPTION
## Summary by Sourcery

改进故事日志导出和上传的鲁棒性，同时引入基于哈希的日志别名和更安全的文件名处理。

Bug 修复：
- 在写入和同步临时日志导出文件时处理错误，避免静默失败。
- 通过清理并哈希化日志名称和分组 ID，防止无效或过长的备份文件名及临时文件模式。
- 仅在序列化和文件写入成功后再设置 JSON 导出数据，并安全地关闭 zip writer/文件。

增强：
- 为日志名称添加基于哈希的别名键，允许通过键或精确名称解析用户输入，并在日志列表输出中显示别名。
- 在执行统计、导出和上传等操作之前优先解析日志名称（包括别名），当日志缺失时提供更清晰的面向用户的错误提示。
- 在日志导出和上传流程中传递关于文件名回退或哈希处理的提示，并在用户响应中展示这些信息。

测试：
- 添加用于日志别名索引构建、键冲突处理、名称解析以及使用别名键进行后端上传的单元测试。
- 添加用于备份文件名和临时模式生成的单元测试，包括针对无效和过长名称的测试，并确保遵守大小限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve story log export and upload robustness while introducing hash-based log aliases and safer filename handling.

Bug Fixes:
- Handle errors when writing and syncing temporary log export files to avoid silent failures.
- Prevent invalid or overly long backup filenames and temp file patterns by sanitizing and hashing log names and group IDs.
- Ensure JSON export data is set only after successful serialization and file writes, and close zip writers/files safely.

Enhancements:
- Add hash-based alias keys for log names, allow resolving user input via keys or exact names, and display aliases in log list output.
- Prefer resolving log names (including aliases) before operations such as stats, export, and upload, with better user-facing error hints when logs are missing.
- Propagate notices about filename fallbacks or hashing through log export and upload flows and surface them in user responses.

Tests:
- Add unit tests for log alias index building, key collision handling, name resolution, and backend upload using alias keys.
- Add unit tests for backup filename and temp pattern generation, including invalid and long names and ensuring size limits are respected.

</details>