### PR TITLE
feat: 为 `.log end` 加入可后跟参数进行自定义 log 结束的功能

### DIFF
--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -348,7 +348,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "end") {
 				logName := cmdArgs.GetArgN(2)
-				endCurrentLog := false
+				var endCurrentLog bool
 				if logName != "" {
 					var ok bool
 					logName, ok = resolveLogNameWithReply(group.GroupID, logName)

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -125,7 +125,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 	const helpLog = `.log new [<日志名>] // 新建日志并开始记录，注意new后跟空格！
 .log on [<日志名>]  // 开始记录，不写日志名则开启最近一次日志，注意on后跟空格！
 .log off // 暂停记录
-.log end // 完成记录并发送日志文件
+.log end [<日志名>] // 完成记录并发送日志文件
 .log get [<日志名>] // 重新上传日志，并获取链接
 .log halt // 强行关闭当前log，不上传日志
 .log list // 查看当前群的日志列表
@@ -347,27 +347,60 @@ func RegisterBuiltinExtLog(self *Dice) {
 				getAndUpload(group.GroupID, logName)
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "end") {
-				if group.LogCurName == "" {
+				logName := cmdArgs.GetArgN(2)
+				endCurrentLog := false
+				if logName != "" {
+					var ok bool
+					logName, ok = resolveLogNameWithReply(group.GroupID, logName)
+					if !ok {
+						return CmdExecuteResult{Matched: true, Solved: true}
+					}
+					endCurrentLog = group.LogCurName == logName
+				} else {
+					logName = group.LogCurName
+					if logName == "" {
+						logNames, err := service.LogGetList(ctx.Dice.DBOperator, group.GroupID)
+						if err != nil {
+							ReplyToSender(ctx, msg, "获取记录出错: "+err.Error())
+							return CmdExecuteResult{Matched: true, Solved: true}
+						}
+						if len(logNames) > 0 {
+							logName = logNames[0]
+						}
+					}
+					endCurrentLog = true
+				}
+
+				if logName == "" {
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_关闭_失败"))
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
-				lines, _ := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, group.LogCurName)
+				lines, exists := service.LogLinesCountGet(ctx.Dice.DBOperator, group.GroupID, logName)
+				if !exists {
+					VarSetValueStr(ctx, "$t记录名称", logName)
+					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "日志:记录_开启_失败_无此记录"))
+					return CmdExecuteResult{Matched: true, Solved: true}
+				}
 				VarSetValueInt64(ctx, "$t当前记录条数", lines)
-				VarSetValueStr(ctx, "$t记录名称", group.LogCurName)
+				VarSetValueStr(ctx, "$t记录名称", logName)
 				text := DiceFormatTmpl(ctx, "日志:记录_结束")
 				// Note: 2024-02-28 经过讨论，日志在 off 的情况下 end 属于合理操作，这里不再检查是否开启
 				// if !group.LogOn {
 				//	 text = strings.TrimRightFunc(DiceFormatTmpl(ctx, "日志:记录_关闭_失败"), unicode.IsSpace) + "\n" + text
 				// }
 				ReplyToSender(ctx, msg, text)
-				group.LogOn = false
-				group.MarkDirty(ctx.Dice)
+				if endCurrentLog {
+					group.LogOn = false
+					group.MarkDirty(ctx.Dice)
+				}
 
 				time.Sleep(time.Duration(0.3 * float64(time.Second)))
 				// Note: 2024-10-15 经过简单测试，似乎能缓解#1034的问题，但无法根本解决。
-				go getAndUpload(group.GroupID, group.LogCurName)
-				group.LogCurName = ""
-				group.MarkDirty(ctx.Dice)
+				go getAndUpload(group.GroupID, logName)
+				if endCurrentLog {
+					group.LogCurName = ""
+					group.MarkDirty(ctx.Dice)
+				}
 				return CmdExecuteResult{Matched: true, Solved: true}
 			} else if cmdArgs.IsArgEqual(1, "halt") {
 				if len(group.LogCurName) > 0 {


### PR DESCRIPTION
rt.
如果直接输入 `.log end` ，则关闭最近的、为打开状态的 log 并上传
如果后跟参数，如 `.log end <params>`，则关闭指定的 log 并上传
已自测通过，效果如图

![Image_1782399071233_829.png](https://github.com/user-attachments/assets/c5b250b9-e222-4678-99ea-d6bc6baaebac)





## Summary by Sourcery

扩展 `.log end`，使其可以选择性地针对指定的命名日志，同时在未提供名称时保留当前日志的行为。

新功能：
- 允许使用 `.log end [<日志名>]` 来结束并上传指定的日志，包括非活动日志。

错误修复：
- 在尝试结束不存在的日志时，返回更清晰的失败反馈，并在响应中使用请求的日志名称。
- 在结束其他日志时，避免无意中停止或清除当前日志状态。

文档：
- 更新内联帮助文本，记录 `.log end` 的新可选日志名参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend `.log end` to optionally target a specific named log, while preserving current-log behavior when no name is provided.

New Features:
- Allow `.log end [<日志名>]` to end and upload a specified log, including non-active logs.

Bug Fixes:
- Return clearer failure feedback when attempting to end a non-existent log, using the requested log name in the response.
- Avoid unintentionally stopping or clearing the current log state when ending a different log.

Documentation:
- Update inline help text to document the new optional log name parameter for `.log end`.

</details>

新功能：
- 支持 `.log end [<日志名>]` 来结束并上传指定日志，即使该日志当前并未处于活动状态。

错误修复：
- 在 `.log end` 目标为不存在或未命名的日志时，提供更清晰的失败响应。
- 在结束其他日志时，避免无意中关闭或清除当前日志状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

扩展 `.log end`，使其可以选择性地针对指定的命名日志，同时在未提供名称时保留当前日志的行为。

新功能：
- 允许使用 `.log end [<日志名>]` 来结束并上传指定的日志，包括非活动日志。

错误修复：
- 在尝试结束不存在的日志时，返回更清晰的失败反馈，并在响应中使用请求的日志名称。
- 在结束其他日志时，避免无意中停止或清除当前日志状态。

文档：
- 更新内联帮助文本，记录 `.log end` 的新可选日志名参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend `.log end` to optionally target a specific named log, while preserving current-log behavior when no name is provided.

New Features:
- Allow `.log end [<日志名>]` to end and upload a specified log, including non-active logs.

Bug Fixes:
- Return clearer failure feedback when attempting to end a non-existent log, using the requested log name in the response.
- Avoid unintentionally stopping or clearing the current log state when ending a different log.

Documentation:
- Update inline help text to document the new optional log name parameter for `.log end`.

</details>

</details>