### PR TITLE
fix(backup): 根据使用的数据库类型调整备份方式

### DIFF
--- a/dice/dice_backup.go
+++ b/dice/dice_backup.go
@@ -118,33 +118,44 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 	}(writer)
 
 	fileOK := func(fn string) bool {
-		stat, err := os.Stat(fn)
-		return err == nil && !stat.IsDir()
+		stat, statErr := os.Stat(fn)
+		return statErr == nil && !stat.IsDir()
 	}
 	dirOK := func(fn string) bool {
-		stat, err := os.Stat(fn)
-		return err == nil && stat.IsDir()
+		stat, statErr := os.Stat(fn)
+		return statErr == nil && stat.IsDir()
 	}
 
 	backup := func(d *Dice, fn string) {
-		file, err := os.Open(fn)
-		if err != nil && !strings.Contains(fn, "session.token") {
+		file, openErr := os.Open(fn)
+		if openErr != nil && !strings.Contains(fn, "session.token") {
 			if d != nil {
-				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
+				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, openErr.Error())
 			} else {
-				logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
+				logger.Errorf("备份文件失败: %s, 原因: %s", fn, openErr.Error())
 			}
 			return
 		}
 		defer file.Close()
 
-		h := &zip.FileHeader{Name: fn, Method: zip.Deflate, Flags: 0x800}
-		fileWriter, err := writer.CreateHeader(h)
-		if err != nil {
+		zipName := filepath.ToSlash(fn)
+		if filepath.IsAbs(fn) {
+			if wd, wdErr := os.Getwd(); wdErr == nil {
+				if rel, relErr := filepath.Rel(wd, fn); relErr == nil {
+					zipName = filepath.ToSlash(rel)
+				}
+			} else if rel, relErr := filepath.Rel(".", fn); relErr == nil {
+				zipName = filepath.ToSlash(rel)
+			}
+		}
+
+		h := &zip.FileHeader{Name: zipName, Method: zip.Deflate, Flags: 0x800}
+		fileWriter, createErr := writer.CreateHeader(h)
+		if createErr != nil {
 			if d != nil {
-				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
+				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, createErr.Error())
 			} else {
-				logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
+				logger.Errorf("备份文件失败: %s, 原因: %s", fn, createErr.Error())
 			}
 			return
 		}
@@ -224,6 +235,12 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 
 	withJS := sel&BackupSelectionJS != 0
 	cfgDice.JSScripts = withJS
+	databaseType := ""
+	databaseIncluded := false
+	var databaseFiles map[string]string
+	if dm.Operator != nil {
+		databaseType, databaseFiles = dm.Operator.GetBackupInfo()
+	}
 
 	for _, d := range dm.Dice {
 		cfgGlb.Dices[d.BaseConfig.Name] = &cfgDice
@@ -235,27 +252,6 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 		}
 		if fn := filepath.Join(dataDir, "configs", "plugin-configs.json"); fileOK(fn) {
 			backup(d, fn)
-		}
-
-		err := service.FlushWAL(d.DBOperator.GetDataDB(constant.WRITE))
-		if err != nil {
-			d.Logger.Errorf("备份时data数据库flush出错 错误为:%v", err.Error())
-		} else {
-			backup(d, filepath.Join(dataDir, "data.db"))
-		}
-		err = service.FlushWAL(d.DBOperator.GetLogDB(constant.WRITE))
-		if err != nil {
-			d.Logger.Errorf("备份时logs数据库flush出错 错误为:%v", err.Error())
-		} else {
-			backup(d, filepath.Join(dataDir, "data-logs.db"))
-		}
-		if d.CensorManager != nil && d.CensorManager.DB != nil {
-			err = service.FlushWAL(d.DBOperator.GetCensorDB(constant.WRITE))
-			if err != nil {
-				d.Logger.Errorf("备份时censor数据库flush出错 %v", err.Error())
-			} else {
-				backup(d, filepath.Join(dataDir, "data-censor.db"))
-			}
 		}
 
 		backup(d, filepath.Join(dataDir, "configs/text-template.yaml"))
@@ -325,11 +321,42 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 		}
 	}
 
