### PR TITLE
fix(log): 修复日志并发路由与消息回溯

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -842,7 +842,7 @@ func (d *Dice) registerCoreCommands() {
 					ctx.IsCurGroupBotOn = true
 
 					text := DiceFormatTmpl(ctx, "核心:骰子开启")
-					if ctx.Group.LogOn {
+					if ctx.Group.GetLogState().On {
 						text += "\n请特别注意: 日志记录处于开启状态"
 					}
 					ReplyToSender(ctx, msg, text)

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/panjf2000/ants/v2"
 	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"gorm.io/gorm"
 
 	sealdiceLogger "sealdice-core/logger"
@@ -431,6 +433,59 @@ func TestExecuteNew_GroupInfo_Created(t *testing.T) {
 	}
 	if !groupInfo.Active {
 		t.Error("new GroupInfo should have Active=true")
+	}
+}
+
+func TestOnMessageDeletedWritesUILog(t *testing.T) {
+	d, ep, _, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+	encoderConfig := zap.NewProductionEncoderConfig()
+	encoderConfig.TimeKey = "time"
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	encoderConfig.NameKey = "module"
+	encoderConfig.EncodeName = zapcore.FullNameEncoder
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(d.LogWriter), zapcore.InfoLevel)
+	d.Logger = zap.New(core).Named(sealdiceLogger.LogKeyMain).Sugar()
+
+	ctx := &MsgContext{
+		Dice:     d,
+		EndPoint: ep,
+		Session:  d.ImSession,
+	}
+	group := SetBotOnAtGroup(ctx, "QQ-Group:10001")
+	group.GroupName = "TestGroup"
+
+	msg := &Message{
+		Platform:    "QQ",
+		MessageType: "group",
+		GroupID:     "QQ-Group:10001",
+		GroupName:   "TestGroup",
+		Time:        time.Now().Unix(),
+		Sender: SenderBase{
+			UserID:   "QQ:20001",
+			Nickname: "Alice",
+		},
+		Message: "这是一条被撤回的消息",
+		RawID:   "raw-delete-1",
+	}
+
+	d.ImSession.OnMessageDeleted(ctx, msg)
+
+	var found bool
+	for _, item := range d.LogWriter.Items {
+		if item == nil {
+			continue
+		}
+		if strings.Contains(item.Msg, "撤回消息事件") &&
+			strings.Contains(item.Msg, msg.GroupID) &&
+			strings.Contains(item.Msg, msg.Sender.UserID) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected UI log to contain message delete event, got %+v", d.LogWriter.Items)
 	}
 }
 

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-module/carbon"
@@ -25,6 +26,21 @@ import (
 )
 
 var ErrGroupCardOverlong = errors.New("群名片长度超过限制")