+	if databaseType == constant.SQLITE && dm.Operator != nil {
+		databaseIncluded = true
+		if err = service.FlushWAL(dm.Operator.GetDataDB(constant.WRITE)); err != nil {
+			logger.Errorf("备份时data数据库flush出错 错误为:%v", err.Error())
+		} else if fn := databaseFiles["data"]; fn != "" {
+			backup(nil, fn)
+		}
+		if err = service.FlushWAL(dm.Operator.GetLogDB(constant.WRITE)); err != nil {
+			logger.Errorf("备份时logs数据库flush出错 错误为:%v", err.Error())
+		} else if fn := databaseFiles["logs"]; fn != "" {
+			backup(nil, fn)
+		}
+
+		needCensorBackup := false
+		for _, d := range dm.Dice {
+			if d.CensorManager != nil && d.CensorManager.DB != nil {
+				needCensorBackup = true
+				break
+			}
+		}
+		if needCensorBackup {
+			if err = service.FlushWAL(dm.Operator.GetCensorDB(constant.WRITE)); err != nil {
+				logger.Errorf("备份时censor数据库flush出错 %v", err.Error())
+			} else if fn := databaseFiles["censor"]; fn != "" {
+				backup(nil, fn)
+			}
+		}
+	}
+
 	// 写入文件信息
 	data, _ := json.Marshal(map[string]interface{}{
-		"config":      cfgGlb,
-		"version":     VERSION.String(),
-		"versionCode": VERSION_CODE,
+		"config":           cfgGlb,
+		"version":          VERSION.String(),
+		"versionCode":      VERSION_CODE,
+		"databaseType":     databaseType,
+		"databaseIncluded": databaseIncluded,
 	})
 
 	h := &zip.FileHeader{Name: "backup_info.json", Method: zip.Deflate, Flags: 0x800}

--- a/dice/dice_backup_test.go
+++ b/dice/dice_backup_test.go
@@ -1,0 +1,236 @@
+//nolint:testpackage
+package dice
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	sealdiceLogger "sealdice-core/logger"
+	"sealdice-core/utils/constant"
+	"sealdice-core/utils/dboperator/engine"
+)
+
+type backupTestOperator struct {
+	dbType       string
+	databaseFile map[string]string
+}
+
+func (o *backupTestOperator) Init(_ context.Context) error { return nil }
+
+func (o *backupTestOperator) Type() string { return o.dbType }
+
+func (o *backupTestOperator) DBCheck() {}
+
+func (o *backupTestOperator) GetDataDB(_ constant.DBMode) *gorm.DB { return nil }
+
+func (o *backupTestOperator) GetLogDB(_ constant.DBMode) *gorm.DB { return nil }
+
+func (o *backupTestOperator) GetCensorDB(_ constant.DBMode) *gorm.DB { return nil }
+
+func (o *backupTestOperator) GetBackupInfo() (string, map[string]string) {
+	return o.dbType, maps.Clone(o.databaseFile)
+}
+
+func (o *backupTestOperator) Close() {}
+
+func TestBackupSkipsDatabaseFilesForNonSQLite(t *testing.T) {
+	t.Setenv("DATADIR", "")
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	var err error
+
+	for _, dir := range []string{
+		"data/default/configs",
+		"data/default/extensions/reply",
+		"data/default/scripts",
+		"data/decks",
+		"data/helpdoc",
+		"data/censor",
+		"data/names",
+		"data/images",
+	} {
+		if err = os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err = os.WriteFile("data/dice.yaml", []byte("serveAddress: 0.0.0.0:3211\n"), 0o644); err != nil {
+		t.Fatalf("write dice.yaml: %v", err)
+	}
+	if err = os.WriteFile("data/default/serve.yaml", []byte("name: default\n"), 0o644); err != nil {
+		t.Fatalf("write serve.yaml: %v", err)
+	}
+	if err = os.WriteFile("data/default/configs/text-template.yaml", []byte(""), 0o644); err != nil {
+		t.Fatalf("write text-template.yaml: %v", err)
+	}
+	for _, name := range []string{"data.db", "data-logs.db", "data-censor.db"} {
+		if err = os.WriteFile(filepath.Join("data/default", name), []byte("stale sqlite"), 0o644); err != nil {
+			t.Fatalf("write stale db %s: %v", name, err)
+		}
+	}
+
+	dm := newBackupTestDiceManager(&backupTestOperator{
+		dbType:       constant.MYSQL,
+		databaseFile: nil,
+	})
+
+	backupPath, err := dm.Backup(BackupSelectionBasic, false)
+	if err != nil {
+		t.Fatalf("Backup() error = %v", err)
+	}
+
+	entries, info := readBackupArchive(t, backupPath)
+	for _, name := range []string{"data/default/data.db", "data/default/data-logs.db", "data/default/data-censor.db"} {
+		if slices.Contains(entries, name) {
+			t.Fatalf("backup unexpectedly contains %s", name)
+		}
+	}
+	if info.DatabaseIncluded {
+		t.Fatalf("backup_info.json databaseIncluded = true, want false")
+	}
+	if info.DatabaseType != constant.MYSQL {
+		t.Fatalf("backup_info.json databaseType = %q, want %q", info.DatabaseType, constant.MYSQL)
+	}
+}
+
+func TestBackupIncludesSQLiteFilesFromOperatorDataDir(t *testing.T) {
+	t.Setenv("DATADIR", "")
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	var err error
+
+	for _, dir := range []string{
+		"data/default/configs",
+		"data/default/extensions/reply",
+		"data/default/scripts",
+		"data/decks",
+		"data/helpdoc",
+		"data/censor",
+		"data/names",
+		"data/images",
+	} {
+		if err = os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err = os.WriteFile("data/dice.yaml", []byte("serveAddress: 0.0.0.0:3211\n"), 0o644); err != nil {
+		t.Fatalf("write dice.yaml: %v", err)
+	}
+	if err = os.WriteFile("data/default/serve.yaml", []byte("name: default\n"), 0o644); err != nil {
+		t.Fatalf("write serve.yaml: %v", err)
+	}
+	if err = os.WriteFile("data/default/configs/text-template.yaml", []byte(""), 0o644); err != nil {
+		t.Fatalf("write text-template.yaml: %v", err)
+	}
+
+	dbDir := filepath.Join(tmpDir, "external-sqlite")
+	if err = os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir dbDir: %v", err)
+	}
+	dbFiles := map[string]string{
+		"data":   filepath.Join(dbDir, "data.db"),
+		"logs":   filepath.Join(dbDir, "data-logs.db"),
+		"censor": filepath.Join(dbDir, "data-censor.db"),
+	}
+	for key, path := range dbFiles {
+		if err = os.WriteFile(path, []byte(key+"-content"), 0o644); err != nil {
+			t.Fatalf("write sqlite file %s: %v", key, err)
+		}
+	}
+
+	dm := newBackupTestDiceManager(&backupTestOperator{
+		dbType:       constant.SQLITE,
+		databaseFile: dbFiles,
+	})
+	dm.Dice[0].CensorManager = &CensorManager{DB: dm.Operator}
+
+	backupPath, err := dm.Backup(BackupSelectionBasic, false)
+	if err != nil {
+		t.Fatalf("Backup() error = %v", err)
+	}
+
+	entries, info := readBackupArchive(t, backupPath)
+	for _, name := range []string{"external-sqlite/data.db", "external-sqlite/data-logs.db", "external-sqlite/data-censor.db"} {
+		if !slices.Contains(entries, name) {
+			t.Fatalf("backup missing %s; entries=%v", name, entries)
+		}
+	}
+	if info.DatabaseIncluded != true {
+		t.Fatalf("backup_info.json databaseIncluded = false, want true")
+	}
+	if info.DatabaseType != constant.SQLITE {
+		t.Fatalf("backup_info.json databaseType = %q, want %q", info.DatabaseType, constant.SQLITE)
+	}
+}
+
+type backupInfoMetadata struct {
+	Config           json.RawMessage `json:"config"`
+	Version          string          `json:"version"`
+	VersionCode      int64           `json:"versionCode"`
+	DatabaseType     string          `json:"databaseType"`
+	DatabaseIncluded bool            `json:"databaseIncluded"`
+}
+
+func newBackupTestDiceManager(operator engine.DatabaseOperator) *DiceManager {
+	d := &Dice{
+		BaseConfig: BaseConfig{
+			Name:    "default",
+			DataDir: filepath.Join("data", "default"),
+		},
+		Logger:     zap.NewNop().Sugar(),
+		LogWriter:  sealdiceLogger.NewUIWriter(),
+		DBOperator: operator,
+		ImSession: &IMSession{
+			EndPoints: []*EndPointInfo{},
+		},
+	}
+	dm := &DiceManager{
+		Dice:     []*Dice{d},
+		Operator: operator,
+	}
+	d.Parent = dm
+	return dm
+}
+
+func readBackupArchive(t *testing.T, backupPath string) ([]string, backupInfoMetadata) {
+	t.Helper()
+
+	reader, err := zip.OpenReader(backupPath)
+	if err != nil {
+		t.Fatalf("open backup zip: %v", err)
+	}
+	defer reader.Close()
+
+	entries := make([]string, 0, len(reader.File))
+	var info backupInfoMetadata
+	for _, file := range reader.File {
+		entries = append(entries, file.Name)
+		if file.Name != "backup_info.json" {
+			continue
+		}
+		rc, openErr := file.Open()
+		if openErr != nil {
+			t.Fatalf("open backup_info.json: %v", openErr)
+		}
+		data, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			t.Fatalf("read backup_info.json: %v", readErr)
+		}
+		if err = json.Unmarshal(data, &info); err != nil {
+			t.Fatalf("unmarshal backup_info.json: %v", err)
+		}
+	}
+	return entries, info
+}

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -135,6 +135,9 @@ func (m *mockDatabaseOperator) DBCheck()                               {}
 func (m *mockDatabaseOperator) GetDataDB(_ constant.DBMode) *gorm.DB   { return m.db }
 func (m *mockDatabaseOperator) GetLogDB(_ constant.DBMode) *gorm.DB    { return m.db }
 func (m *mockDatabaseOperator) GetCensorDB(_ constant.DBMode) *gorm.DB { return m.db }