+
+func getGroupLogState(group *GroupInfo) GroupLogState {
+	if group == nil {
+		return GroupLogState{}
+	}
+	return group.GetLogState()
+}
+
+func getGroupLogName(group *GroupInfo) string {
+	return getGroupLogState(group).Name
+}
+
+func getGroupLogOn(group *GroupInfo) bool {
+	return getGroupLogState(group).On
+}
 
 func SetPlayerGroupCardByTemplate(ctx *MsgContext, tmpl string) (string, error) {
 	if ctx.SystemTemplate == nil {
@@ -53,11 +69,13 @@ func SetPlayerGroupCardByTemplate(ctx *MsgContext, tmpl string) (string, error) 
 
 func RegisterBuiltinExtLog(self *Dice) {
 	privateCommandListen := map[int64]int64{}
+	privateCommandListenMu := sync.RWMutex{}
 
 	// 这个机制作用是记录私聊指令？？忘记了
 	privateCommandListenCheck := func() {
 		now := time.Now().Unix()
 		newMap := map[int64]int64{}
+		privateCommandListenMu.Lock()
 		for k, v := range privateCommandListen {
 			// 30s间隔以上清除
 			if now-v < 30 {
@@ -65,6 +83,20 @@ func RegisterBuiltinExtLog(self *Dice) {
 			}
 		}
 		privateCommandListen = newMap
+		privateCommandListenMu.Unlock()
+	}
+
+	privateCommandListenHas := func(commandID int64) bool {
+		privateCommandListenMu.RLock()
+		_, exists := privateCommandListen[commandID]
+		privateCommandListenMu.RUnlock()
+		return exists
+	}
+
+	privateCommandListenSet := func(commandID int64, ts int64) {
+		privateCommandListenMu.Lock()
+		privateCommandListen[commandID] = ts
+		privateCommandListenMu.Unlock()
 	}
 
 	// 避免群信息重复记录
@@ -115,7 +147,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 
 	// 获取logname，第一项是默认名字
 	getLogName := func(ctx *MsgContext, _ *Message, cmdArgs *CmdArgs, index int) (string, string) {
-		bakLogCurName := ctx.Group.LogCurName
+		bakLogCurName := getGroupLogName(ctx.Group)
 		if newName := cmdArgs.GetArgN(index); newName != "" {
 			return bakLogCurName, newName
 		}
@@ -158,11 +190,12 @@ func RegisterBuiltinExtLog(self *Dice) {
 
 			if len(cmdArgs.Args) == 0 {
 				onText := "关闭"
-				if group.LogOn {
+				state := getGroupLogState(group)
+				if state.On {
 					onText = "开启"
 				}
-				lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, group.LogCurName)
-				text := fmt.Sprintf("当前故事: %s\n当前状态: %s\n已记录文本%d条", group.LogCurName, onText, lines)
+				lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, state.Name)
+				text := fmt.Sprintf("当前故事: %s\n当前状态: %s\n已记录文本%d条", state.Name, onText, lines)
 				ReplyToSender(ctx, msg, text)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
@@ -234,15 +267,16 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 
 				// 如果日志已经开启，报错返回
-				if group.LogOn {
-					VarSetValueStr(ctx, "$t记录名称", group.LogCurName)
+				currentState := getGroupLogState(group)
+				if currentState.On {
+					VarSetValueStr(ctx, "$t记录名称", currentState.Name)
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_开启_失败_未结束的记录"))
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
 				name := cmdArgs.GetArgN(2)
 				if name == "" {
-					name = group.LogCurName
+					name = currentState.Name
 				}
 				if name != "" {
 					var ok bool
@@ -260,9 +294,15 @@ func RegisterBuiltinExtLog(self *Dice) {
 							return CmdExecuteResult{Matched: true, Solved: true}
 						}
 
-						group.LogOn = true
-						group.LogCurName = name
+						logID, err := service.LogGetOrCreate(ctx.Dice.DBOperator, group.GroupID, name)
+						if err != nil {
+							ReplyToSender(ctx, msg, "日志开启失败: "+err.Error())
+							ctx.Dice.Logger.Errorf("日志开启失败: group=%s name=%s err=%v", group.GroupID, name, err)
+							return CmdExecuteResult{Matched: true, Solved: true}
+						}
+						group.SetLogState(logID, name, true)
 						group.MarkDirty(ctx.Dice)
+						ctx.Dice.Logger.Infof("日志状态切换: 群=%s 开启日志 name=%s id=%d", group.GroupID, name, logID)
 
 						VarSetValueStr(ctx, "$t记录名称", name)
 						VarSetValueInt64(ctx, "$t当前记录条数", lines)
@@ -276,11 +316,13 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "off") {
-				if group.LogCurName != "" && group.LogOn {
-					group.LogOn = false
+				state := getGroupLogState(group)
+				if state.Name != "" && state.On {
+					group.SetLogOn(false)
 					group.MarkDirty(ctx.Dice)
-					lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, group.LogCurName)
-					VarSetValueStr(ctx, "$t记录名称", group.LogCurName)
+					ctx.Dice.Logger.Infof("日志状态切换: 群=%s 暂停日志 name=%s id=%d", group.GroupID, state.Name, state.ID)
+					lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, state.Name)
+					VarSetValueStr(ctx, "$t记录名称", state.Name)
 					VarSetValueInt64(ctx, "$t当前记录条数", lines)
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_关闭_成功"))
 				} else {
@@ -299,7 +341,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 
 				VarSetValueStr(ctx, "$t记录名称", name)
-				if name == group.LogCurName {
+				if name == getGroupLogName(group) {
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_删除_失败_正在进行"))
 				} else {
 					err := service.LogDelete(ctx.Dice.DBOperator, group.GroupID, name)
@@ -333,7 +375,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
-				logName := group.LogCurName
+				logName := getGroupLogName(group)
 				if newName := cmdArgs.GetArgN(2); newName != "" {
 					logName = newName
 				}
@@ -347,39 +389,44 @@ func RegisterBuiltinExtLog(self *Dice) {
 				getAndUpload(group.GroupID, logName)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "end") {
-				if group.LogCurName == "" {
+				state := getGroupLogState(group)
+				if state.Name == "" {
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_关闭_失败"))
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
-				lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, group.LogCurName)
+				lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, state.Name)
 				VarSetValueInt64(ctx, "$t当前记录条数", lines)
-				VarSetValueStr(ctx, "$t记录名称", group.LogCurName)
+				VarSetValueStr(ctx, "$t记录名称", state.Name)
 				text := DiceFormatTmpl(ctx, "日志:记录_结束")
 				// Note: 2024-02-28 经过讨论，日志在 off 的情况下 end 属于合理操作，这里不再检查是否开启
 				// if !group.LogOn {
 				//	 text = strings.TrimRightFunc(DiceFormatTmpl(ctx, "日志:记录_关闭_失败"), unicode.IsSpace) + "\n" + text
 				// }
 				ReplyToSender(ctx, msg, text)
-				group.LogOn = false
+				group.SetLogOn(false)
 				group.MarkDirty(ctx.Dice)
+				ctx.Dice.Logger.Infof("日志状态切换: 群=%s 结束日志 name=%s id=%d，准备上传", group.GroupID, state.Name, state.ID)
 
 				time.Sleep(time.Duration(0.3 * float64(time.Second)))
 				// Note: 2024-10-15 经过简单测试，似乎能缓解#1034的问题，但无法根本解决。
-				go getAndUpload(group.GroupID, group.LogCurName)
-				group.LogCurName = ""
+				uploadGroupID := group.GroupID
+				uploadName := state.Name
+				go getAndUpload(uploadGroupID, uploadName)
+				group.ClearLogState()
 				group.MarkDirty(ctx.Dice)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "halt") {
-				if len(group.LogCurName) > 0 {
-					lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, group.LogCurName)
+				state := getGroupLogState(group)
+				if len(state.Name) > 0 {
+					lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, state.Name)
 					VarSetValueInt64(ctx, "$t当前记录条数", lines)
-					VarSetValueStr(ctx, "$t记录名称", group.LogCurName)
+					VarSetValueStr(ctx, "$t记录名称", state.Name)
 				}
 				text := DiceFormatTmpl(ctx, "日志:记录_结束")
 				ReplyToSender(ctx, msg, text)
-				group.LogOn = false
-				group.LogCurName = ""
+				group.ClearLogState()
 				group.MarkDirty(ctx.Dice)
+				ctx.Dice.Logger.Infof("日志状态切换: 群=%s 强制终止当前日志", group.GroupID)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "list") {
 				groupID, requestForAnotherGroup := getSpecifiedGroupIfMaster(ctx, msg, cmdArgs)
@@ -415,8 +462,9 @@ func RegisterBuiltinExtLog(self *Dice) {
 				}
 
 				name := cmdArgs.GetArgN(2)
-				if group.LogCurName != "" && name == "" {
-					VarSetValueStr(ctx, "$t记录名称", group.LogCurName)
+				currentState := getGroupLogState(group)
+				if currentState.Name != "" && name == "" {
+					VarSetValueStr(ctx, "$t记录名称", currentState.Name)
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_新建_失败_未结束的记录"))
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
@@ -427,16 +475,22 @@ func RegisterBuiltinExtLog(self *Dice) {
 				if name == "" {
 					name = time.Now().Format("2006_01_02_15_04_05")
 				}
-				if group.LogCurName != "" {
+				if currentState.Name != "" {
 					VarSetValueInt64(ctx, "$t存在开启记录", 1)
 				} else {
 					VarSetValueInt64(ctx, "$t存在开启记录", 0)
 				}
-				VarSetValueStr(ctx, "$t上一记录名称", group.LogCurName)
+				VarSetValueStr(ctx, "$t上一记录名称", currentState.Name)
 				VarSetValueStr(ctx, "$t记录名称", name)
-				group.LogCurName = name
-				group.LogOn = true
+				logID, err := service.LogGetOrCreate(ctx.Dice.DBOperator, group.GroupID, name)
+				if err != nil {
+					ReplyToSender(ctx, msg, "日志新建失败: "+err.Error())
+					ctx.Dice.Logger.Errorf("日志新建失败: group=%s name=%s err=%v", group.GroupID, name, err)
+					return CmdExecuteResult{Matched: true, Solved: true}
+				}
+				group.SetLogState(logID, name, true)
 				group.MarkDirty(ctx.Dice)
+				ctx.Dice.Logger.Infof("日志状态切换: 群=%s 新建并开启日志 name=%s id=%d", group.GroupID, name, logID)
 
 				ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_新建"))
 				return CmdExecuteResult{Matched: true, Solved: true}
@@ -490,7 +544,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 
-				logName := group.LogCurName
+				logName := getGroupLogName(group)
 				if newName := cmdArgs.GetArgN(2); newName != "" {
 					logName = newName
 				}
@@ -882,11 +936,15 @@ func RegisterBuiltinExtLog(self *Dice) {
 			}
 			privateCommandListenCheck()
 			if msg.MessageType == "private" && ctx.CommandHideFlag != "" {
-				if _, exists := privateCommandListen[ctx.CommandID]; exists {
+				if privateCommandListenHas(ctx.CommandID) {
 					session := ctx.Session
 					groupInfo, ok := session.ServiceAtNew.Load(ctx.CommandHideFlag)
 					if !ok {
 						ctx.Dice.Logger.Warn("ServiceAtNew ext_log加载groupInfo异常")
+						return
+					}
+					logState := getGroupLogState(groupInfo)
+					if !logState.On || logState.ID == 0 || logState.Name == "" {
 						return
 					}
 					a := model.LogOneItem{
@@ -901,7 +959,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 						RawMsgID:    msg.RawID,
 					}
 
-					LogAppend(ctx, groupInfo.GroupID, groupInfo.LogCurName, &a)
+					LogAppend(ctx, groupInfo.GroupID, logState.ID, logState.Name, &a)
 				}
 			}
 
@@ -912,11 +970,12 @@ func RegisterBuiltinExtLog(self *Dice) {
 					ctx.Dice.Logger.Warn("ServiceAtNew ext_log加载groupInfo异常")
 					return
 				}
-				if groupInfo.LogOn {
+				logState := getGroupLogState(groupInfo)
+				if logState.On && logState.ID > 0 && logState.Name != "" {
 					// <2022-02-15 09:54:14.0> [摸鱼king]: 有的 但我不知道
 					if ctx.CommandHideFlag != "" {
 						// 记录当前指令和时间
-						privateCommandListen[ctx.CommandID] = time.Now().Unix()
+						privateCommandListenSet(ctx.CommandID, time.Now().Unix())
 					}
 
 					a := model.LogOneItem{
@@ -930,14 +989,15 @@ func RegisterBuiltinExtLog(self *Dice) {
 						CommandInfo: ctx.CommandInfo,
 						RawMsgID:    msg.RawID,
 					}
-					LogAppend(ctx, groupInfo.GroupID, groupInfo.LogCurName, &a)
+					LogAppend(ctx, groupInfo.GroupID, logState.ID, logState.Name, &a)
 				}
 			}
 		},
 		OnMessageReceived: func(ctx *MsgContext, msg *Message) {
 			// 处理日志
 			if ctx.Group != nil {
-				if ctx.Group.LogOn {
+				logState := getGroupLogState(ctx.Group)
+				if logState.On && logState.ID > 0 && logState.Name != "" {
 					// 去重，用于同群多骰情况
 					if !groupMsgInfoCheckOk(msg.RawID) {
 						return
@@ -956,14 +1016,14 @@ func RegisterBuiltinExtLog(self *Dice) {
 						RawMsgID:  msg.RawID,
 					}
 
-					LogAppend(ctx, ctx.Group.GroupID, ctx.Group.LogCurName, &a)
+					LogAppend(ctx, ctx.Group.GroupID, logState.ID, logState.Name, &a)
 				}
 			}
 		},
 		OnMessageDeleted: func(ctx *MsgContext, msg *Message) {
 			if ctx.Group != nil {
-				if ctx.Group.LogOn {
-					LogDeleteByID(ctx, ctx.Group.GroupID, ctx.Group.LogCurName, msg.RawID)
+				if getGroupLogOn(ctx.Group) {
+					LogDeleteByID(ctx, ctx.Group.GroupID, msg.RawID)
 					// ctx.Session.Parent.Logger.Infof("删除日志 %s %s", ctx.Group.GroupId, msg.RawId.(string))
 				}
 			}
@@ -973,8 +1033,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 				return
 			}
 
-			if ctx.Group.LogOn {
-				LogEditByID(ctx, ctx.Group.GroupID, ctx.Group.LogCurName, msg.Message, msg.RawID)
+			if getGroupLogOn(ctx.Group) {
+				LogEditByID(ctx, ctx.Group.GroupID, msg.Message, msg.RawID)
 			}
 		},
 		GetDescText: GetExtensionDesc,
@@ -1019,8 +1079,13 @@ func FilenameReplace(name string) string {
 	return re.ReplaceAllString(name, "")
 }
 
-func LogAppend(ctx *MsgContext, groupID string, logName string, logItem *model.LogOneItem) bool {
-	ok := service.LogAppend(ctx.Dice.DBOperator, groupID, logName, logItem)
+func LogAppend(ctx *MsgContext, groupID string, logID uint64, logName string, logItem *model.LogOneItem) bool {
+	ok := false
+	if logID > 0 {
+		ok = service.LogAppendByID(ctx.Dice.DBOperator, logID, groupID, logItem)
+	} else if logName != "" {
+		ok = service.LogAppend(ctx.Dice.DBOperator, groupID, logName, logItem)
+	}
 	if ok {
 		if size, okCount := service.LogLinesCountGet(ctx.Dice.DBOperator, groupID, logName); okCount {
 			// 默认每记录500条发出提示
@@ -1040,8 +1105,8 @@ func LogAppend(ctx *MsgContext, groupID string, logName string, logItem *model.L
 	return ok
 }
 
-func LogDeleteByID(ctx *MsgContext, groupID string, logName string, messageID interface{}) bool {
-	err := service.LogMarkDeleteByMsgID(ctx.Dice.DBOperator, groupID, logName, messageID)
+func LogDeleteByID(ctx *MsgContext, groupID string, messageID interface{}) bool {
+	err := service.LogMarkDeleteByRawMsgID(ctx.Dice.DBOperator, groupID, messageID)
 	if err != nil {
 		ctx.Dice.Logger.Error("LogDeleteById:", zap.Error(err))
 		return false
@@ -1051,8 +1116,8 @@ func LogDeleteByID(ctx *MsgContext, groupID string, logName string, messageID in
 
 // LogEditByID finds the log item under logName with messageID and replace it with content.
 // If the log item cannot be found or an error happens, it returns false.
-func LogEditByID(ctx *MsgContext, groupID, logName, content string, messageID interface{}) bool {
-	err := service.LogEditByMsgID(ctx.Dice.DBOperator, groupID, logName, content, messageID)
+func LogEditByID(ctx *MsgContext, groupID, content string, messageID interface{}) bool {
+	err := service.LogEditByRawMsgID(ctx.Dice.DBOperator, groupID, content, messageID)
 	if err != nil {
 		ctx.Dice.Logger.Error("LogEditByID:", zap.Error(err))
 		return false

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -39,7 +39,28 @@ func getGroupLogName(group *GroupInfo) string {
 }
 
 func getGroupLogOn(group *GroupInfo) bool {
-	return getGroupLogState(group).On
+	state := getGroupLogState(group)
+	return state.On && state.Name != ""
+}
+
+func ensureGroupLogState(ctx *MsgContext, group *GroupInfo) GroupLogState {
+	state := getGroupLogState(group)
+	if group == nil || !state.On || state.Name == "" || state.ID > 0 {
+		return state
+	}
+
+	logID, err := service.LogGetOrCreate(ctx.Dice.DBOperator, group.GroupID, state.Name)
+	if err != nil {
+		if ctx != nil && ctx.Dice != nil && ctx.Dice.Logger != nil {
+			ctx.Dice.Logger.Warnf("日志状态修复失败: 群=%s 名称=%s err=%v", group.GroupID, state.Name, err)
+		}
+		return state
+	}
+	group.SetLogState(logID, state.Name, state.On)
+	if ctx != nil && ctx.Dice != nil && ctx.Dice.Logger != nil {
+		ctx.Dice.Logger.Infof("日志状态修复: 群=%s 记录=%s 补全logID=%d", group.GroupID, state.Name, logID)
+	}
+	return getGroupLogState(group)
 }
 
 func SetPlayerGroupCardByTemplate(ctx *MsgContext, tmpl string) (string, error) {
@@ -943,8 +964,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 						ctx.Dice.Logger.Warn("ServiceAtNew ext_log加载groupInfo异常")
 						return
 					}
-					logState := getGroupLogState(groupInfo)
-					if !logState.On || logState.ID == 0 || logState.Name == "" {
+					logState := ensureGroupLogState(ctx, groupInfo)
+					if !logState.On || logState.Name == "" {
 						return
 					}
 					a := model.LogOneItem{
@@ -970,8 +991,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 					ctx.Dice.Logger.Warn("ServiceAtNew ext_log加载groupInfo异常")
 					return
 				}
-				logState := getGroupLogState(groupInfo)
-				if logState.On && logState.ID > 0 && logState.Name != "" {
+				logState := ensureGroupLogState(ctx, groupInfo)
+				if logState.On && logState.Name != "" {
 					// <2022-02-15 09:54:14.0> [摸鱼king]: 有的 但我不知道
 					if ctx.CommandHideFlag != "" {
 						// 记录当前指令和时间
@@ -996,8 +1017,8 @@ func RegisterBuiltinExtLog(self *Dice) {
 		OnMessageReceived: func(ctx *MsgContext, msg *Message) {
 			// 处理日志
 			if ctx.Group != nil {
-				logState := getGroupLogState(ctx.Group)
-				if logState.On && logState.ID > 0 && logState.Name != "" {
+				logState := ensureGroupLogState(ctx, ctx.Group)
+				if logState.On && logState.Name != "" {
 					// 去重，用于同群多骰情况
 					if !groupMsgInfoCheckOk(msg.RawID) {
 						return

--- a/dice/ext_log_alias_test.go
+++ b/dice/ext_log_alias_test.go
@@ -219,3 +219,32 @@ func TestLogSendToBackendAcceptsAliasKey(t *testing.T) {
 		t.Fatalf("url = %q", url)
 	}
 }
+
+func TestEnsureGroupLogStateBackfillsLegacyLogID(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:2001"
+	logName := "legacy-log"
+
+	ctx := &MsgContext{
+		Dice: &Dice{DBOperator: mockDB},
+		Group: &GroupInfo{
+			GroupID:    groupID,
+			LogCurName: logName,
+			LogOn:      true,
+		},
+	}
+
+	logState := ensureGroupLogState(ctx, ctx.Group)
+	if !logState.On {
+		t.Fatal("expected legacy log state to stay on")
+	}
+	if logState.Name != logName {
+		t.Fatalf("logState.Name = %q, want %q", logState.Name, logName)
+	}
+	if logState.ID == 0 {
+		t.Fatal("expected legacy log state to backfill non-zero log id")
+	}
+	if got := ctx.Group.GetLogState().ID; got != logState.ID {
+		t.Fatalf("group LogCurID = %d, want %d", got, logState.ID)
+	}
+}

--- a/dice/ext_log_alias_test.go
+++ b/dice/ext_log_alias_test.go
@@ -34,7 +34,7 @@ func newLogAliasTestDB(t *testing.T) *mockDatabaseOperator {
 func appendTestLog(t *testing.T, mockDB *mockDatabaseOperator, groupID, logName string) {
 	t.Helper()
 
-	ok := LogAppend(&MsgContext{Dice: &Dice{DBOperator: mockDB}}, groupID, logName, &model.LogOneItem{
+	ok := LogAppend(&MsgContext{Dice: &Dice{DBOperator: mockDB}}, groupID, 0, logName, &model.LogOneItem{
 		Nickname: "tester",
 		IMUserID: "user",
 		Message:  "line",

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -87,10 +87,12 @@ type GroupInfo struct {
 	DiceSideExpr    string                 `json:"diceSideExpr"    yaml:"diceSideExpr"` //
 	System          string                 `json:"system"          yaml:"system"`       // 规则系统，概念同bcdice的gamesystem，距离如dnd5e coc7
 
-	HelpPackages []string `json:"helpPackages"   yaml:"-"`
-	CocRuleIndex int      `jsbind:"cocRuleIndex" json:"cocRuleIndex" yaml:"cocRuleIndex"`
-	LogCurName   string   `jsbind:"logCurName"   json:"logCurName"   yaml:"logCurFile"`
-	LogOn        bool     `jsbind:"logOn"        json:"logOn"        yaml:"logOn"`
+	HelpPackages []string     `json:"helpPackages"   yaml:"-"`
+	CocRuleIndex int          `jsbind:"cocRuleIndex" json:"cocRuleIndex" yaml:"cocRuleIndex"`
+	logStateMu   sync.RWMutex `json:"-" yaml:"-"`
+	LogCurID     uint64       `json:"-" yaml:"-"`
+	LogCurName   string       `jsbind:"logCurName"   json:"logCurName"   yaml:"logCurFile"`
+	LogOn        bool         `jsbind:"logOn"        json:"logOn"        yaml:"logOn"`
 
 	QuitMarkAutoClean   bool   `json:"-"                     yaml:"-"` // 自动清群 - 播报，即将自动退出群组
 	QuitMarkMaster      bool   `json:"-"                     yaml:"-"` // 骰主命令退群 - 播报，即将自动退出群组
@@ -281,6 +283,44 @@ func (g *GroupInfo) MarkDirty(d *Dice) {
 	if d != nil && d.DirtyGroups != nil {
 		d.DirtyGroups.Store(g.GroupID, now)
 	}
+}
+
+type GroupLogState struct {
+	ID   uint64
+	Name string
+	On   bool
+}
+
+func (g *GroupInfo) GetLogState() GroupLogState {
+	g.logStateMu.RLock()
+	defer g.logStateMu.RUnlock()
+	return GroupLogState{
+		ID:   g.LogCurID,
+		Name: g.LogCurName,
+		On:   g.LogOn,
+	}
+}
+
+func (g *GroupInfo) SetLogState(logID uint64, logName string, logOn bool) {
+	g.logStateMu.Lock()
+	g.LogCurID = logID
+	g.LogCurName = logName
+	g.LogOn = logOn
+	g.logStateMu.Unlock()
+}
+
+func (g *GroupInfo) SetLogOn(logOn bool) {
+	g.logStateMu.Lock()
+	g.LogOn = logOn
+	g.logStateMu.Unlock()
+}
+
+func (g *GroupInfo) ClearLogState() {
+	g.logStateMu.Lock()
+	g.LogCurID = 0
+	g.LogCurName = ""
+	g.LogOn = false
+	g.logStateMu.Unlock()
 }
 
 func (group *GroupInfo) IsActive(ctx *MsgContext) bool {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -87,12 +87,12 @@ type GroupInfo struct {
 	DiceSideExpr    string                 `json:"diceSideExpr"    yaml:"diceSideExpr"` //
 	System          string                 `json:"system"          yaml:"system"`       // 规则系统，概念同bcdice的gamesystem，距离如dnd5e coc7
 
-	HelpPackages []string     `json:"helpPackages"   yaml:"-"`
-	CocRuleIndex int          `jsbind:"cocRuleIndex" json:"cocRuleIndex" yaml:"cocRuleIndex"`
-	logStateMu   sync.RWMutex `json:"-" yaml:"-"`
-	LogCurID     uint64       `json:"-" yaml:"-"`
-	LogCurName   string       `jsbind:"logCurName"   json:"logCurName"   yaml:"logCurFile"`
-	LogOn        bool         `jsbind:"logOn"        json:"logOn"        yaml:"logOn"`
+	HelpPackages []string      `json:"helpPackages"   yaml:"-"`
+	CocRuleIndex int           `jsbind:"cocRuleIndex" json:"cocRuleIndex" yaml:"cocRuleIndex"`
+	logStateMu   *sync.RWMutex `json:"-" yaml:"-"`
+	LogCurID     uint64        `json:"-" yaml:"-"`
+	LogCurName   string        `jsbind:"logCurName"   json:"logCurName"   yaml:"logCurFile"`
+	LogOn        bool          `jsbind:"logOn"        json:"logOn"        yaml:"logOn"`
 
 	QuitMarkAutoClean   bool   `json:"-"                     yaml:"-"` // 自动清群 - 播报，即将自动退出群组
 	QuitMarkMaster      bool   `json:"-"                     yaml:"-"` // 骰主命令退群 - 播报，即将自动退出群组
@@ -291,9 +291,17 @@ type GroupLogState struct {
 	On   bool
 }
 
+func (g *GroupInfo) ensureLogStateMu() *sync.RWMutex {
+	if g.logStateMu == nil {
+		g.logStateMu = &sync.RWMutex{}
+	}
+	return g.logStateMu
+}
+
 func (g *GroupInfo) GetLogState() GroupLogState {
-	g.logStateMu.RLock()
-	defer g.logStateMu.RUnlock()
+	mu := g.ensureLogStateMu()
+	mu.RLock()
+	defer mu.RUnlock()
 	return GroupLogState{
 		ID:   g.LogCurID,
 		Name: g.LogCurName,
@@ -302,25 +310,28 @@ func (g *GroupInfo) GetLogState() GroupLogState {
 }
 
 func (g *GroupInfo) SetLogState(logID uint64, logName string, logOn bool) {
-	g.logStateMu.Lock()
+	mu := g.ensureLogStateMu()
+	mu.Lock()
 	g.LogCurID = logID
 	g.LogCurName = logName
 	g.LogOn = logOn
-	g.logStateMu.Unlock()
+	mu.Unlock()
 }
 
 func (g *GroupInfo) SetLogOn(logOn bool) {
-	g.logStateMu.Lock()
+	mu := g.ensureLogStateMu()
+	mu.Lock()
 	g.LogOn = logOn
-	g.logStateMu.Unlock()
+	mu.Unlock()
 }
 
 func (g *GroupInfo) ClearLogState() {
-	g.logStateMu.Lock()
+	mu := g.ensureLogStateMu()
+	mu.Lock()
 	g.LogCurID = 0
 	g.LogCurName = ""
 	g.LogOn = false
-	g.logStateMu.Unlock()
+	mu.Unlock()
 }
 
 func (group *GroupInfo) IsActive(ctx *MsgContext) bool {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -2214,6 +2214,13 @@ func (s *IMSession) OnMessageDeleted(mctx *MsgContext, msg *Message) {
 
 	_ = mctx.fillPrivilege(msg)
 
+	log := d.Logger
+	if msg.MessageType == "group" {
+		log.Infof("收到群(%s)内<%s>(%s)的撤回消息事件: rawId=%v", msg.GroupID, msg.Sender.Nickname, msg.Sender.UserID, msg.RawID)
+	} else {
+		log.Infof("收到<%s>(%s)的撤回消息事件: rawId=%v", msg.Sender.Nickname, msg.Sender.UserID, msg.RawID)
+	}
+
 	for _, i := range s.Parent.ExtList {
 		i.CallOnMessageDeleted(mctx.Dice, mctx, msg)
 	}

--- a/dice/im_vars.go
+++ b/dice/im_vars.go
@@ -303,11 +303,12 @@ func SetTempVars(ctx *MsgContext, qqNickname string) {
 		VarSetValueStr(ctx, "$t游戏模式", ctx.Group.System)
 		VarSetValueStr(ctx, "$t规则模板", ctx.Group.System)
 		VarSetValueStr(ctx, "$tSystem", ctx.Group.System)
-		VarSetValueStr(ctx, "$t当前记录", ctx.Group.LogCurName)
+		logState := ctx.Group.GetLogState()
+		VarSetValueStr(ctx, "$t当前记录", logState.Name)
 		VarSetValueInt64(ctx, "$t权限等级", int64(ctx.PrivilegeLevel))
 
 		var isLogOn int64
-		if ctx.Group.LogOn {
+		if logState.On {
 			isLogOn = 1
 		}
 		VarSetValueInt64(ctx, "$t日志开启", isLogOn)

--- a/dice/platform_adapter_gocq_channel.go
+++ b/dice/platform_adapter_gocq_channel.go
@@ -67,8 +67,8 @@ func (pa *PlatformAdapterGocq) QQChannelTrySolve(message string) {
 		if msgQQ.PostType == "notice" && msgQQ.NoticeType == "guild_channel_recall" {
 			groupInfo, ok := session.ServiceAtNew.Load(msg.GroupID)
 			if ok {
-				if groupInfo.LogOn {
-					_ = service.LogMarkDeleteByMsgID(ctx.Dice.DBOperator, groupInfo.GroupID, groupInfo.LogCurName, msgQQ.MessageID)
+				if groupInfo.GetLogState().On {
+					_ = service.LogMarkDeleteByRawMsgID(ctx.Dice.DBOperator, groupInfo.GroupID, msgQQ.MessageID)
 				}
 			}
 			return

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -440,8 +440,8 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 			case "group_message_delete": // 消息撤回
 				groupInfo, ok := s.ServiceAtNew.Load(msg.GroupID)
 				if ok {
-					if groupInfo.LogOn {
-						_ = service.LogMarkDeleteByMsgID(ctx.Dice.DBOperator, groupInfo.GroupID, groupInfo.LogCurName, n.MessageID)
+					if groupInfo.GetLogState().On {
+						_ = service.LogMarkDeleteByRawMsgID(ctx.Dice.DBOperator, groupInfo.GroupID, n.MessageID)
 					}
 				}
 				return

--- a/dice/service/log.go
+++ b/dice/service/log.go
@@ -199,6 +199,83 @@ func getIDByGroupIDAndName(db *gorm.DB, groupID string, logName string) (logID u
 	return logInfo.ID, nil
 }
 
+func getLogInfoByID(db *gorm.DB, logID uint64) (*model.LogInfo, error) {
+	var logInfo model.LogInfo
+	err := db.Model(&model.LogInfo{}).
+		Where("id = ?", logID).
+		Take(&logInfo).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrLogNotFound
+		}
+		return nil, err
+	}
+	if logInfo.ID == 0 {
+		return nil, ErrLogNotFound
+	}
+	return &logInfo, nil
+}
+
+func getLogInfoByRawMsgID(db *gorm.DB, groupID string, rawID interface{}) (*model.LogInfo, error) {
+	rid := fmt.Sprintf("%v", rawID)
+	if rid == "" {
+		return nil, ErrLogNotFound
+	}
+
+	var logInfo model.LogInfo
+	err := db.Model(&model.LogInfo{}).
+		Select("logs.id, logs.name, logs.group_id, logs.created_at, logs.updated_at, logs.upload_url, logs.upload_time").
+		Joins("JOIN log_items ON log_items.log_id = logs.id").
+		Where("log_items.group_id = ? AND log_items.raw_msg_id = ?", groupID, rid).
+		Order("log_items.id DESC").
+		Take(&logInfo).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrLogNotFound
+		}
+		return nil, err
+	}
+	if logInfo.ID == 0 {
+		return nil, ErrLogNotFound
+	}
+	return &logInfo, nil
+}
+
+func createLog(tx *gorm.DB, groupID string, logName string, nowTimestamp int64) (uint64, error) {
+	newLog := model.LogInfo{Name: logName, GroupID: groupID, CreatedAt: nowTimestamp, UpdatedAt: nowTimestamp}
+	if err := tx.Create(&newLog).Error; err != nil {
+		existedLogID, findErr := getIDByGroupIDAndName(tx, groupID, logName)
+		if findErr != nil {
+			return 0, err
+		}
+		return existedLogID, nil
+	}
+	return newLog.ID, nil
+}
+
+// LogGetOrCreate 返回指定群和日志名对应的内部 log_id，不存在时自动创建。
+func LogGetOrCreate(operator engine2.DatabaseOperator, groupID string, logName string) (uint64, error) {
+	db := operator.GetLogDB(constant.WRITE)
+	logID, err := getIDByGroupIDAndName(db, groupID, logName)
+	if err == nil {
+		return logID, nil
+	}
+	if !errors.Is(err, ErrLogNotFound) {
+		return 0, err
+	}
+
+	nowTimestamp := time.Now().Unix()
+	err = db.Transaction(func(tx *gorm.DB) error {
+		var createErr error
+		logID, createErr = createLog(tx, groupID, logName, nowTimestamp)
+		return createErr
+	})
+	if err != nil {
+		return 0, err
+	}
+	return logID, nil
+}
+
 // LogGetUploadInfo 获取上传信息
 func LogGetUploadInfo(operator engine2.DatabaseOperator, groupID string, logName string) (url string, uploadTime, updateTime int64, err error) {
 	db := operator.GetLogDB(constant.READ)
@@ -519,6 +596,54 @@ func LogAppend(operator engine2.DatabaseOperator, groupID string, logName string
 	return err == nil
 }
 
+// LogAppendByID 向指定 log_id 的日志中追加一条消息。
+func LogAppendByID(operator engine2.DatabaseOperator, logID uint64, groupID string, logItem *model.LogOneItem) bool {
+	db := operator.GetLogDB(constant.WRITE)
+	if logID == 0 {
+		return false
+	}
+
+	now := time.Now()
+	nowTimestamp := now.Unix()
+	newLogItem := model.LogOneItem{
+		LogID:       logID,
+		GroupID:     groupID,
+		Nickname:    logItem.Nickname,
+		IMUserID:    logItem.IMUserID,
+		Time:        nowTimestamp,
+		Message:     logItem.Message,
+		IsDice:      logItem.IsDice,
+		CommandID:   logItem.CommandID,
+		CommandInfo: logItem.CommandInfo,
+		RawMsgID:    logItem.RawMsgID,
+		UniformID:   logItem.UniformID,
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		logInfo, getErr := getLogInfoByID(tx, logID)
+		if getErr != nil {
+			return getErr
+		}
+		if logInfo.GroupID != groupID {
+			return fmt.Errorf("log append by id: log %d 不属于群 %s", logID, groupID)
+		}
+		if err := tx.Create(&newLogItem).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&model.LogInfo{}).
+			Where("id = ?", logID).
+			Updates(map[string]interface{}{
+				"updated_at": nowTimestamp,
+				"size":       gorm.Expr("COALESCE(size, 0) + ?", 1),
+			}).Error; err != nil {
+			return err
+		}
+		return nil
+	})
+
+	return err == nil
+}
+
 // LogMarkDeleteByMsgID 撤回删除
 func LogMarkDeleteByMsgID(operator engine2.DatabaseOperator, groupID string, logName string, rawID interface{}) error {
 	db := operator.GetLogDB(constant.WRITE)
@@ -549,6 +674,19 @@ func LogMarkDeleteByMsgID(operator engine2.DatabaseOperator, groupID string, log
 	return err
 }
 
+// LogMarkDeleteByRawMsgID 根据消息 ID 反查所属日志并删除，避免依赖当前日志名。
+func LogMarkDeleteByRawMsgID(operator engine2.DatabaseOperator, groupID string, rawID interface{}) error {
+	db := operator.GetLogDB(constant.WRITE)
+	logInfo, err := getLogInfoByRawMsgID(db, groupID, rawID)
+	if err != nil {
+		if errors.Is(err, ErrLogNotFound) {
+			return nil
+		}
+		return err
+	}
+	return LogMarkDeleteByMsgID(operator, logInfo.GroupID, logInfo.Name, rawID)
+}
+
 // LogEditByMsgID 编辑日志
 func LogEditByMsgID(operator engine2.DatabaseOperator, groupID, logName, newContent string, rawID interface{}) error {
 	db := operator.GetLogDB(constant.WRITE)
@@ -576,4 +714,17 @@ func LogEditByMsgID(operator engine2.DatabaseOperator, groupID, logName, newCont
 	}
 
 	return nil
+}
+
+// LogEditByRawMsgID 根据消息 ID 反查所属日志并编辑，避免依赖当前日志名。
+func LogEditByRawMsgID(operator engine2.DatabaseOperator, groupID, newContent string, rawID interface{}) error {
+	db := operator.GetLogDB(constant.WRITE)
+	logInfo, err := getLogInfoByRawMsgID(db, groupID, rawID)
+	if err != nil {
+		if errors.Is(err, ErrLogNotFound) {
+			return nil
+		}
+		return err
+	}
+	return LogEditByMsgID(operator, logInfo.GroupID, logInfo.Name, newContent, rawID)
 }

--- a/dice/service/log.go
+++ b/dice/service/log.go
@@ -222,23 +222,32 @@ func getLogInfoByRawMsgID(db *gorm.DB, groupID string, rawID interface{}) (*mode
 		return nil, ErrLogNotFound
 	}
 
-	var logInfo model.LogInfo
-	err := db.Model(&model.LogInfo{}).
-		Select("logs.id, logs.name, logs.group_id, logs.created_at, logs.updated_at, logs.upload_url, logs.upload_time").
-		Joins("JOIN log_items ON log_items.log_id = logs.id").
-		Where("log_items.group_id = ? AND log_items.raw_msg_id = ?", groupID, rid).
-		Order("log_items.id DESC").
-		Take(&logInfo).Error
+	// NOTE:
+	// - 这里依赖 log_items 上的复合索引 (group_id, raw_msg_id, id)，以支撑 WHERE + ORDER BY 的查询模式。
+	// - 正常情况下，同一群内不应存在多条相同 raw_msg_id 的日志项；若出现，默认以最新一条为准。
+	var candidates []struct {
+		ID    uint64 `gorm:"column:id"`
+		LogID uint64 `gorm:"column:log_id"`
+	}
+	err := db.Model(&model.LogOneItem{}).
+		Select("id, log_id").
+		Where("group_id = ? AND raw_msg_id = ?", groupID, rid).
+		Order("id DESC").
+		Limit(2).
+		Find(&candidates).Error
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrLogNotFound
-		}
 		return nil, err
 	}
-	if logInfo.ID == 0 {
+
+	if len(candidates) == 0 || candidates[0].LogID == 0 {
 		return nil, ErrLogNotFound
 	}
-	return &logInfo, nil
+
+	if len(candidates) > 1 {
+		zap.S().Named(logger.LogKeyDatabase).Warnf("日志RawMsgID出现重复，按最新记录处理: group=%s raw_msg_id=%s latest_item_id=%d", groupID, rid, candidates[0].ID)
+	}
+
+	return getLogInfoByID(db, candidates[0].LogID)
 }
 
 func createLog(tx *gorm.DB, groupID string, logName string, nowTimestamp int64) (uint64, error) {

--- a/dice/service/log_test.go
+++ b/dice/service/log_test.go
@@ -377,3 +377,90 @@ func TestLogEditByRawMsgIDUpdatesOriginalMessage(t *testing.T) {
 		t.Fatalf("log-b message = %q, want %q", linesB[0].Message, "before-b")
 	}
 }
+
+func TestLogEditByRawMsgIDUsesLatestDuplicateInGroup(t *testing.T) {
+	db := newLogInfoTestDB(t)
+	op := &logInfoTestOperator{db: db, dbType: constant.SQLITE}
+	groupID := "QQ-Group:1004"
+
+	logIDA, err := service.LogGetOrCreate(op, groupID, "log-a")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate(log-a): %v", err)
+	}
+	logIDB, err := service.LogGetOrCreate(op, groupID, "log-b")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate(log-b): %v", err)
+	}
+
+	const sharedRawID = "raw-shared"
+	if !service.LogAppendByID(op, logIDA, groupID, &model.LogOneItem{
+		Nickname: "tester-a",
+		IMUserID: "user-a",
+		Message:  "before-a",
+		RawMsgID: sharedRawID,
+	}) {
+		t.Fatal("LogAppendByID(log-a) failed")
+	}
+	if !service.LogAppendByID(op, logIDB, groupID, &model.LogOneItem{
+		Nickname: "tester-b",
+		IMUserID: "user-b",
+		Message:  "before-b",
+		RawMsgID: sharedRawID,
+	}) {
+		t.Fatal("LogAppendByID(log-b) failed")
+	}
+
+	err = service.LogEditByRawMsgID(op, groupID, "after-latest", sharedRawID)
+	if err != nil {
+		t.Fatalf("LogEditByRawMsgID(): %v", err)
+	}
+
+	linesA, err := service.LogGetAllLines(op, groupID, "log-a")
+	if err != nil {
+		t.Fatalf("LogGetAllLines(log-a): %v", err)
+	}
+	if len(linesA) != 1 {
+		t.Fatalf("len(log-a lines) = %d, want 1", len(linesA))
+	}
+	if linesA[0].Message != "before-a" {
+		t.Fatalf("log-a message = %q, want %q", linesA[0].Message, "before-a")
+	}
+
+	linesB, err := service.LogGetAllLines(op, groupID, "log-b")
+	if err != nil {
+		t.Fatalf("LogGetAllLines(log-b): %v", err)
+	}
+	if len(linesB) != 1 {
+		t.Fatalf("len(log-b lines) = %d, want 1", len(linesB))
+	}
+	if linesB[0].Message != "after-latest" {
+		t.Fatalf("log-b message = %q, want %q", linesB[0].Message, "after-latest")
+	}
+}
+
+func TestLogModelCreatesCompositeRawMsgIDIndexOnSQLite(t *testing.T) {
+	db := newLogInfoTestDB(t)
+
+	type sqliteIndexInfo struct {
+		Name string `gorm:"column:name"`
+		SQL  string `gorm:"column:sql"`
+	}
+	var indexes []sqliteIndexInfo
+	if err := db.Raw("SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'log_items'").Scan(&indexes).Error; err != nil {
+		t.Fatalf("query sqlite indexes: %v", err)
+	}
+
+	var found bool
+	for _, idx := range indexes {
+		if idx.Name != "idx_log_delete_by_id" {
+			continue
+		}
+		found = true
+		if !regexp.MustCompile("(?i)[(`]?group_id[)`]?,\\s*[(`]?raw_msg_id[)`]?,\\s*[(`]?id[)`]?").MatchString(idx.SQL) {
+			t.Fatalf("idx_log_delete_by_id sql = %q, want composite (group_id, raw_msg_id, id)", idx.SQL)
+		}
+	}
+	if !found {
+		t.Fatal("expected idx_log_delete_by_id to exist on log_items")
+	}
+}

--- a/dice/service/log_test.go
+++ b/dice/service/log_test.go
@@ -244,3 +244,136 @@ func seedLogInfoTestDB(t *testing.T, db *gorm.DB) {
 		t.Fatalf("delete log item gap: %v", err)
 	}
 }
+
+func TestLogGetOrCreateReturnsStableID(t *testing.T) {
+	db := newLogInfoTestDB(t)
+	op := &logInfoTestOperator{db: db, dbType: constant.SQLITE}
+
+	firstID, err := service.LogGetOrCreate(op, "QQ-Group:1001", "first-log")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate() first error = %v", err)
+	}
+	if firstID == 0 {
+		t.Fatal("LogGetOrCreate() returned zero id")
+	}
+
+	secondID, err := service.LogGetOrCreate(op, "QQ-Group:1001", "first-log")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate() second error = %v", err)
+	}
+	if secondID != firstID {
+		t.Fatalf("LogGetOrCreate() second id = %d, want %d", secondID, firstID)
+	}
+}
+
+func TestLogAppendByIDAndDeleteByRawMsgIDOperateOnOriginalLog(t *testing.T) {
+	db := newLogInfoTestDB(t)
+	op := &logInfoTestOperator{db: db, dbType: constant.SQLITE}
+	groupID := "QQ-Group:1002"
+
+	logIDA, err := service.LogGetOrCreate(op, groupID, "log-a")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate(log-a): %v", err)
+	}
+	logIDB, err := service.LogGetOrCreate(op, groupID, "log-b")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate(log-b): %v", err)
+	}
+
+	if !service.LogAppendByID(op, logIDA, groupID, &model.LogOneItem{
+		Nickname: "tester-a",
+		IMUserID: "user-a",
+		Message:  "message-a",
+		RawMsgID: "raw-a",
+	}) {
+		t.Fatal("LogAppendByID(log-a) failed")
+	}
+	if !service.LogAppendByID(op, logIDB, groupID, &model.LogOneItem{
+		Nickname: "tester-b",
+		IMUserID: "user-b",
+		Message:  "message-b",
+		RawMsgID: "raw-b",
+	}) {
+		t.Fatal("LogAppendByID(log-b) failed")
+	}
+
+	err = service.LogMarkDeleteByRawMsgID(op, groupID, "raw-a")
+	if err != nil {
+		t.Fatalf("LogMarkDeleteByRawMsgID(): %v", err)
+	}
+
+	linesA, err := service.LogGetAllLines(op, groupID, "log-a")
+	if err != nil {
+		t.Fatalf("LogGetAllLines(log-a): %v", err)
+	}
+	if len(linesA) != 0 {
+		t.Fatalf("len(log-a lines) = %d, want 0", len(linesA))
+	}
+
+	linesB, err := service.LogGetAllLines(op, groupID, "log-b")
+	if err != nil {
+		t.Fatalf("LogGetAllLines(log-b): %v", err)
+	}
+	if len(linesB) != 1 {
+		t.Fatalf("len(log-b lines) = %d, want 1", len(linesB))
+	}
+}
+
+func TestLogEditByRawMsgIDUpdatesOriginalMessage(t *testing.T) {
+	db := newLogInfoTestDB(t)
+	op := &logInfoTestOperator{db: db, dbType: constant.SQLITE}
+	groupID := "QQ-Group:1003"
+
+	logIDA, err := service.LogGetOrCreate(op, groupID, "log-a")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate(log-a): %v", err)
+	}
+	logIDB, err := service.LogGetOrCreate(op, groupID, "log-b")
+	if err != nil {
+		t.Fatalf("LogGetOrCreate(log-b): %v", err)
+	}
+
+	if !service.LogAppendByID(op, logIDA, groupID, &model.LogOneItem{
+		Nickname: "tester-a",
+		IMUserID: "user-a",
+		Message:  "before-a",
+		RawMsgID: "raw-a",
+	}) {
+		t.Fatal("LogAppendByID(log-a) failed")
+	}
+	if !service.LogAppendByID(op, logIDB, groupID, &model.LogOneItem{
+		Nickname: "tester-b",
+		IMUserID: "user-b",
+		Message:  "before-b",
+		RawMsgID: "raw-b",
+	}) {
+		t.Fatal("LogAppendByID(log-b) failed")
+	}
+
+	err = service.LogEditByRawMsgID(op, groupID, "after-a", "raw-a")
+	if err != nil {
+		t.Fatalf("LogEditByRawMsgID(): %v", err)
+	}
+
+	linesA, err := service.LogGetAllLines(op, groupID, "log-a")
+	if err != nil {
+		t.Fatalf("LogGetAllLines(log-a): %v", err)
+	}
+	if len(linesA) != 1 {
+		t.Fatalf("len(log-a lines) = %d, want 1", len(linesA))
+	}
+	if linesA[0].Message != "after-a" {
+		t.Fatalf("log-a message = %q, want %q", linesA[0].Message, "after-a")
+	}
+
+	linesB, err := service.LogGetAllLines(op, groupID, "log-b")
+	if err != nil {
+		t.Fatalf("LogGetAllLines(log-b): %v", err)
+	}
+	if len(linesB) != 1 {
+		t.Fatalf("len(log-b lines) = %d, want 1", len(linesB))
+	}
+	if linesB[0].Message != "before-b" {
+		t.Fatalf("log-b message = %q, want %q", linesB[0].Message, "before-b")
+	}
+}

--- a/migrate/v2/enter.go
+++ b/migrate/v2/enter.go
@@ -32,9 +32,9 @@ func InitUpgrader(operator operator.DatabaseOperator) error {
 	mgr.Register(v150.V150FixGroupInfoMigration)
 	// v151注册
 	mgr.Register(v151.V151GORMCleanMigration)
-	mgr.Register(v151.V151LogRawMsgIDIndexMigration)
 	// v160注册
 	mgr.Register(v160.V160LogIDZeroCleanMigration)
+	mgr.Register(v160.V160LogRawMsgIDIndexMigration)
 	err := mgr.ApplyAll()
 	if err != nil {
 		return err

--- a/migrate/v2/enter.go
+++ b/migrate/v2/enter.go
@@ -32,6 +32,7 @@ func InitUpgrader(operator operator.DatabaseOperator) error {
 	mgr.Register(v150.V150FixGroupInfoMigration)
 	// v151注册
 	mgr.Register(v151.V151GORMCleanMigration)
+	mgr.Register(v151.V151LogRawMsgIDIndexMigration)
 	// v160注册
 	mgr.Register(v160.V160LogIDZeroCleanMigration)
 	err := mgr.ApplyAll()

--- a/migrate/v2/v151/v151_log_indexes.go
+++ b/migrate/v2/v151/v151_log_indexes.go
@@ -1,0 +1,57 @@
+package v151
+
+import (
+	"fmt"
+
+	"sealdice-core/model"
+	"sealdice-core/utils/constant"
+	operator "sealdice-core/utils/dboperator/engine"
+	upgrade "sealdice-core/utils/upgrader"
+)
+
+func V151LogRawMsgIDIndexMigrate(dboperator operator.DatabaseOperator, logf func(string)) error {
+	db := dboperator.GetLogDB(constant.WRITE)
+	if !db.Migrator().HasTable(&model.LogOneItem{}) {
+		return nil
+	}
+
+	switch dboperator.Type() {
+	case constant.MYSQL:
+		if !db.Migrator().HasIndex(&model.LogOneItemHookMySQL{}, "idx_log_delete_by_id") {
+			if err := db.Exec("CREATE INDEX idx_log_delete_by_id ON log_items(group_id(20), raw_msg_id(20), id)").Error; err != nil {
+				return err
+			}
+			logf("数据修复 - LogItems表，已为(group_id, raw_msg_id, id)创建复合索引")
+		} else {
+			logf("数据修复 - LogItems表，复合索引已存在，无需处理")
+		}
+	default:
+		if !db.Migrator().HasIndex(&model.LogOneItem{}, "idx_log_delete_by_id") {
+			if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_log_delete_by_id ON log_items(group_id, raw_msg_id, id)").Error; err != nil {
+				return err
+			}
+			logf("数据修复 - LogItems表，已为(group_id, raw_msg_id, id)创建复合索引")
+		} else {
+			logf("数据修复 - LogItems表，复合索引已存在，无需处理")
+		}
+	}
+
+	return nil
+}
+
+var V151LogRawMsgIDIndexMigration = upgrade.Upgrade{
+	ID: "007a_V151LogRawMsgIDIndexMigration",
+	Description: `
+# 升级说明
+为日志消息回查补齐(group_id, raw_msg_id, id)复合索引
+`,
+	Apply: func(logf func(string), operator operator.DatabaseOperator) error {
+		logf(fmt.Sprintf("[INFO] V151日志索引修复开始 type=%s", operator.Type()))
+		err := V151LogRawMsgIDIndexMigrate(operator, logf)
+		if err != nil {
+			return err
+		}
+		logf("[INFO] V151日志索引修复处置完毕")
+		return nil
+	},
+}

--- a/migrate/v2/v160/v160_log_indexes.go
+++ b/migrate/v2/v160/v160_log_indexes.go
@@ -1,4 +1,4 @@
-package v151
+package v160
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	upgrade "sealdice-core/utils/upgrader"
 )
 
-func V151LogRawMsgIDIndexMigrate(dboperator operator.DatabaseOperator, logf func(string)) error {
+func V160LogRawMsgIDIndexMigrate(dboperator operator.DatabaseOperator, logf func(string)) error {
 	db := dboperator.GetLogDB(constant.WRITE)
 	if !db.Migrator().HasTable(&model.LogOneItem{}) {
 		return nil
@@ -39,19 +39,19 @@ func V151LogRawMsgIDIndexMigrate(dboperator operator.DatabaseOperator, logf func
 	return nil
 }
 
-var V151LogRawMsgIDIndexMigration = upgrade.Upgrade{
-	ID: "007a_V151LogRawMsgIDIndexMigration",
+var V160LogRawMsgIDIndexMigration = upgrade.Upgrade{
+	ID: "008a_V160LogRawMsgIDIndexMigration",
 	Description: `
 # 升级说明
 为日志消息回查补齐(group_id, raw_msg_id, id)复合索引
 `,
 	Apply: func(logf func(string), operator operator.DatabaseOperator) error {
-		logf(fmt.Sprintf("[INFO] V151日志索引修复开始 type=%s", operator.Type()))
-		err := V151LogRawMsgIDIndexMigrate(operator, logf)
+		logf(fmt.Sprintf("[INFO] V160日志索引修复开始 type=%s", operator.Type()))
+		err := V160LogRawMsgIDIndexMigrate(operator, logf)
 		if err != nil {
 			return err
 		}
-		logf("[INFO] V151日志索引修复处置完毕")
+		logf("[INFO] V160日志索引修复处置完毕")
 		return nil
 	},
 }

--- a/model/log.go
+++ b/model/log.go
@@ -25,9 +25,9 @@ func (*LogOneItemParquet) TableName() string {
 }
 
 type LogOneItem struct {
-	ID             uint64      `gorm:"primaryKey;autoIncrement;column:id"                                      json:"id"`
+	ID             uint64      `gorm:"primaryKey;autoIncrement;column:id;index:idx_log_delete_by_id,priority:3" json:"id"`
 	LogID          uint64      `gorm:"column:log_id;index:idx_log_items_log_id"                                json:"-"`
-	GroupID        string      `gorm:"index:idx_log_items_group_id;column:group_id;index:idx_log_delete_by_id"`
+	GroupID        string      `gorm:"index:idx_log_items_group_id;column:group_id;index:idx_log_delete_by_id,priority:1"`
 	Nickname       string      `gorm:"column:nickname"                                                         json:"nickname"`
 	IMUserID       string      `gorm:"column:im_userid"                                                        json:"IMUserId"`
 	Time           int64       `gorm:"column:time"                                                             json:"time"`
@@ -38,7 +38,7 @@ type LogOneItem struct {
 	CommandInfoStr string      `gorm:"column:command_info"                                                     json:"-"`
 	// 这里的RawMsgID 真的什么都有可能
 	RawMsgID    interface{} `gorm:"-"                                                                 json:"rawMsgId"  parquet:"-"`
-	RawMsgIDStr string      `gorm:"column:raw_msg_id;index:idx_raw_msg_id;index:idx_log_delete_by_id" json:"-"`
+	RawMsgIDStr string      `gorm:"column:raw_msg_id;index:idx_raw_msg_id;index:idx_log_delete_by_id,priority:2" json:"-"`
 	UniformID   string      `gorm:"column:user_uniform_id"                                            json:"uniformId"`
 	// 数据库里没有的
 	Channel string `gorm:"-" json:"channel"`
@@ -133,9 +133,9 @@ func (*LogInfoHookMySQL) TableName() string {
 }
 
 type LogOneItemHookMySQL struct {
-	ID             uint64      `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
+	ID             uint64      `gorm:"primaryKey;autoIncrement;column:id;index:idx_log_delete_by_id,priority:3" json:"id"`
 	LogID          uint64      `gorm:"column:log_id"                      json:"-"`
-	GroupID        string      `gorm:"column:group_id"`
+	GroupID        string      `gorm:"column:group_id;index:idx_log_delete_by_id,priority:1"`
 	Nickname       string      `gorm:"column:nickname"                    json:"nickname"`
 	IMUserID       string      `gorm:"column:im_userid"                   json:"IMUserId"`
 	Time           int64       `gorm:"column:time"                        json:"time"`
@@ -145,7 +145,7 @@ type LogOneItemHookMySQL struct {
 	CommandInfo    interface{} `gorm:"-"                                  json:"commandInfo"`
 	CommandInfoStr string      `gorm:"column:command_info"                json:"-"`
 	RawMsgID       interface{} `gorm:"-"                                  json:"rawMsgId"`
-	RawMsgIDStr    string      `gorm:"column:raw_msg_id"                  json:"-"`
+	RawMsgIDStr    string      `gorm:"column:raw_msg_id;index:idx_log_delete_by_id,priority:2" json:"-"`
 	UniformID      string      `gorm:"column:user_uniform_id"             json:"uniformId"`
 	Channel        string      `gorm:"-"                                  json:"channel"`
 	Removed        *int        `gorm:"column:removed"                     json:"-"`


### PR DESCRIPTION
注：
1. 日志名称目前已经出现过传递神秘字符等行为，在这种情况下，修改或许是未来有需求的一个行为。

## Summary by Sourcery

改进群组日志的并发安全性，并通过跟踪内部日志 ID 以及在需要时通过原始消息 ID 解析日志，使日志追加/编辑/删除在日志名称变更后仍然健壮可用。

Bug 修复：
- 确保在处理已删除或已编辑消息的日志操作时，即使当前日志名称已更改，也能解析到正确的日志。
- 修复在并发处理程序中访问群组级日志状态和私有命令追踪时出现的竞争条件。

增强功能：
- 引入线程安全的 `GroupLogState`，使用内部日志 ID 驱动所有日志操作，而不是仅依赖可变的日志名称。
- 在日志生命周期事件（create、start、stop、end、halt）周围添加结构化日志，以提升可观测性。

测试：
- 添加单元测试，验证 `LogGetOrCreate` 的 ID 稳定性，以及基于原始消息 ID 的追加/编辑/删除操作能够始终作用于原始日志而不会出现跨日志干扰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve group log concurrency safety and make log append/edit/delete robust to log name changes by tracking an internal log ID and resolving logs by raw message ID where needed.

Bug Fixes:
- Ensure log operations for deleted or edited messages resolve the correct log even if the current log name has changed.
- Fix race conditions when accessing per-group logging state and private command tracking in concurrent handlers.

Enhancements:
- Introduce a thread-safe GroupLogState with an internal log ID to drive all logging operations instead of relying solely on the mutable log name.
- Add structured logging around log lifecycle events (create, start, stop, end, halt) for better observability.

Tests:
- Add unit tests verifying LogGetOrCreate ID stability, and that append/edit/delete-by-raw-message-ID operate on the original log without cross-log interference.

</details>