+func (m *mockDatabaseOperator) GetBackupInfo() (string, map[string]string) {
+	return constant.SQLITE, nil
+}
 func (m *mockDatabaseOperator) Close() {
 	if sqlDB, err := m.db.DB(); err == nil {
 		_ = sqlDB.Close()

--- a/dice/service/backup.go
+++ b/dice/service/backup.go
@@ -8,6 +8,9 @@ import (
 
 // Vacuum 执行数据库的 vacuum 操作
 func Vacuum(db *gorm.DB, path string) error {
+	if db == nil {
+		return nil
+	}
 	// 检查数据库驱动是否为 SQLite
 	if !strings.Contains(db.Name(), "sqlite") {
 		return nil
@@ -21,6 +24,9 @@ func Vacuum(db *gorm.DB, path string) error {
 // FlushWAL 执行 WAL 日志的检查点和内存收缩
 // TODO: 在确认备份逻辑后删除该函数并收归到engine内，由engine统一做备份
 func FlushWAL(db *gorm.DB) error {
+	if db == nil {
+		return nil
+	}
 	// 检查数据库驱动是否为 SQLite
 	if !strings.Contains(db.Name(), "sqlite") {
 		return nil

--- a/dice/service/log_test.go
+++ b/dice/service/log_test.go
@@ -30,7 +30,10 @@ func (o *logInfoTestOperator) DBCheck()                               {}
 func (o *logInfoTestOperator) GetDataDB(_ constant.DBMode) *gorm.DB   { return o.db }
 func (o *logInfoTestOperator) GetLogDB(_ constant.DBMode) *gorm.DB    { return o.db }
 func (o *logInfoTestOperator) GetCensorDB(_ constant.DBMode) *gorm.DB { return o.db }
-func (o *logInfoTestOperator) Close()                                 {}
+func (o *logInfoTestOperator) GetBackupInfo() (string, map[string]string) {
+	return o.dbType, nil
+}
+func (o *logInfoTestOperator) Close() {}
 
 func TestLogGetInfoUsesSQLiteSequenceForRows(t *testing.T) {
 	db := newLogInfoTestDB(t)

--- a/utils/dboperator/engine/engine_interface.go
+++ b/utils/dboperator/engine/engine_interface.go
@@ -20,6 +20,7 @@ type DatabaseOperator interface {
 	GetDataDB(mode constant.DBMode) *gorm.DB
 	GetLogDB(mode constant.DBMode) *gorm.DB
 	GetCensorDB(mode constant.DBMode) *gorm.DB
+	GetBackupInfo() (string, map[string]string)
 	Close()
 }
 

--- a/utils/dboperator/engine/mysql/engine_mysql.go
+++ b/utils/dboperator/engine/mysql/engine_mysql.go
@@ -51,6 +51,10 @@ func (s *MYSQLEngine) GetCensorDB(_ constant.DBMode) *gorm.DB {
 	return s.censorDB
 }
 
+func (s *MYSQLEngine) GetBackupInfo() (string, map[string]string) {
+	return constant.MYSQL, nil
+}
+
 func (s *MYSQLEngine) Init(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("ctx is missing")
@@ -109,5 +113,5 @@ func (s *MYSQLEngine) censorDBInit() (*gorm.DB, error) {
 }
 
 func (s *MYSQLEngine) Type() string {
-	return "mysql"
+	return constant.MYSQL
 }

--- a/utils/dboperator/engine/pgsql/engine_pgsql.go
+++ b/utils/dboperator/engine/pgsql/engine_pgsql.go
@@ -49,6 +49,10 @@ func (s *PGSQLEngine) GetCensorDB(_ constant.DBMode) *gorm.DB {
 	return s.censorDB
 }
 
+func (s *PGSQLEngine) GetBackupInfo() (string, map[string]string) {
+	return constant.POSTGRESQL, nil
+}
+
 func (s *PGSQLEngine) Init(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("ctx is missing")

--- a/utils/dboperator/engine/sqlite/engine_sqlite.go
+++ b/utils/dboperator/engine/sqlite/engine_sqlite.go
@@ -96,6 +96,14 @@ func (s *SQLiteEngine) GetCensorDB(mode constant.DBMode) *gorm.DB {
 	return s.getDBByModeAndKey(mode, CensorsDBKey)
 }
 
+func (s *SQLiteEngine) GetBackupInfo() (string, map[string]string) {
+	return constant.SQLITE, map[string]string{
+		"data":   filepath.Join(s.DataDir, "data.db"),
+		"logs":   filepath.Join(s.DataDir, "data-logs.db"),
+		"censor": filepath.Join(s.DataDir, "data-censor.db"),
+	}
+}
+
 const defaultDataDir = "./data/default"
 
 func (s *SQLiteEngine) Init(ctx context.Context) error {


### PR DESCRIPTION
终于，不会让所有的备份都找那个DB了。

## Summary by Sourcery

调整备份行为以尊重已配置的数据库引擎，并通过 operator 集中管理数据库文件的选择，同时改进备份元数据和健壮性。

New Features:
- 在 `backup_info.json` 元数据中包含数据库类型以及是否存在数据库文件的信息。
- 通过在数据库 operator 接口上新增 `GetBackupInfo` 方法，支持由引擎提供的备份信息。

Bug Fixes:
- 在使用非 SQLite 引擎时，阻止运行仅适用于 SQLite 的备份逻辑，避免产生错误或过期的数据库备份。

Enhancements:
- 规范备份压缩包中存储的文件路径，使其为相对路径并统一使用斜杠分隔。
- 为数据库维护工具 `Vacuum` 和 `FlushWAL` 增加防御性的 `nil` 检查，以在数据库不存在时避免触发 panic。

Tests:
- 添加备份测试，覆盖 SQLite 与非 SQLite 的数据库配置，并确保在备份中正确包含或排除数据库文件。
- 扩展现有测试用数据库 operator，使其实现备份逻辑所需的新 `GetBackupInfo` 接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust backup behavior to respect the configured database engine and centralize database file selection via the operator, while improving backup metadata and robustness.

New Features:
- Include database type and whether database files are present in backup_info.json metadata.
- Support engine-provided backup information through a new GetBackupInfo method on the database operator interface.

Bug Fixes:
- Prevent SQLite-specific backup logic from running when using non-SQLite engines, avoiding incorrect or stale database backups.

Enhancements:
- Normalize file paths stored in the backup zip to be relative and slash-separated.
- Add defensive nil checks to database maintenance utilities Vacuum and FlushWAL to avoid panics when databases are absent.

Tests:
- Add backup tests covering SQLite and non-SQLite database configurations and ensuring correct inclusion or exclusion of database files in backups.
- Extend existing test database operators to implement the new GetBackupInfo interface required by backup logic.

</details>