### PR TITLE
fix(endpoint): 调整Session初始化逻辑及插件获取的Endpoint数据

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -475,9 +475,7 @@ func ImConnectionsAddDiscord(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewDiscordConnItem(dice.AddDiscordEcho(*v))
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterDiscord)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -503,9 +501,7 @@ func ImConnectionsAddKook(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewKookConnItem(v.Token)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterKook)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -532,11 +528,9 @@ func ImConnectionsAddTelegram(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewTelegramConnItem(v.Token, v.ProxyURL)
-		conn.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 
 		// myDice.Logger.Infof("成功创建endpoint")
-		pa := conn.Adapter.(*dice.PlatformAdapterTelegram)
-		pa.Session = myDice.ImSession
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -562,9 +556,7 @@ func ImConnectionsAddMinecraft(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewMinecraftConnItem(v.URL)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterMinecraft)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -591,9 +583,7 @@ func ImConnectionsAddSealChat(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewSealChatConnItem(v.URL, v.Token)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterSealChat)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -620,9 +610,7 @@ func ImConnectionsAddDodo(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewDodoConnItem(v.ClientID, v.Token)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterDodo)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -646,9 +634,7 @@ func ImConnectionsAddDingTalk(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewDingTalkConnItem(v.ClientID, v.Token, v.Nickname, v.RobotCode)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterDingTalk)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -675,8 +661,7 @@ func ImConnectionsAddSlack(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewSlackConnItem(v.AppToken, v.BotToken)
-		pa := conn.Adapter.(*dice.PlatformAdapterSlack)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -709,8 +694,7 @@ func ImConnectionsAddMilky(c echo.Context) error {
 			RestGateway: v.RestGateway,
 			BuiltInMode: "",
 		})
-		pa := conn.Adapter.(*dice.PlatformAdapterMilky)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -755,8 +739,7 @@ func ImConnectionsAddMilkyInternal(c echo.Context) error {
 			BuiltInMode: v.ClientMode,
 		})
 		conn.UserID = dice.FormatDiceIDQQ(strconv.FormatUint(v.Uin, 10))
-		pa := conn.Adapter.(*dice.PlatformAdapterMilky)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -800,12 +783,11 @@ func ImConnectionsAddBuiltinGocq(c echo.Context) error {
 
 		conn := dice.NewGoCqhttpConnectInfoItem(v.Account)
 		conn.UserID = dice.FormatDiceIDQQ(uid)
-		conn.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		pa := conn.Adapter.(*dice.PlatformAdapterGocq)
 		pa.InPackGoCqhttpProtocol = v.Protocol
 		pa.InPackGoCqhttpPassword = v.Password
 		pa.InPackGoCqhttpAppVersion = v.AppVersion
-		pa.Session = myDice.ImSession
 		pa.UseSignServer = v.UseSignServer
 		pa.SignServerConfig = v.SignServerConfig
 
@@ -858,8 +840,7 @@ func ImConnectionsAddGocqSeparate(c echo.Context) error {
 			Mode:          "client",
 		})
 		conn.UserID = dice.FormatDiceIDQQ(uid)
-		pa := conn.Adapter.(*dice.PlatformAdapterOnebot)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		// 设置正在使用中 千万不要设置这个
 		// conn.SetEnable(myDice, true)
@@ -902,8 +883,7 @@ func ImConnectionsAddReverseWs(c echo.Context) error {
 			Mode:          "server",
 		})
 		conn.UserID = dice.FormatDiceIDQQ(uid)
-		pa := conn.Adapter.(*dice.PlatformAdapterOnebot)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		// 设置正在使用中 千万不要设置这个
 		// conn.SetEnable(myDice, true)
@@ -933,9 +913,7 @@ func ImConnectionsAddRed(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewRedConnItem(v.Host, v.Port, v.Token)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterRed)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -962,9 +940,7 @@ func ImConnectionsAddOfficialQQ(c echo.Context) error {
 	err := c.Bind(&v)
 	if err == nil {
 		conn := dice.NewOfficialQQConnItem(v.AppID, v.Token, v.AppSecret, v.OnlyQQGuild)
-		conn.Session = myDice.ImSession
-		pa := conn.Adapter.(*dice.PlatformAdapterOfficialQQ)
-		pa.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()
 		myDice.Save(false)
@@ -994,9 +970,7 @@ func ImConnectionsAddSatori(c echo.Context) error {
 	}
 
 	conn := dice.NewSatoriConnItem(v.Platform, v.Host, v.Port, v.Token)
-	conn.Session = myDice.ImSession
-	pa := conn.Adapter.(*dice.PlatformAdapterSatori)
-	pa.Session = myDice.ImSession
+	conn.BindRuntime(myDice.ImSession)
 	myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 	myDice.LastUpdatedTime = time.Now().Unix()
 	myDice.Save(false)
@@ -1026,10 +1000,9 @@ func ImConnectionsAddBuiltinLagrange(c echo.Context) error {
 
 		conn := dice.NewLagrangeConnectInfoItem(v.Account)
 		conn.UserID = dice.FormatDiceIDQQ(uid)
-		conn.Session = myDice.ImSession
+		conn.BindRuntime(myDice.ImSession)
 		pa := conn.Adapter.(*dice.PlatformAdapterGocq)
 		// pa.InPackGoCqhttpProtocol = v.Protocol
-		pa.Session = myDice.ImSession
 
 		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
 		myDice.LastUpdatedTime = time.Now().Unix()

--- a/dice/builtin_commands_test.go
+++ b/dice/builtin_commands_test.go
@@ -375,9 +375,9 @@ func newMilkyQuitCommandTestContext(t *testing.T, d *Dice, senderID, groupID, gr
 		},
 	}
 	pa.EndPoint = ep
-	pa.Session = d.ImSession
 	pa.IntentSession = session
 	ep.Adapter = pa
+	ep.BindRuntime(d.ImSession)
 
 	d.Config.BotExitWithoutAt = true
 	ctx, msg := newQuitCommandTestContext(t, d, ep, senderID, groupID, groupName)
@@ -432,9 +432,9 @@ func TestDismissMilkyLookupErrorFallsBackToSafetyConfirmation(t *testing.T) {
 		},
 	}
 	pa.EndPoint = ep
-	pa.Session = d.ImSession
 	pa.IntentSession = session
 	ep.Adapter = pa
+	ep.BindRuntime(d.ImSession)
 
 	d.Config.BotExitWithoutAt = true
 	ctx, msg := newQuitCommandTestContext(t, d, ep, "QQ:9020", testMilkyFallbackGroupID, "MilkyFallbackGroup")

--- a/dice/config.go
+++ b/dice/config.go
@@ -2354,8 +2354,7 @@ func (d *Dice) loads() {
 	})
 
 	for _, i := range d.ImSession.EndPoints {
-		i.Session = d.ImSession
-		i.AdapterSetup()
+		i.BindRuntime(d.ImSession)
 	}
 	d.warnIfNoPlatformEndpoint(missingPlatformConfigInServe)
 

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -604,7 +604,10 @@ func (d *Dice) JsInit() {
 			}
 		})
 		_ = seal.Set("getEndPoints", func() []*EndPointInfo {
-			return d.ImSession.EndPoints
+			src := d.ImSession.EndPoints
+			dst := make([]*EndPointInfo, len(src))
+			copy(dst, src)
+			return dst
 		})
 
 		_ = vm.Set("atob", func(s string) (string, error) {

--- a/dice/endpoint_runtime_test.go
+++ b/dice/endpoint_runtime_test.go
@@ -110,3 +110,31 @@ func TestBindRuntimeSetsSessionOnPureOnebotEndpoint(t *testing.T) {
 		t.Fatalf("expected adapter endpoint back-reference to be rebound")
 	}
 }
+
+func TestCreateTempCtxAllowsBoundInternalUIEndpoint(t *testing.T) {
+	d, _, _, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	uiEp := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			ID:       "1",
+			UserID:   "UI:1000",
+			Nickname: "UI",
+			Platform: "UI",
+			Enable:   true,
+			State:    StateConnected,
+		},
+		Adapter: &PlatformAdapterHTTP{},
+	}
+	uiEp.BindRuntime(d.ImSession)
+
+	msg := newGroupMsg("UI-Group:2101", "UI:1101", ".r 1")
+	ctx := CreateTempCtx(uiEp, msg)
+
+	if ctx.EndPoint != uiEp {
+		t.Fatalf("expected internal UI endpoint to be used directly")
+	}
+	if ctx.Session != d.ImSession {
+		t.Fatalf("expected ctx session to be current imSession, got %#v", ctx.Session)
+	}
+}

--- a/dice/endpoint_runtime_test.go
+++ b/dice/endpoint_runtime_test.go
@@ -1,0 +1,112 @@
+//nolint:testpackage
+package dice
+
+import (
+	"testing"
+)
+
+func TestCreateTempCtxResolvesLiveEndpointByID(t *testing.T) {
+	d, oldEp, _, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	oldEp.ProtocolType = "pureonebot"
+	oldEp.State = StateDisconnected
+	oldEp.Enable = false
+
+	newEp := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			ID:           oldEp.ID,
+			UserID:       oldEp.UserID,
+			Nickname:     "NewBot",
+			Platform:     oldEp.Platform,
+			ProtocolType: oldEp.ProtocolType,
+			Enable:       true,
+			State:        StateConnected,
+		},
+		Adapter: NewOnebotConnItem(AddOnebotEcho{
+			Token:      "test-token",
+			ConnectURL: "ws://127.0.0.1:8080",
+			Mode:       "client",
+		}).Adapter,
+	}
+	newEp.BindRuntime(d.ImSession)
+	d.ImSession.EndPoints = []*EndPointInfo{newEp}
+
+	msg := newGroupMsg("QQ-Group:2233", "QQ:4455", ".r 1")
+	ctx := CreateTempCtx(oldEp, msg)
+
+	if ctx.EndPoint != newEp {
+		t.Fatalf("expected CreateTempCtx to resolve live endpoint %p, got %p", newEp, ctx.EndPoint)
+	}
+	if ctx.Session != d.ImSession {
+		t.Fatalf("expected ctx session to be current imSession, got %#v", ctx.Session)
+	}
+	if ctx.Dice != d {
+		t.Fatalf("expected ctx dice to be current dice, got %#v", ctx.Dice)
+	}
+}
+
+func TestCreateTempCtxResolvesLiveEndpointByUserIDFallback(t *testing.T) {
+	d, oldEp, _, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	oldEp.ID = "old-id"
+	oldEp.ProtocolType = "pureonebot"
+	oldEp.State = StateDisconnected
+	oldEp.Enable = false
+
+	newEp := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			ID:           "new-id",
+			UserID:       oldEp.UserID,
+			Nickname:     "NewBot",
+			Platform:     oldEp.Platform,
+			ProtocolType: oldEp.ProtocolType,
+			Enable:       true,
+			State:        StateConnected,
+		},
+		Adapter: NewOnebotConnItem(AddOnebotEcho{
+			Token:      "test-token",
+			ConnectURL: "ws://127.0.0.1:8080",
+			Mode:       "client",
+		}).Adapter,
+	}
+	newEp.BindRuntime(d.ImSession)
+	d.ImSession.EndPoints = []*EndPointInfo{newEp}
+
+	msg := newGroupMsg("QQ-Group:2233", "QQ:4455", ".r 1")
+	ctx := CreateTempCtx(oldEp, msg)
+
+	if ctx.EndPoint != newEp {
+		t.Fatalf("expected CreateTempCtx fallback to resolve live endpoint %p, got %p", newEp, ctx.EndPoint)
+	}
+}
+
+func TestBindRuntimeSetsSessionOnPureOnebotEndpoint(t *testing.T) {
+	d, _, _, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	ep := NewOnebotConnItem(AddOnebotEcho{
+		Token:      "test-token",
+		ConnectURL: "ws://127.0.0.1:8080",
+		Mode:       "client",
+	})
+
+	if ep.Session != nil {
+		t.Fatalf("expected new endpoint session to be nil before binding, got %#v", ep.Session)
+	}
+
+	ep.BindRuntime(d.ImSession)
+
+	if ep.Session != d.ImSession {
+		t.Fatalf("expected endpoint session to be bound to imSession, got %#v", ep.Session)
+	}
+
+	pa, ok := ep.Adapter.(*PlatformAdapterOnebot)
+	if !ok {
+		t.Fatalf("expected pureonebot adapter, got %T", ep.Adapter)
+	}
+	if pa.EndPoint != ep {
+		t.Fatalf("expected adapter endpoint back-reference to be rebound")
+	}
+}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -704,6 +704,10 @@ func (s *IMSession) ResolveLiveEndpoint(ep *EndPointInfo) (*EndPointInfo, error)
 		return matched, nil
 	}
 
+	if ep.Platform == "UI" && ep.Session == s {
+		return ep, nil
+	}
+
 	return nil, fmt.Errorf("endpoint not found: id=%s userId=%s platform=%s protocolType=%s", ep.ID, ep.UserID, ep.Platform, ep.ProtocolType)
 }
 

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"regexp"
@@ -653,6 +654,57 @@ type IMSession struct {
 	EndPoints    []*EndPointInfo                    `yaml:"endPoints"`
 	ServiceAtNew *SyncMap[string, *GroupInfo]       `json:"servicesAt" yaml:"-"`
 	PendingQuits *SyncMap[string, *PendingQuitInfo] `json:"-" yaml:"-"`
+}
+
+func (s *IMSession) ResolveLiveEndpoint(ep *EndPointInfo) (*EndPointInfo, error) {
+	if ep == nil {
+		return nil, errors.New("endpoint is nil")
+	}
+	if s == nil {
+		return nil, errors.New("session is nil")
+	}
+
+	for _, cur := range s.EndPoints {
+		if cur == ep {
+			if cur.Session == nil {
+				cur.BindRuntime(s)
+			}
+			return cur, nil
+		}
+	}
+
+	if ep.ID != "" {
+		for _, cur := range s.EndPoints {
+			if cur != nil && cur.ID == ep.ID {
+				if cur.Session == nil {
+					cur.BindRuntime(s)
+				}
+				return cur, nil
+			}
+		}
+	}
+
+	var matched *EndPointInfo
+	for _, cur := range s.EndPoints {
+		if cur == nil {
+			continue
+		}
+		if cur.UserID != ep.UserID || cur.Platform != ep.Platform || cur.ProtocolType != ep.ProtocolType {
+			continue
+		}
+		if matched != nil && matched != cur {
+			return nil, fmt.Errorf("endpoint resolution ambiguous for userId=%s platform=%s protocolType=%s", ep.UserID, ep.Platform, ep.ProtocolType)
+		}
+		matched = cur
+	}
+	if matched != nil {
+		if matched.Session == nil {
+			matched.BindRuntime(s)
+		}
+		return matched, nil
+	}
+
+	return nil, fmt.Errorf("endpoint not found: id=%s userId=%s platform=%s protocolType=%s", ep.ID, ep.UserID, ep.Platform, ep.ProtocolType)
 }
 
 type PendingQuitInfo struct {
@@ -2324,79 +2376,76 @@ func (ep *EndPointInfo) SetEnable(_ *Dice, enable bool) {
 	}
 }
 
-func (ep *EndPointInfo) AdapterSetup() {
+func (ep *EndPointInfo) BindRuntime(session *IMSession) {
+	if ep == nil {
+		return
+	}
+	ep.Session = session
+
+	if ep.Adapter == nil {
+		return
+	}
+
 	switch ep.Platform {
 	case "QQ":
 		switch ep.ProtocolType {
 		case "onebot":
 			pa := ep.Adapter.(*PlatformAdapterGocq)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 		case "walle-q":
 			pa := ep.Adapter.(*PlatformAdapterWalleQ)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 		case "red":
 			pa := ep.Adapter.(*PlatformAdapterRed)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 		case "official":
 			pa := ep.Adapter.(*PlatformAdapterOfficialQQ)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 		case "satori":
 			pa := ep.Adapter.(*PlatformAdapterSatori)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 		case "milky":
 			pa := ep.Adapter.(*PlatformAdapterMilky)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 		case "pureonebot":
 			pa := ep.Adapter.(*PlatformAdapterOnebot)
 			log := zap.S().Named(logger.LogKeyAdapter)
-			pa.Session = ep.Session
 			pa.EndPoint = ep
 			pa.logger = log
 			pa.desiredEnabled = ep.Enable
 			// case "LagrangeGo":
 			//	pa := ep.Adapter.(*PlatformAdapterLagrangeGo)
-			//	pa.Session = ep.Session
 			//	pa.EndPoint = ep
 		}
 	case "DISCORD":
 		pa := ep.Adapter.(*PlatformAdapterDiscord)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "KOOK":
 		pa := ep.Adapter.(*PlatformAdapterKook)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "TG":
 		pa := ep.Adapter.(*PlatformAdapterTelegram)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "MC":
 		pa := ep.Adapter.(*PlatformAdapterMinecraft)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "DODO":
 		pa := ep.Adapter.(*PlatformAdapterDodo)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "DINGTALK":
 		pa := ep.Adapter.(*PlatformAdapterDingTalk)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "SLACK":
 		pa := ep.Adapter.(*PlatformAdapterSlack)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	case "SEALCHAT":
 		pa := ep.Adapter.(*PlatformAdapterSealChat)
-		pa.Session = ep.Session
 		pa.EndPoint = ep
 	}
+}
+
+func (ep *EndPointInfo) AdapterSetup() {
+	ep.BindRuntime(ep.Session)
 }
 
 func (ep *EndPointInfo) RefreshGroupNum() {

--- a/dice/platform_adapter_dingtalk.go
+++ b/dice/platform_adapter_dingtalk.go
@@ -13,7 +13,6 @@ import (
 )
 
 type PlatformAdapterDingTalk struct {
-	Session       *IMSession        `json:"-"           yaml:"-"`
 	ClientID      string            `json:"-"    yaml:"clientID"`
 	Token         string            `json:"-"       yaml:"token"`
 	RobotCode     string            `json:"-"   yaml:"robotCode"`
@@ -26,12 +25,12 @@ type PlatformAdapterDingTalk struct {
 
 func (pa *PlatformAdapterDingTalk) DoRelogin() bool {
 	if err := pa.closeSessionLocked(); err != nil {
-		pa.Session.Parent.Logger.Error("Dingtalk 断开连接失败: ", err)
+		pa.EndPoint.Session.Parent.Logger.Error("Dingtalk 断开连接失败: ", err)
 		return false
 	}
-	pa.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
 	if err := pa.openSessionLocked(); err != nil {
-		pa.Session.Parent.Logger.Errorf("与DingTalk服务进行连接时出错:%s", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("与DingTalk服务进行连接时出错:%s", err.Error())
 		pa.EndPoint.State = 3
 		pa.EndPoint.Enable = false
 		return false
@@ -43,9 +42,9 @@ func (pa *PlatformAdapterDingTalk) DoRelogin() bool {
 
 func (pa *PlatformAdapterDingTalk) SetEnable(enable bool) {
 	if enable {
-		pa.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
+		pa.EndPoint.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
 		if err := pa.openSessionLocked(); err != nil {
-			pa.Session.Parent.Logger.Errorf("与DingTalk服务进行连接时出错:%s", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("与DingTalk服务进行连接时出错:%s", err.Error())
 			pa.EndPoint.State = 3
 			pa.EndPoint.Enable = false
 			return
@@ -54,7 +53,7 @@ func (pa *PlatformAdapterDingTalk) SetEnable(enable bool) {
 		pa.EndPoint.Enable = true
 	} else {
 		if err := pa.closeSessionLocked(); err != nil {
-			pa.Session.Parent.Logger.Error("Dingtalk 断开连接失败: ", err)
+			pa.EndPoint.Session.Parent.Logger.Error("Dingtalk 断开连接失败: ", err)
 			return
 		}
 		pa.EndPoint.State = 0
@@ -79,17 +78,17 @@ func (pa *PlatformAdapterDingTalk) SendToPerson(ctx *MsgContext, uid string, tex
 	pa.sessionMu.RLock()
 	defer pa.sessionMu.RUnlock()
 	if pa.IntentSession == nil || !pa.sessionOpened {
-		pa.Session.Parent.Logger.Warn("Dingtalk session 未开启，忽略私聊发送")
+		pa.EndPoint.Session.Parent.Logger.Warn("Dingtalk session 未开启，忽略私聊发送")
 		return
 	}
 	session := pa.IntentSession
 
 	messageID, err := session.MessagePrivateSend(rawUserID, pa.RobotCode, &msg)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("Dingtalk SendToPerson Error: ", err)
+		pa.EndPoint.Session.Parent.Logger.Error("Dingtalk SendToPerson Error: ", err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "DINGTALK",
 		MessageType: "private",
 		Message:     text,
@@ -108,16 +107,16 @@ func (pa *PlatformAdapterDingTalk) SendToGroup(ctx *MsgContext, uid string, text
 	pa.sessionMu.RLock()
 	defer pa.sessionMu.RUnlock()
 	if pa.IntentSession == nil || !pa.sessionOpened {
-		pa.Session.Parent.Logger.Warn("Dingtalk session 未开启，忽略群聊发送")
+		pa.EndPoint.Session.Parent.Logger.Warn("Dingtalk session 未开启，忽略群聊发送")
 		return
 	}
 	session := pa.IntentSession
 	messageID, err := session.MessageGroupSend(rawGroupID, pa.RobotCode, pa.CoolAppCode, &msg)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("Dingtalk SendToGroup Error: ", err)
+		pa.EndPoint.Session.Parent.Logger.Error("Dingtalk SendToGroup Error: ", err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "DINGTALK",
 		MessageType: "group",
 		Message:     text,
@@ -166,16 +165,18 @@ func (pa *PlatformAdapterDingTalk) GetGroupInfoAsync(groupID string) {
 }
 
 func (pa *PlatformAdapterDingTalk) OnChatReceive(_ *dingtalk.Session, data *chatbot.BotCallbackDataModel) {
-	groupInfo, ok := pa.Session.ServiceAtNew.Load(FormatDiceIDDingTalkGroup(data.ConversationId))
+	session := pa.EndPoint.Session
+	groupInfo, ok := session.ServiceAtNew.Load(FormatDiceIDDingTalkGroup(data.ConversationId))
 	if ok {
 		groupInfo.GroupName = data.ConversationTitle
 	}
 	msg := pa.toStdMessage(data)
-	pa.Session.Execute(pa.EndPoint, msg, false)
+	session.Execute(pa.EndPoint, msg, false)
 }
 
 func (pa *PlatformAdapterDingTalk) OnGroupJoined(_ *dingtalk.Session, data *dingtalk.GroupJoinedEvent) {
-	palogger := pa.Session.Parent.Logger
+	session := pa.EndPoint.Session
+	palogger := session.Parent.Logger
 	msg := &Message{
 		Platform: "DINGTALK",
 		RawID:    data.EventId,
@@ -187,12 +188,12 @@ func (pa *PlatformAdapterDingTalk) OnGroupJoined(_ *dingtalk.Session, data *ding
 	palogger.Info("Dingtalk OnGroupJoined: ", data)
 	pa.CoolAppCode = data.CoolAppCode
 	pa.RobotCode = data.RobotCode
-	d := pa.Session.Parent
+	d := session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
-	logger := pa.Session.Parent.Logger
+	logger := session.Parent.Logger
 	ep := pa.EndPoint
-	ctx := &MsgContext{MessageType: "group", EndPoint: ep, Session: pa.Session, Dice: pa.Session.Parent}
+	ctx := &MsgContext{MessageType: "group", EndPoint: ep, Session: session, Dice: session.Parent}
 	gi := SetBotOnAtGroup(ctx, msg.GroupID)
 	gi.InviteUserID = msg.Sender.UserID
 	gi.EnteredTime = time.Now().Unix()
@@ -241,7 +242,7 @@ func (pa *PlatformAdapterDingTalk) Serve() int {
 	if pa.EndPoint.Nickname == "" {
 		pa.EndPoint.Nickname = "DingTalkBot"
 	}
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	logger.Info("Dingtalk Serve")
 
 	pa.sessionMu.Lock()
@@ -263,7 +264,7 @@ func (pa *PlatformAdapterDingTalk) Serve() int {
 	logger.Info("Dingtalk 连接成功")
 	pa.EndPoint.State = 1
 	pa.EndPoint.Enable = true
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	return 0

--- a/dice/platform_adapter_dingtalk_helper.go
+++ b/dice/platform_adapter_dingtalk_helper.go
@@ -27,7 +27,7 @@ func ServeDingTalk(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "DINGTALK" {
 		conn := ep.Adapter.(*PlatformAdapterDingTalk)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Dingtalk 尝试连接")
 		if conn.Serve() != 0 {
 			d.Logger.Errorf("连接Dingtalk 失败")

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -19,7 +19,6 @@ import (
 
 // PlatformAdapterDiscord 只有token需要记录，别的是生成的
 type PlatformAdapterDiscord struct {
-	Session            *IMSession         `json:"-"                  yaml:"-"`
 	Token              string             `json:"-"              yaml:"token"`
 	ProxyURL           string             `json:"proxyURL"           yaml:"proxyURL"`
 	ReverseProxyUrl    string             `json:"reverseProxyUrl"    yaml:"reverseProxyUrl"`
@@ -35,8 +34,8 @@ func (pa *PlatformAdapterDiscord) GetGroupInfoAsync(groupID string) {
 		return
 	}
 	go pa.updateChannelNum()
-	logger := pa.Session.Parent.Logger
-	dm := pa.Session.Parent.Parent
+	logger := pa.EndPoint.Session.Parent.Logger
+	dm := pa.EndPoint.Session.Parent.Parent
 	channel, err := pa.IntentSession.Channel(ExtractDiscordChannelID(groupID))
 	if err != nil {
 		logger.Errorf("获取Discord频道信息#%s时出错:%s", groupID, err.Error())
@@ -46,11 +45,11 @@ func (pa *PlatformAdapterDiscord) GetGroupInfoAsync(groupID string) {
 		Name: channel.Name,
 		time: time.Now().Unix(),
 	})
-	groupInfo, ok := pa.Session.ServiceAtNew.Load(groupID)
+	groupInfo, ok := pa.EndPoint.Session.ServiceAtNew.Load(groupID)
 	if ok {
 		if channel.Name != groupInfo.GroupName {
 			groupInfo.GroupName = channel.Name
-			groupInfo.MarkDirty(pa.Session.Parent)
+			groupInfo.MarkDirty(pa.EndPoint.Session.Parent)
 		}
 	}
 }
@@ -73,13 +72,13 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 	dg, err := discordgo.New("Bot " + pa.Token)
 	// 这里出错很大概率是token不对
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("创建DiscordSession时出错:%s", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("创建DiscordSession时出错:%s", err.Error())
 		return 1
 	}
 	if pa.ProxyURL != "" {
 		u, e := url.Parse(pa.ProxyURL)
 		if e != nil {
-			pa.Session.Parent.Logger.Errorf("代理地址解析错误%s", e.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("代理地址解析错误%s", e.Error())
 			return 1
 		}
 		dg.Client.Transport = &http.Transport{
@@ -89,11 +88,11 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 		dg.Dialer.Proxy = http.ProxyURL(u)
 	}
 	if pa.ReverseProxyUrl != "" {
-		pa.Session.Parent.Logger.Infof("Discord代理地址已设置为%s", pa.ReverseProxyUrl)
+		pa.EndPoint.Session.Parent.Logger.Infof("Discord代理地址已设置为%s", pa.ReverseProxyUrl)
 		regenerateDiscordEndPoint(pa.ReverseProxyUrl)
 	}
 	if pa.ReverseProxyCDNUrl != "" {
-		pa.Session.Parent.Logger.Infof("Discord CDN代理地址已设置为%s", pa.ReverseProxyCDNUrl)
+		pa.EndPoint.Session.Parent.Logger.Infof("Discord CDN代理地址已设置为%s", pa.ReverseProxyCDNUrl)
 		regenerateDiscordEndPointCDN(pa.ReverseProxyCDNUrl)
 	}
 	dg.AddHandler(func(s *discordgo.Session, m *discordgo.MessageCreate) {
@@ -112,12 +111,12 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 		if errConv != nil {
 			return
 		}
-		pa.Session.Execute(pa.EndPoint, msg, false)
+		pa.EndPoint.Session.Execute(pa.EndPoint, msg, false)
 	})
 	dg.AddHandler(func(s *discordgo.Session, m *discordgo.MessageDelete) {
 		ch, errChannel := pa.IntentSession.Channel(m.ChannelID)
 		if errChannel != nil {
-			pa.Session.Parent.Logger.Errorf("获取Discord频道#%s信息时出错:%s", FormatDiceIDDiscordChannel(m.ChannelID), errChannel.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("获取Discord频道#%s信息时出错:%s", FormatDiceIDDiscordChannel(m.ChannelID), errChannel.Error())
 			return
 		}
 		msg := &Message{}
@@ -138,8 +137,8 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 		}
 		msg.RawID = m.ID
 		msg.Time = m.Timestamp.Unix()
-		mctx := &MsgContext{Session: pa.Session, EndPoint: pa.EndPoint, Dice: pa.Session.Parent, MessageType: msg.MessageType}
-		pa.Session.OnMessageDeleted(mctx, msg)
+		mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
+		pa.EndPoint.Session.OnMessageDeleted(mctx, msg)
 	})
 	// Szzrain 注: bot疑似在每次启动时都会收到一次这个入群事件，会导致入群致辞被重复发送，暂时注释掉
 	// dg.AddHandler(func(s *discordgo.Session, m *discordgo.GuildCreate) {
@@ -164,12 +163,12 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 	//	// GuildCreate 似乎不会在私聊消息时触发
 	//	msg.MessageType = "group"
 	//
-	//	mctx := &MsgContext{Session: pa.Session, EndPoint: pa.EndPoint, Dice: pa.Session.Parent, MessageType: msg.MessageType}
+	//	mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
 	//	pa.GetGroupInfoAsync(msg.GroupId)
 	//	go func() {
 	//		defer func() {
 	//			if r := recover(); r != nil {
-	//				pa.Session.Parent.Logger.Errorf("入群致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
+	//				pa.EndPoint.Session.Parent.Logger.Errorf("入群致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
 	//			}
 	//		}()
 	//
@@ -177,7 +176,7 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 	//		time.Sleep(1 * time.Second)
 	//
 	//		mctx.Player = &GroupPlayerInfo{}
-	//		pa.Session.Parent.Logger.Infof("发送入群致辞，群: <%s>(%s)", m.Name, msg.GuildId)
+	//		pa.EndPoint.Session.Parent.Logger.Infof("发送入群致辞，群: <%s>(%s)", m.Name, msg.GuildId)
 	//		text := DiceFormatTmpl(mctx, "核心:骰子进群")
 	//		for _, i := range mctx.SplitText(text) {
 	//			pa.SendToGroup(mctx, msg.GroupId, strings.TrimSpace(i), "")
@@ -216,7 +215,7 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 
 		ch, errChannel := pa.IntentSession.Channel(ctx.ChannelID)
 		if errChannel != nil {
-			pa.Session.Parent.Logger.Errorf(
+			pa.EndPoint.Session.Parent.Logger.Errorf(
 				"获取Discord频道#%s信息时出错:%s",
 				FormatDiceIDDiscordChannel(ctx.ChannelID),
 				errChannel.Error(),
@@ -233,13 +232,13 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 		msg.GuildID = FormatDiceIDDiscordGuild(ctx.GuildID)
 
 		mctx := &MsgContext{
-			Session:     pa.Session,
+			Session:     pa.EndPoint.Session,
 			EndPoint:    pa.EndPoint,
-			Dice:        pa.Session.Parent,
+			Dice:        pa.EndPoint.Session.Parent,
 			MessageType: msg.MessageType,
 			Player:      &GroupPlayerInfo{},
 		}
-		pa.Session.OnMessageEdit(mctx, msg)
+		pa.EndPoint.Session.OnMessageEdit(mctx, msg)
 	})
 	// 这里只处理消息，未来根据需要再改这里
 	dg.Identify.Intents = discordgo.IntentsAll
@@ -247,7 +246,7 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 	err = dg.Open()
 	// 这里出错要么没连上，要么连接被阻止了（懂得都懂）
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
 		return 1
 	}
 	// 把bot的状态改成正在玩SealDice，这一行可以删掉，但是他很cool欸
@@ -256,9 +255,9 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 	pa.EndPoint.Nickname = pa.IntentSession.State.User.Username
 	pa.EndPoint.State = 1
 	pa.EndPoint.Enable = true
-	pa.Session.Parent.Logger.Infof("Discord 服务连接成功，账号<%s>(%s)", pa.IntentSession.State.User.Username, FormatDiceIDDiscord(pa.IntentSession.State.User.ID))
+	pa.EndPoint.Session.Parent.Logger.Infof("Discord 服务连接成功，账号<%s>(%s)", pa.IntentSession.State.User.Username, FormatDiceIDDiscord(pa.IntentSession.State.User.ID))
 
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	return 0
@@ -273,14 +272,14 @@ func (pa *PlatformAdapterDiscord) DoRelogin() bool {
 	_ = pa.IntentSession.Close()
 	err := pa.IntentSession.Open()
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
 		pa.EndPoint.State = 0
 		return false
 	}
 	_ = pa.IntentSession.UpdateGameStatus(0, "SealDice")
 	pa.EndPoint.State = 1
 	pa.EndPoint.Enable = true
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	return true
@@ -289,20 +288,20 @@ func (pa *PlatformAdapterDiscord) DoRelogin() bool {
 // SetEnable 禁用之后骰子仍然有可能显示在线一段时间，可能是因为没有挥手机制，不过已经不会接收到事件了
 func (pa *PlatformAdapterDiscord) SetEnable(enable bool) {
 	if enable {
-		pa.Session.Parent.Logger.Infof("正在启用Discord服务……")
+		pa.EndPoint.Session.Parent.Logger.Infof("正在启用Discord服务……")
 		if pa.IntentSession == nil {
 			pa.Serve()
 			return
 		}
 		err := pa.IntentSession.Open()
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
 			pa.EndPoint.State = 3
 			pa.EndPoint.Enable = false
 			return
 		}
 		_ = pa.IntentSession.UpdateGameStatus(0, "SealDice")
-		pa.Session.Parent.Logger.Infof("Discord 服务连接成功，账号<%s>(%s)", pa.IntentSession.State.User.Username, FormatDiceIDDiscord(pa.IntentSession.State.User.ID))
+		pa.EndPoint.Session.Parent.Logger.Infof("Discord 服务连接成功，账号<%s>(%s)", pa.IntentSession.State.User.Username, FormatDiceIDDiscord(pa.IntentSession.State.User.ID))
 		pa.EndPoint.State = 1
 		pa.EndPoint.Enable = true
 	} else {
@@ -312,7 +311,7 @@ func (pa *PlatformAdapterDiscord) SetEnable(enable bool) {
 			_ = pa.IntentSession.Close()
 		}
 	}
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 }
@@ -328,14 +327,14 @@ func (pa *PlatformAdapterDiscord) SendToPerson(ctx *MsgContext, userID string, t
 	is := pa.IntentSession
 	ch, err := is.UserChannelCreate(ExtractDiscordUserID(userID))
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("创建Discord用户#%s的私聊频道时出错:%s", userID, err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("创建Discord用户#%s的私聊频道时出错:%s", userID, err)
 		return
 	}
 	resp, err := pa.sendToChannelRaw(ch.ID, text)
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "DISCORD",
 		MessageType: "private",
 		Message:     text,
@@ -354,7 +353,7 @@ func (pa *PlatformAdapterDiscord) SendToGroup(ctx *MsgContext, groupID string, t
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "DISCORD",
 		MessageType: "group",
 		Message:     text,
@@ -371,14 +370,14 @@ func (pa *PlatformAdapterDiscord) SendFileToPerson(ctx *MsgContext, userID strin
 	is := pa.IntentSession
 	ch, err := is.UserChannelCreate(ExtractDiscordUserID(userID))
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("创建Discord用户#%s的私聊频道时出错:%s", userID, err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("创建Discord用户#%s的私聊频道时出错:%s", userID, err)
 		return
 	}
 	resp, err := pa.sendFileToChannelRaw(ch.ID, path)
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "DISCORD",
 		MessageType: "private",
 		Segment: []message.IMessageElement{
@@ -399,7 +398,7 @@ func (pa *PlatformAdapterDiscord) SendFileToGroup(ctx *MsgContext, groupID strin
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "DISCORD",
 		MessageType: "group",
 		Segment: []message.IMessageElement{
@@ -417,7 +416,7 @@ func (pa *PlatformAdapterDiscord) SendFileToGroup(ctx *MsgContext, groupID strin
 }
 
 func (pa *PlatformAdapterDiscord) sendFileToChannelRaw(channelID string, path string) (*discordgo.Message, error) {
-	dice := pa.Session.Parent
+	dice := pa.EndPoint.Session.Parent
 	e, err := message.FilepathToFileElement(path)
 	id := ExtractDiscordChannelID(channelID)
 	if err != nil {
@@ -441,7 +440,7 @@ func (pa *PlatformAdapterDiscord) sendFileToChannelRaw(channelID string, path st
 }
 
 func (pa *PlatformAdapterDiscord) sendToChannelRaw(channelID string, text string) (*discordgo.Message, error) {
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	elem := message.ConvertStringMessage(text)
 	id := ExtractDiscordChannelID(channelID)
 	var err error
@@ -502,7 +501,7 @@ func (pa *PlatformAdapterDiscord) sendToChannelRaw(channelID string, text string
 				_, err = pa.IntentSession.ChannelMessageSendComplex(id, msgSend)
 			}
 			if err != nil {
-				pa.Session.Parent.Logger.Errorf("向Discord频道#%s发送消息时出错:%s", id, err)
+				pa.EndPoint.Session.Parent.Logger.Errorf("向Discord频道#%s发送消息时出错:%s", id, err)
 				break
 			}
 			msgSend = &discordgo.MessageSend{Content: ""}
@@ -520,15 +519,15 @@ func (pa *PlatformAdapterDiscord) sendToChannelRaw(channelID string, text string
 			msgSend.Reference = ref
 		}
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("向Discord频道#%s发送消息时出错:%s", id, err)
+			pa.EndPoint.Session.Parent.Logger.Errorf("向Discord频道#%s发送消息时出错:%s", id, err)
 			return nil, err
 		}
 	}
 	if msgSend.Content != "" || msgSend.Files != nil || msgSend.Embeds != nil {
 		info, err := pa.IntentSession.ChannelMessageSendComplex(id, msgSend)
-		// pa.Session.Parent.Logger.Infof("真的向Discord频道#%s发送消息:%s", id, msgSend.Content)
+		// pa.EndPoint.Session.Parent.Logger.Infof("真的向Discord频道#%s发送消息:%s", id, msgSend.Content)
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("向Discord频道#%s发送消息时出错:%s", id, err)
+			pa.EndPoint.Session.Parent.Logger.Errorf("向Discord频道#%s发送消息时出错:%s", id, err)
 			return nil, err
 		}
 		return info, err
@@ -542,13 +541,13 @@ func (pa *PlatformAdapterDiscord) QuitGroup(_ *MsgContext, id string) {
 	// 另一个不建议使用此功能的原因是把discordBot重新拉回服务器很麻烦，需要去discord开发者页面再生成一遍链接
 	ch, err := pa.IntentSession.Channel(ExtractDiscordUserID(id))
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("获取Discord频道#%s信息时出错:%s", id, err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("获取Discord频道#%s信息时出错:%s", id, err.Error())
 		return
 	}
 	guildID := ch.GuildID
 	err = pa.IntentSession.GuildLeave(guildID)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("退出Discord群组#%s时出错:%s", guildID, err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("退出Discord群组#%s时出错:%s", guildID, err.Error())
 		return
 	}
 }
@@ -558,7 +557,7 @@ func (pa *PlatformAdapterDiscord) SetGroupCardName(ctx *MsgContext, name string)
 	guildID := ctx.Group.GuildID
 	err := pa.IntentSession.GuildMemberNickname(guildID, ExtractDiscordUserID(ctx.Player.UserID), name)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("修改用户#%s在Discord服务器%s(来源频道#%s)的昵称时出错:%s", ctx.Player.UserID, guildID, ctx.Group.GroupID, err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("修改用户#%s在Discord服务器%s(来源频道#%s)的昵称时出错:%s", ctx.Player.UserID, guildID, ctx.Group.GroupID, err.Error())
 	}
 }
 
@@ -575,7 +574,7 @@ func (pa *PlatformAdapterDiscord) EditMessage(ctx *MsgContext, msgID, message st
 	}
 
 	if _, err := pa.IntentSession.ChannelMessageEdit(envID, msgID, message); err != nil {
-		pa.Session.Parent.Logger.Errorf("更新Discord消息失败: %v", err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("更新Discord消息失败: %v", err)
 	}
 }
 
@@ -627,7 +626,7 @@ func (pa *PlatformAdapterDiscord) toStdMessage(m *discordgo.MessageCreate) (*Mes
 	msg.Platform = "DISCORD"
 	ch, err := pa.IntentSession.Channel(m.ChannelID)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("获取Discord频道#%s信息时出错:%s", FormatDiceIDDiscordChannel(m.ChannelID), err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("获取Discord频道#%s信息时出错:%s", FormatDiceIDDiscordChannel(m.ChannelID), err.Error())
 		return nil, errors.New("")
 	}
 	if ch != nil && ch.Type == discordgo.ChannelTypeDM {
@@ -649,9 +648,9 @@ func (pa *PlatformAdapterDiscord) toStdMessage(m *discordgo.MessageCreate) (*Mes
 
 func (pa *PlatformAdapterDiscord) checkIfGuildAdmin(m *discordgo.Message) bool {
 	p, err := pa.IntentSession.State.MessagePermissions(m)
-	// pa.Session.Parent.Logger.Info(m.Author.Username, p)
+	// pa.EndPoint.Session.Parent.Logger.Info(m.Author.Username, p)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("Discord 鉴权时出现错误，\n发送者:%s，\n频道:%s，\n服务器id:%s，\n消息id:%s，\n时间:%s，\n消息内容:\"%s\"，\n错误详情:%s",
+		pa.EndPoint.Session.Parent.Logger.Errorf("Discord 鉴权时出现错误，\n发送者:%s，\n频道:%s，\n服务器id:%s，\n消息id:%s，\n时间:%s，\n消息内容:\"%s\"，\n错误详情:%s",
 			FormatDiceIDDiscord(m.Author.ID),
 			FormatDiceIDDiscordChannel(m.ChannelID),
 			m.GuildID,

--- a/dice/platform_adapter_discord_helper.go
+++ b/dice/platform_adapter_discord_helper.go
@@ -37,7 +37,7 @@ func ServeDiscord(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "DISCORD" {
 		conn := ep.Adapter.(*PlatformAdapterDiscord)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("DiscordGo 尝试连接")
 		if conn.Serve() != 0 {
 			d.Logger.Errorf("连接Discord服务失败")

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -19,7 +19,6 @@ import (
 )
 
 type PlatformAdapterDodo struct {
-	Session           *IMSession                                              `json:"-"        yaml:"-"`
 	ClientID          string                                                  `json:"-" yaml:"clientID"`
 	Token             string                                                  `json:"-"    yaml:"token"`
 	EndPoint          *EndPointInfo                                           `json:"-"        yaml:"-"`
@@ -46,19 +45,19 @@ func (pa *PlatformAdapterDodo) GetGroupInfoAsync(groupID string) {
 	if err != nil {
 		return
 	}
-	dm := pa.Session.Parent.Parent
+	dm := pa.EndPoint.Session.Parent.Parent
 	dm.GroupNameCache.Store(groupID, &GroupNameCacheItem{
 		Name: info.ChannelName,
 		time: time.Now().Unix(),
 	})
-	groupInfo, ok := pa.Session.ServiceAtNew.Load(groupID)
+	groupInfo, ok := pa.EndPoint.Session.ServiceAtNew.Load(groupID)
 	if ok {
 		groupInfo.GroupName = info.ChannelName
 	}
 }
 
 func (pa *PlatformAdapterDodo) Serve() int {
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	clientID := pa.ClientID
 	token := pa.Token
 	instance, err := client.New(clientID, token, client.WithTimeout(time.Second*3))
@@ -70,7 +69,7 @@ func (pa *PlatformAdapterDodo) Serve() int {
 	if err == nil {
 		pa.EndPoint.UserID = FormatDiceIDDodo(selfid.DodoSourceId)
 		pa.EndPoint.Nickname = selfid.NickName
-		d := pa.Session.Parent
+		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 	}
@@ -78,25 +77,25 @@ func (pa *PlatformAdapterDodo) Serve() int {
 	channelMessageHandler := func(event *websocket.WSEventMessage, data *websocket.ChannelMessageEventBody) error {
 		// defer func() {
 		// 	if recoverError := recover(); recoverError != nil {
-		// 		pa.Session.Parent.Logger.Errorf("Dodo消息处理错误:%v\n Stack: \n%v", recoverError, string(debug.Stack()))
+		// 		pa.EndPoint.Session.Parent.Logger.Errorf("Dodo消息处理错误:%v\n Stack: \n%v", recoverError, string(debug.Stack()))
 		// 	}
 		// }()
-		// pa.Session.Parent.Logger.Infof("WS-收到Dodo频道消息:%s", string(data.MessageBody))
+		// pa.EndPoint.Session.Parent.Logger.Infof("WS-收到Dodo频道消息:%s", string(data.MessageBody))
 		msg, errs := pa.toStdChannelMessage(data)
 		if errs != nil {
-			pa.Session.Parent.Logger.Errorf("Dodo消息转换错误:%s", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("Dodo消息转换错误:%s", err.Error())
 			return errs
 		}
-		pa.Session.Execute(pa.EndPoint, msg, false)
+		pa.EndPoint.Session.Execute(pa.EndPoint, msg, false)
 		return nil
 	}
 	personalMessageHandler := func(event *websocket.WSEventMessage, data *websocket.PersonalMessageEventBody) error {
 		msg, errs := pa.toStdPersonalMessage(data)
 		if errs != nil {
-			pa.Session.Parent.Logger.Errorf("Dodo消息转换错误:%s", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("Dodo消息转换错误:%s", err.Error())
 			return errs
 		}
-		pa.Session.Execute(pa.EndPoint, msg, false)
+		pa.EndPoint.Session.Execute(pa.EndPoint, msg, false)
 		return nil
 	}
 	msgHandlers.ChannelMessage = channelMessageHandler
@@ -109,7 +108,7 @@ func (pa *PlatformAdapterDodo) Serve() int {
 		for pa.RetryConnectTimes <= 5 {
 			pa.RetryConnectTimes++
 			time.Sleep(time.Second * 5)
-			pa.Session.Parent.Logger.Infof("Dodo 尝试重连, 第 [%d/5] 次", pa.RetryConnectTimes)
+			pa.EndPoint.Session.Parent.Logger.Infof("Dodo 尝试重连, 第 [%d/5] 次", pa.RetryConnectTimes)
 			ws.Close()
 			if err = ws.Connect(); err == nil {
 				pa.RetryConnectTimes = 0
@@ -122,7 +121,7 @@ func (pa *PlatformAdapterDodo) Serve() int {
 		if err != nil {
 			logger.Errorf("Dodo 短时间内重试次数过多，先行中断")
 			pa.EndPoint.State = 3
-			d := pa.Session.Parent
+			d := pa.EndPoint.Session.Parent
 			d.LastUpdatedTime = time.Now().Unix()
 			d.Save(false)
 			return 1
@@ -131,9 +130,9 @@ func (pa *PlatformAdapterDodo) Serve() int {
 	pa.WebSocket = ws
 	pa.EndPoint.State = 1
 	pa.RetryConnectTimes = 0
-	pa.Session.Parent.Logger.Infof("Dodo 连接成功")
+	pa.EndPoint.Session.Parent.Logger.Infof("Dodo 连接成功")
 	pa.EndPoint.Enable = true
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	go func() {
@@ -142,7 +141,7 @@ func (pa *PlatformAdapterDodo) Serve() int {
 			logger.Errorf("Dodo监听错误:%s", err.Error())
 			if pa.EndPoint.Enable {
 				pa.EndPoint.State = 3
-				d := pa.Session.Parent
+				d := pa.EndPoint.Session.Parent
 				d.LastUpdatedTime = time.Now().Unix()
 				d.Save(false)
 				logger.Infof("Dodo 连接断开，正在尝试重连……")
@@ -165,7 +164,7 @@ func (pa *PlatformAdapterDodo) toStdPersonalMessage(msgRaw *websocket.PersonalMe
 	if msgRaw.IslandSourceId != "" {
 		msg.GuildID = msgRaw.IslandSourceId
 	}
-	// pa.Session.Parent.Logger.Infof("source id: %s", msgRaw.IslandSourceId)
+	// pa.EndPoint.Session.Parent.Logger.Infof("source id: %s", msgRaw.IslandSourceId)
 	if msgRaw.MessageType == 1 {
 		msgDodo := new(model.TextMessage)
 		err := json.Unmarshal(msgRaw.MessageBody, msgDodo)
@@ -240,14 +239,14 @@ func (pa *PlatformAdapterDodo) refreshPermCache(guildID string, userID string) (
 		DodoSourceId:   userID,
 	})
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("Dodo获取权限列表失败:%s", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("Dodo获取权限列表失败:%s", err.Error())
 		return aperm
 	}
 
 	for _, role := range list {
 		num, err := strconv.ParseInt(role.Permission, 16, 64) // 16 表示这是一个十六进制数
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("Dodo权限转换错误:%s", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("Dodo权限转换错误:%s", err.Error())
 			return aperm
 		}
 		aperm |= num
@@ -263,7 +262,7 @@ func (pa *PlatformAdapterDodo) refreshPermCache(guildID string, userID string) (
 			IslandSourceId: guildID,
 		})
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("Dodo获取群信息失败:%s", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Errorf("Dodo获取群信息失败:%s", err.Error())
 			return aperm
 		}
 
@@ -287,7 +286,7 @@ func (pa *PlatformAdapterDodo) DoRelogin() bool {
 	defer func() {
 		_ = recover()
 	}()
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	if pa.WebSocket != nil {
 		pa.WebSocket.Close()
 		pa.Client = nil
@@ -304,7 +303,7 @@ func (pa *PlatformAdapterDodo) SetEnable(enable bool) {
 	defer func() {
 		_ = recover()
 	}()
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	if enable {
 		if pa.Client != nil && pa.WebSocket != nil {
 			pa.WebSocket.Close()
@@ -331,13 +330,13 @@ func (pa *PlatformAdapterDodo) SendSegmentToPerson(ctx *MsgContext, userID strin
 }
 
 func (pa *PlatformAdapterDodo) SendToPerson(ctx *MsgContext, uid string, text string, flag string) {
-	// pa.Session.Parent.Logger.Infof("send to %s", ExtractDodoUserId(uid))
+	// pa.EndPoint.Session.Parent.Logger.Infof("send to %s", ExtractDodoUserId(uid))
 	err := pa.SendToPersonRaw(ctx, uid, text, true)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("DODO 发送私聊消息失败：%v\n", err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("DODO 发送私聊消息失败：%v\n", err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		MessageType: "private",
 		Platform:    "DODO",
 		Message:     text,
@@ -351,10 +350,10 @@ func (pa *PlatformAdapterDodo) SendToPerson(ctx *MsgContext, uid string, text st
 func (pa *PlatformAdapterDodo) SendToGroup(ctx *MsgContext, uid string, text string, flag string) {
 	err := pa.SendToChatRaw(ctx, uid, text, false)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("DODO 发送消息失败：%v\n", err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("DODO 发送消息失败：%v\n", err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		MessageType: "group",
 		Platform:    "DODO",
 		Message:     text,
@@ -605,7 +604,7 @@ func (pa *PlatformAdapterDodo) QuitGroup(ctx *MsgContext, groupId string) {
 		IslandSourceId: ctx.Group.GuildID,
 	})
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("Dodo退群失败:%v", err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("Dodo退群失败:%v", err)
 	}
 }
 
@@ -616,6 +615,6 @@ func (pa *PlatformAdapterDodo) SetGroupCardName(ctx *MsgContext, name string) {
 		NickName:       name,
 	})
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("Dodo设置群名片失败:%v", err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("Dodo设置群名片失败:%v", err)
 	}
 }

--- a/dice/platform_adapter_dodo_helper.go
+++ b/dice/platform_adapter_dodo_helper.go
@@ -26,7 +26,7 @@ func ServeDodo(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "DODO" {
 		conn := ep.Adapter.(*PlatformAdapterDodo)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Dodo 尝试连接")
 		if conn.Serve() != 0 {
 			d.Logger.Errorf("连接Dodo失败")

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -52,7 +52,6 @@ type echoMapInfo struct {
 
 type PlatformAdapterGocq struct {
 	EndPoint *EndPointInfo `json:"-" yaml:"-"`
-	Session  *IMSession    `json:"-" yaml:"-"`
 
 	IsReverse   bool       `json:"isReverse"   yaml:"isReverse"`
 	ReverseAddr string     `json:"reverseAddr" yaml:"reverseAddr"`
@@ -422,7 +421,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		pa.Implementation = "gocq"
 	}
 	ep := pa.EndPoint
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
 	dm := s.Parent.Parent
 	interrupt := make(chan os.Signal, 1)
@@ -439,7 +438,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 	ep.State = 2
 	socket.OnConnected = func(socket gowebsocket.Socket) {
-		defer ErrorLogAndContinue(pa.Session.Parent)
+		defer ErrorLogAndContinue(pa.EndPoint.Session.Parent)
 		ep.State = 1
 		if pa.IsReverse {
 			log.Info("onebot v11 反向ws连接成功")
@@ -453,7 +452,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 	}
 
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
-		defer ErrorLogAndContinue(pa.Session.Parent)
+		defer ErrorLogAndContinue(pa.EndPoint.Session.Parent)
 		// if CheckDialErr(err) != syscall.ECONNREFUSED {
 		// refused 不算大事
 		log.Error("onebot v11 connection error: ", err)
@@ -477,7 +476,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 	tempFriendInviteSent := map[string]int64{}     // gocq会重新发送已经发过的邀请
 
 	socket.OnTextMessage = func(message string, socket gowebsocket.Socket) {
-		defer ErrorLogAndContinue(pa.Session.Parent)
+		defer ErrorLogAndContinue(pa.EndPoint.Session.Parent)
 		// if strings.Contains(message, `.`) {
 		//	log.Info("...", message)
 		// }
@@ -533,7 +532,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			log.Debug("骰子信息已刷新")
 			ep.RefreshGroupNum()
 
-			d := pa.Session.Parent
+			d := pa.EndPoint.Session.Parent
 			d.LastUpdatedTime = time.Now().Unix()
 			d.Save(false)
 			return
@@ -1046,9 +1045,9 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		if msgQQ.PostType == "notice" && msgQQ.SubType == "poke" {
 			// {"post_type":"notice","notice_type":"notify","time":1672489767,"self_id":2589922907,"sub_type":"poke","group_id":131687852,"user_id":303451945,"sender_id":303451945,"target_id":2589922907}
 			go func() {
-				defer ErrorLogAndContinue(pa.Session.Parent)
+				defer ErrorLogAndContinue(pa.EndPoint.Session.Parent)
 				isPrivate := msg.MessageType == "private"
-				pa.Session.OnPoke(pa.packTempCtx(msgQQ, msg), &events.PokeEvent{
+				pa.EndPoint.Session.OnPoke(pa.packTempCtx(msgQQ, msg), &events.PokeEvent{
 					GroupID:   msg.GroupID,
 					SenderID:  FormatDiceIDQQ(string(msgQQ.UserID)),
 					TargetID:  FormatDiceIDQQ(string(msgQQ.TargetID)),
@@ -1102,7 +1101,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		lastDisconnect = now
 
 		log.Info("onebot 服务的连接被对方关闭")
-		_ = pa.Session.Parent.SendMail("", MailTypeConnectClose)
+		_ = pa.EndPoint.Session.Parent.SendMail("", MailTypeConnectClose)
 		pa.InPackGoCqhttpDisconnectedCH <- 1
 	}
 
@@ -1181,7 +1180,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 }
 
 func (pa *PlatformAdapterGocq) DoRelogin() bool {
-	myDice := pa.Session.Parent
+	myDice := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
 	if pa.Socket != nil {
 		go func() {
@@ -1248,7 +1247,7 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	c := pa.EndPoint
 	if enable {
 		c.Enable = true
@@ -1297,7 +1296,7 @@ func (pa *PlatformAdapterGocq) SetQQProtocol(protocol int) bool {
 	pa.InPackGoCqhttpProtocol = protocol
 
 	// ep.Session.Parent.GetDiceDataPath(ep.RelWorkDir)
-	workDir := filepath.Join(pa.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
+	workDir := filepath.Join(pa.EndPoint.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
 	deviceFilePath := filepath.Join(workDir, "device.json")
 	if _, err := os.Stat(deviceFilePath); err == nil {
 		configFile, _ := os.ReadFile(deviceFilePath)
@@ -1317,7 +1316,7 @@ func (pa *PlatformAdapterGocq) SetQQProtocol(protocol int) bool {
 }
 
 func (pa *PlatformAdapterGocq) SetSignServer(signServerConfig *SignServerConfig) bool {
-	workDir := filepath.Join(pa.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
+	workDir := filepath.Join(pa.EndPoint.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
 	configFilePath := filepath.Join(workDir, "config.yml")
 	if _, err := os.Stat(configFilePath); err == nil {
 		configFile, _ := os.ReadFile(configFilePath)
@@ -1357,7 +1356,7 @@ func (pa *PlatformAdapterGocq) IsLoginSuccessed() bool {
 
 func (pa *PlatformAdapterGocq) packTempCtx(msgQQ *MessageQQ, msg *Message) *MsgContext {
 	ep := pa.EndPoint
-	session := pa.Session
+	session := pa.EndPoint.Session
 
 	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: session, Dice: session.Parent}
 

--- a/dice/platform_adapter_gocq_actions.go
+++ b/dice/platform_adapter_gocq_actions.go
@@ -446,7 +446,7 @@ func (pa *PlatformAdapterGocq) SendFileToPerson(ctx *MsgContext, userID string, 
 		return
 	}
 
-	dice := pa.Session.Parent
+	dice := pa.EndPoint.Session.Parent
 	// 路径可以是 http/base64/本地路径，但 gocq 的文件上传只支持本地文件，所以临时下载到本地
 	fileName, temp, err := message.ExtractLocalTempFile(path)
 
@@ -488,7 +488,7 @@ func (pa *PlatformAdapterGocq) SendFileToGroup(ctx *MsgContext, groupID string, 
 		return
 	}
 
-	dice := pa.Session.Parent
+	dice := pa.EndPoint.Session.Parent
 	// 路径可以是 http/base64/本地路径，但 gocq 的文件上传只支持本地文件，所以临时下载到本地
 	fileName, temp, err := message.ExtractLocalTempFile(path)
 

--- a/dice/platform_adapter_gocq_channel.go
+++ b/dice/platform_adapter_gocq_channel.go
@@ -58,10 +58,10 @@ func (pa *PlatformAdapterGocq) QQChannelTrySolve(message string) {
 	if err == nil {
 		// fmt.Println("DDD", message)
 		ep := pa.EndPoint
-		session := pa.Session
+		session := pa.EndPoint.Session
 
 		msg := msgQQ.toStdMessage()
-		ctx := &MsgContext{ /* MessageType: msg.MessageType, EndPoint: ep, Session: pa.Session, */ Dice: pa.Session.Parent}
+		ctx := &MsgContext{ /* MessageType: msg.MessageType, EndPoint: ep, Session: pa.EndPoint.Session, */ Dice: pa.EndPoint.Session.Parent}
 
 		// 消息撤回
 		if msgQQ.PostType == "notice" && msgQQ.NoticeType == "guild_channel_recall" {

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -22,7 +22,6 @@ type HTTPSimpleMessage struct {
 }
 
 type PlatformAdapterHTTP struct {
-	Session       *IMSession
 	EndPoint      *EndPointInfo
 	RecentMessage []HTTPSimpleMessage
 }
@@ -57,7 +56,7 @@ func (pa *PlatformAdapterHTTP) SendToPerson(ctx *MsgContext, uid string, text st
 	for _, sub := range sp {
 		pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, sub, "private"})
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		MessageType: "private",
 		Platform:    "UI",
 		Message:     text,
@@ -73,7 +72,7 @@ func (pa *PlatformAdapterHTTP) SendToGroup(ctx *MsgContext, uid string, text str
 	for _, sub := range sp {
 		pa.RecentMessage = append(pa.RecentMessage, HTTPSimpleMessage{uid, sub, "group"})
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		MessageType: "group",
 		Platform:    "UI",
 		Message:     text,

--- a/dice/platform_adapter_kook.go
+++ b/dice/platform_adapter_kook.go
@@ -128,7 +128,6 @@ type CardMessageModuleFile struct {
 
 // PlatformAdapterKook 与 PlatformAdapterDiscord 基本相同的实现，因此不详细写注释了，可以去参考隔壁的实现
 type PlatformAdapterKook struct {
-	Session       *IMSession    `json:"-"     yaml:"-"`
 	Token         string        `json:"-" yaml:"token"`
 	EndPoint      *EndPointInfo `json:"-"     yaml:"-"`
 	IntentSession *kook.Session `json:"-"     yaml:"-"`
@@ -139,8 +138,8 @@ func (pa *PlatformAdapterKook) GetGroupInfoAsync(groupID string) {
 	if pa.IntentSession == nil {
 		return
 	}
-	logger := pa.Session.Parent.Logger
-	dm := pa.Session.Parent.Parent
+	logger := pa.EndPoint.Session.Parent.Logger
+	dm := pa.EndPoint.Session.Parent.Parent
 	go pa.updateChannelNum()
 	channel, err := pa.IntentSession.ChannelView(ExtractKookChannelID(groupID))
 	if err != nil {
@@ -151,11 +150,11 @@ func (pa *PlatformAdapterKook) GetGroupInfoAsync(groupID string) {
 		Name: channel.Name,
 		time: time.Now().Unix(),
 	})
-	groupInfo, ok := pa.Session.ServiceAtNew.Load(groupID)
+	groupInfo, ok := pa.EndPoint.Session.ServiceAtNew.Load(groupID)
 	if ok {
 		if channel.Name != groupInfo.GroupName {
 			groupInfo.GroupName = channel.Name
-			groupInfo.MarkDirty(pa.Session.Parent)
+			groupInfo.MarkDirty(pa.EndPoint.Session.Parent)
 		}
 	}
 }
@@ -172,7 +171,7 @@ func (pa *PlatformAdapterKook) updateChannelNum() {
 }
 
 func (pa *PlatformAdapterKook) updateGameStatus() {
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	// 注释掉的部分是遗留代码，用于在kook中注册一个叫做SealDice的GameStatus，只需要执行一次因此注释掉
 	// gameupdate := new(kook.GameUpdate)
 	// gameupdate.ID = int64(768222)
@@ -200,7 +199,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 			return
 		}
 		if ctx.Common.Type == kook.MessageTypeKMarkdown || ctx.Common.Type == kook.MessageTypeImage {
-			pa.Session.Execute(pa.EndPoint, pa.toStdMessage(ctx), false)
+			pa.EndPoint.Session.Execute(pa.EndPoint, pa.toStdMessage(ctx), false)
 			return
 		}
 	})
@@ -224,7 +223,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 		}
 		msg.Message = fmt.Sprintf("[CQ:image,file=someimage,url=%s]", ctx.Common.Content)
 		msg.Sender = *send
-		pa.Session.Execute(pa.EndPoint, msg, false)
+		pa.EndPoint.Session.Execute(pa.EndPoint, msg, false)
 	})
 	s.AddHandler(func(ctx *kook.MessageDeleteContext) {
 		msg := new(Message)
@@ -238,9 +237,9 @@ func (pa *PlatformAdapterKook) Serve() int {
 		} else {
 			msg.MessageType = "group"
 		}
-		mctx := &MsgContext{Session: pa.Session, EndPoint: pa.EndPoint, Dice: pa.Session.Parent, MessageType: msg.MessageType}
-		// pa.Session.Parent.Logger.Infof("删除信息#%s(%s)", msg.RawId, msg.GroupId)
-		pa.Session.OnMessageDeleted(mctx, msg)
+		mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
+		// pa.EndPoint.Session.Parent.Logger.Infof("删除信息#%s(%s)", msg.RawId, msg.GroupId)
+		pa.EndPoint.Session.OnMessageDeleted(mctx, msg)
 	})
 
 	s.AddHandler(func(ctx *kook.BotJoinContext) {
@@ -277,7 +276,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 			msg.MessageType = "group"
 		}
 
-		mctx := &MsgContext{Session: pa.Session, EndPoint: pa.EndPoint, Dice: pa.Session.Parent, MessageType: msg.MessageType}
+		mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
 		pa.GetGroupInfoAsync(msg.GroupID)
 		go func() {
 			defer func() {
@@ -336,13 +335,13 @@ func (pa *PlatformAdapterKook) Serve() int {
 		msg.GuildID = FormatDiceIDKookGuild(ctx.Common.TargetID)
 
 		mctx := &MsgContext{
-			Session:     pa.Session,
+			Session:     pa.EndPoint.Session,
 			EndPoint:    pa.EndPoint,
-			Dice:        pa.Session.Parent,
+			Dice:        pa.EndPoint.Session.Parent,
 			MessageType: msg.MessageType,
 			Player:      &GroupPlayerInfo{},
 		}
-		pa.Session.OnMessageEdit(mctx, msg)
+		pa.EndPoint.Session.OnMessageEdit(mctx, msg)
 	})
 
 	err := s.Open()
@@ -358,7 +357,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 	pa.EndPoint.Nickname = self.Nickname
 	pa.EndPoint.UserID = FormatDiceIDKook(self.ID)
 	log.Infof("KOOK 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	return 0
@@ -404,7 +403,7 @@ func (pa *PlatformAdapterKook) SetEnable(enable bool) {
 		_ = pa.IntentSession.Close()
 		pa.IntentSession = nil
 	}
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 }
@@ -429,7 +428,7 @@ func (pa *PlatformAdapterKook) SendToPerson(ctx *MsgContext, userID string, text
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "KOOK",
 		MessageType: "private",
 		Message:     text,
@@ -449,7 +448,7 @@ func (pa *PlatformAdapterKook) SendToGroup(ctx *MsgContext, groupID string, text
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "KOOK",
 		MessageType: "group",
 		Message:     text,
@@ -476,7 +475,7 @@ func (pa *PlatformAdapterKook) SendFileToPerson(ctx *MsgContext, userID string, 
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "KOOK",
 		MessageType: "private",
 		Segment: []message.IMessageElement{
@@ -500,7 +499,7 @@ func (pa *PlatformAdapterKook) SendFileToGroup(ctx *MsgContext, groupID string, 
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "KOOK",
 		MessageType: "group",
 		Segment: []message.IMessageElement{
@@ -647,7 +646,7 @@ func (pa *PlatformAdapterKook) SendToChannelRaw(id string, text string, private 
 		// case *message.FileElement:
 		//	assert, err := bot.AssetCreate(e.File, streamToByte(e.Stream))
 		//	if err != nil {
-		//		pa.Session.Parent.Logger.Errorf("Kook创建asserts时出错:%s", err)
+		//		pa.EndPoint.Session.Parent.Logger.Errorf("Kook创建asserts时出错:%s", err)
 		//		break
 		//	}
 		//	cardModule := CardMessageModuleFile{
@@ -679,7 +678,7 @@ func (pa *PlatformAdapterKook) SendToChannelRaw(id string, text string, private 
 		return nil, err
 	}
 	msgb.Content = string(sendText)
-	// pa.Session.Parent.Logger.Infof("Kook发送消息:%s", msgb.Content)
+	// pa.EndPoint.Session.Parent.Logger.Infof("Kook发送消息:%s", msgb.Content)
 	resp, err := pa.MessageCreateRaw(msgb, id, private)
 	if err != nil {
 		log.Errorf("向Kook频道#%s发送消息时出错:%s", id, err)
@@ -727,7 +726,7 @@ func (pa *PlatformAdapterKook) MessageCreateRaw(base kook.MessageCreateBase, id 
 	}
 	base.TargetID = id
 	resp, err := bot.MessageCreate(&kook.MessageCreate{MessageCreateBase: base})
-	// pa.Session.Parent.Logger.Infof("Kook发送消息返回:%s", ret)
+	// pa.EndPoint.Session.Parent.Logger.Infof("Kook发送消息返回:%s", ret)
 	return resp, err
 }
 

--- a/dice/platform_adapter_kook_helper.go
+++ b/dice/platform_adapter_kook_helper.go
@@ -28,7 +28,7 @@ func ServeKook(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "KOOK" {
 		conn := ep.Adapter.(*PlatformAdapterKook)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		log.Infof("KOOK 尝试连接")
 		if conn.Serve() != 0 {
 			log.Errorf("连接KOOK服务失败")

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -21,7 +21,6 @@ import (
 )
 
 type PlatformAdapterMilky struct {
-	Session             *IMSession     `json:"-"                     yaml:"-"`
 	EndPoint            *EndPointInfo  `json:"-"                     yaml:"-"`
 	IntentSession       *milky.Session `json:"-"                     yaml:"-"`
 	WsGateway           string         `json:"ws_gateway"            yaml:"ws_gateway"`
@@ -60,7 +59,7 @@ func (pa *PlatformAdapterMilky) SendSegmentToGroup(ctx *MsgContext, groupID stri
 		log.Errorf("Failed to send group message to %s: %v", groupID, err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "QQ",
 		MessageType: "group",
 		Segment:     msg,
@@ -86,7 +85,7 @@ func (pa *PlatformAdapterMilky) SendSegmentToPerson(ctx *MsgContext, userID stri
 		log.Errorf("Failed to send private message to %s: %v", userID, err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "QQ",
 		MessageType: "private",
 		Segment:     msg,
@@ -114,12 +113,12 @@ func (pa *PlatformAdapterMilky) GetGroupInfoAsync(groupID string) {
 		log.Warnf("Group info for %s is nil", groupID)
 		return
 	}
-	dm := pa.Session.Parent.Parent
+	dm := pa.EndPoint.Session.Parent.Parent
 	dm.GroupNameCache.Store(groupID, &GroupNameCacheItem{
 		Name: groupInfoMilky.Name,
 		time: time.Now().Unix(),
 	})
-	session := pa.Session
+	session := pa.EndPoint.Session
 	groupInfo, ok := session.ServiceAtNew.Load(groupID)
 	if ok {
 		if groupInfoMilky.Name != groupInfo.GroupName {
@@ -217,7 +216,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		if len(msg.Segment) == 0 {
 			return // 如果没有消息内容，忽略
 		}
-		pa.Session.ExecuteNew(pa.EndPoint, msg)
+		pa.EndPoint.Session.ExecuteNew(pa.EndPoint, msg)
 	})
 	session.AddHandler(func(session2 *milky.Session, m *milky.GroupNudge) {
 		if m == nil {
@@ -232,7 +231,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 				UserID: FormatDiceIDQQ(strconv.FormatInt(m.SenderID, 10)),
 			},
 		}
-		pa.Session.OnPoke(CreateTempCtx(pa.EndPoint, msg), &events.PokeEvent{
+		pa.EndPoint.Session.OnPoke(CreateTempCtx(pa.EndPoint, msg), &events.PokeEvent{
 			GroupID:   msg.GroupID,
 			SenderID:  msg.Sender.UserID,
 			TargetID:  FormatDiceIDQQ(strconv.FormatInt(m.ReceiverID, 10)),
@@ -260,7 +259,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		} else {
 			event.TargetID = msg.Sender.UserID
 		}
-		pa.Session.OnPoke(CreateTempCtx(pa.EndPoint, msg), event)
+		pa.EndPoint.Session.OnPoke(CreateTempCtx(pa.EndPoint, msg), event)
 	})
 	session.AddHandler(func(session2 *milky.Session, m *milky.GroupMemberDecrease) {
 		if m == nil {
@@ -279,14 +278,14 @@ func (pa *PlatformAdapterMilky) Serve() int {
 			log.Infof("Bot has left group %s", msg.GroupID)
 			if m.OperatorID == 0 {
 				log.Debugf("Bot left group %s without an operator ID, treating as a normal leave", msg.GroupID)
-				pa.Session.OnGroupLeave(CreateTempCtx(pa.EndPoint, msg), &events.GroupLeaveEvent{
+				pa.EndPoint.Session.OnGroupLeave(CreateTempCtx(pa.EndPoint, msg), &events.GroupLeaveEvent{
 					GroupID:    msg.GroupID,
 					UserID:     pa.EndPoint.UserID,
 					OperatorID: "",
 				})
 			} else {
 				log.Debugf("Bot left group %s with operator ID %d", msg.GroupID, m.OperatorID)
-				pa.Session.OnGroupLeave(CreateTempCtx(pa.EndPoint, msg), &events.GroupLeaveEvent{
+				pa.EndPoint.Session.OnGroupLeave(CreateTempCtx(pa.EndPoint, msg), &events.GroupLeaveEvent{
 					GroupID:    msg.GroupID,
 					UserID:     pa.EndPoint.UserID,
 					OperatorID: FormatDiceIDQQ(strconv.FormatInt(m.OperatorID, 10)),
@@ -295,7 +294,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		}
 	})
 	session.AddHandler(func(session2 *milky.Session, m *milky.GroupMemberIncrease) {
-		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.Session, Dice: pa.Session.Parent}
+		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
 		inviterID := FormatDiceIDQQ(strconv.FormatInt(m.InvitorID, 10))
 		msg := &Message{
 			Time:        time.Now().Unix(),
@@ -309,19 +308,19 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		newMemberUID := FormatDiceIDQQ(strconv.FormatInt(m.UserID, 10))
 		// 自己加群
 		if newMemberUID == pa.EndPoint.UserID {
-			pa.Session.OnGroupJoined(ctx, msg)
+			pa.EndPoint.Session.OnGroupJoined(ctx, msg)
 		} else {
 			// 其他人被邀请加群
 			msg.Sender.UserID = newMemberUID
-			pa.Session.OnGroupMemberJoined(ctx, msg)
+			pa.EndPoint.Session.OnGroupMemberJoined(ctx, msg)
 		}
 	})
 	session.AddHandler(func(session *milky.Session, m *milky.GroupMute) {
 		if m == nil {
 			return
 		}
-		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.Session, Dice: pa.Session.Parent}
-		dm := pa.Session.Parent.Parent
+		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
+		dm := pa.EndPoint.Session.Parent.Parent
 		groupId := FormatDiceIDQQGroup(strconv.FormatInt(m.GroupID, 10))
 		if FormatDiceIDQQ(strconv.FormatInt(m.UserID, 10)) == pa.EndPoint.UserID {
 			opUID := FormatDiceIDQQ(strconv.FormatInt(m.OperatorID, 10))
@@ -336,16 +335,16 @@ func (pa *PlatformAdapterMilky) Serve() int {
 	})
 	session.AddHandler(func(session2 *milky.Session, m *milky.FriendRequest) {
 		if m != nil {
-			ctx := &MsgContext{MessageType: "private", EndPoint: pa.EndPoint, Session: pa.Session, Dice: pa.Session.Parent}
+			ctx := &MsgContext{MessageType: "private", EndPoint: pa.EndPoint, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
 			pa.handelFriendRequest(ctx, m)
 		}
 	})
 	session.AddHandler(func(session2 *milky.Session, m *milky.GroupInvitation) {
-		dm := pa.Session.Parent.Parent
+		dm := pa.EndPoint.Session.Parent.Parent
 		if m == nil {
 			return
 		}
-		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.Session, Dice: pa.Session.Parent}
+		ctx := &MsgContext{MessageType: "group", EndPoint: pa.EndPoint, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
 		uid := FormatDiceIDQQ(strconv.FormatInt(m.InitiatorID, 10))
 		groupId := FormatDiceIDQQGroup(strconv.FormatInt(m.GroupID, 10))
 		groupName := dm.TryGetGroupName(groupId)
@@ -409,10 +408,10 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		default:
 			return
 		}
-		mctx := &MsgContext{Session: pa.Session, EndPoint: pa.EndPoint, Dice: pa.Session.Parent, MessageType: msg.MessageType}
-		pa.Session.OnMessageDeleted(mctx, msg)
+		mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
+		pa.EndPoint.Session.OnMessageDeleted(mctx, msg)
 	})
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	err = pa.IntentSession.Open()
 	if err != nil {
 		log.Errorf("Failed to open Milky session: %v", err)
@@ -469,7 +468,7 @@ func (pa *PlatformAdapterMilky) handelFriendRequest(ctx *MsgContext, event *milk
 		comment = normalizeMilkyFriendRequestComment(event.Comment)
 	}
 
-	toMatch := strings.TrimSpace(pa.Session.Parent.Config.FriendAddComment)
+	toMatch := strings.TrimSpace(pa.EndPoint.Session.Parent.Config.FriendAddComment)
 	willAccept := comment == DiceFormat(ctx, toMatch)
 	if toMatch == "" {
 		willAccept = true
@@ -658,7 +657,7 @@ func (pa *PlatformAdapterMilky) DoRelogin() bool {
 		}
 		pa.EndPoint.State = 1
 		pa.EndPoint.Enable = true
-		d := pa.Session.Parent
+		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 		return true
@@ -669,9 +668,9 @@ func (pa *PlatformAdapterMilky) DoRelogin() bool {
 		_ = pa.IntentSession.Close()
 	}
 	// kill
-	BuiltinMilkyClientKill(pa.Session.Parent, pa.EndPoint)
-	MilkyRemoveSession(pa.Session.Parent, pa.EndPoint)
-	go ServeMilkyBuiltIn(pa.Session.Parent, pa.EndPoint)
+	BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
+	MilkyRemoveSession(pa.EndPoint.Session.Parent, pa.EndPoint)
+	go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
 	return true
 }
 
@@ -706,21 +705,21 @@ func (pa *PlatformAdapterMilky) SetEnable(enable bool) {
 			pa.EndPoint.Enable = false
 			_ = pa.IntentSession.Close()
 		}
-		d := pa.Session.Parent
+		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 		return
 	}
 	if enable {
-		go ServeMilkyBuiltIn(pa.Session.Parent, pa.EndPoint)
+		go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
 	} else {
 		if pa.IntentSession != nil {
 			_ = pa.IntentSession.Close()
 		}
-		BuiltinMilkyClientKill(pa.Session.Parent, pa.EndPoint)
+		BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
 		pa.EndPoint.State = 0
 		pa.EndPoint.Enable = false
-		d := pa.Session.Parent
+		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 	}
@@ -771,7 +770,7 @@ func (pa *PlatformAdapterMilky) SendToPerson(ctx *MsgContext, uid string, text s
 		log.Errorf("Failed to send private message to %s: %v", uid, err)
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "QQ",
 		MessageType: "private",
 		Message:     text,
@@ -816,7 +815,7 @@ func (pa *PlatformAdapterMilky) SendToGroup(ctx *MsgContext, groupID string, tex
 			}
 		}
 	}()
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "QQ",
 		MessageType: "group",
 		Message:     text,

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -181,9 +181,7 @@ func ServeMilky(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" {
 		conn := ep.Adapter.(*PlatformAdapterMilky)
-		conn.EndPoint = ep
-		conn.Session = d.ImSession
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Milky 尝试连接")
 		if conn.Serve() != 0 {
 			d.Logger.Errorf("连接Milky失败")
@@ -258,9 +256,7 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		}
 	}
 	pa := conn
-	conn.EndPoint = ep
-	conn.Session = d.ImSession
-	ep.Session = d.ImSession
+	ep.BindRuntime(d.ImSession)
 	log := zap.S().Named(logger.LogKeyAdapter)
 
 	workDir := filepath.Join(d.BaseConfig.DataDir, ep.RelWorkDir)

--- a/dice/platform_adapter_minecraft.go
+++ b/dice/platform_adapter_minecraft.go
@@ -12,7 +12,6 @@ import (
 )
 
 type PlatformAdapterMinecraft struct {
-	Session      *IMSession          `json:"-"          yaml:"-"`
 	EndPoint     *EndPointInfo       `json:"-"          yaml:"-"`
 	Socket       *gowebsocket.Socket `json:"-"          yaml:"-"`
 	RetryTimes   int                 `json:"-"          yaml:"-"`
@@ -50,7 +49,7 @@ func (pa *PlatformAdapterMinecraft) Serve() int {
 	pa.Socket = &socket
 	pa.EndPoint.Nickname = "A Minecraft Server"
 	pa.EndPoint.UserID = "WebSocket"
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	pa.socketSetup()
@@ -59,7 +58,7 @@ func (pa *PlatformAdapterMinecraft) Serve() int {
 }
 
 func (pa *PlatformAdapterMinecraft) tryReconnect(socket gowebsocket.Socket) bool {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	if pa.Reconnecting {
 		return false
 	}
@@ -77,7 +76,7 @@ func (pa *PlatformAdapterMinecraft) tryReconnect(socket gowebsocket.Socket) bool
 
 func (pa *PlatformAdapterMinecraft) socketSetup() {
 	ep := pa.EndPoint
-	log := pa.Session.Parent.Logger
+	log := ep.Session.Parent.Logger
 	socket := pa.Socket
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		pa.Reconnecting = true
@@ -85,7 +84,7 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		ep.Enable = true
 		pa.RetryTimes = 0
 
-		d := pa.Session.Parent
+		d := ep.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 
@@ -97,7 +96,7 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		msgMC := new(MessageMinecraft)
 		err := json.Unmarshal([]byte(message), msgMC)
 		if err == nil {
-			pa.Session.Execute(ep, pa.toStdMessage(msgMC), false)
+			ep.Session.Execute(ep, pa.toStdMessage(msgMC), false)
 		}
 	}
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
@@ -154,7 +153,7 @@ func ExtractMCUserID(id string) string {
 }
 
 func (pa *PlatformAdapterMinecraft) DoRelogin() bool {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	pa.Reconnecting = true
 	pa.Socket.Close()
 	socket := gowebsocket.New(pa.ConnectURL)
@@ -167,7 +166,7 @@ func (pa *PlatformAdapterMinecraft) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterMinecraft) SetEnable(enable bool) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	if enable {
 		log.Infof("MC server 连接中")
 		if pa.Socket != nil && pa.Socket.IsConnected {
@@ -209,7 +208,7 @@ func (pa *PlatformAdapterMinecraft) SendToPerson(ctx *MsgContext, uid string, te
 	msg.MessageType = "private"
 	parse, _ := json.Marshal(msg)
 	pa.Socket.SendText(string(parse))
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "MC",
 		MessageType: "private",
 		Message:     text,
@@ -226,7 +225,7 @@ func (pa *PlatformAdapterMinecraft) SendToGroup(ctx *MsgContext, uid string, tex
 	msg.MessageType = "group"
 	parse, _ := json.Marshal(msg)
 	pa.Socket.SendText(string(parse))
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "MC",
 		MessageType: "group",
 		Message:     text,

--- a/dice/platform_adapter_minecraft_helper.go
+++ b/dice/platform_adapter_minecraft_helper.go
@@ -20,7 +20,7 @@ func ServeMinecraft(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "MC" {
 		conn := ep.Adapter.(*PlatformAdapterMinecraft)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Minecraft 尝试连接")
 		conn.Serve()
 	}

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -21,7 +21,6 @@ import (
 )
 
 type PlatformAdapterOfficialQQ struct {
-	Session     *IMSession    `json:"-" yaml:"-"`
 	EndPoint    *EndPointInfo `json:"-" yaml:"-"`
 	DiceServing bool          `yaml:"-"`
 
@@ -38,9 +37,9 @@ type PlatformAdapterOfficialQQ struct {
 
 func (pa *PlatformAdapterOfficialQQ) Serve() int {
 	ep := pa.EndPoint
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 
 	if pa.Ctx != nil {
 		log.Info("official qq session already running, skip Serve")
@@ -153,7 +152,7 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 }
 
 func (pa *PlatformAdapterOfficialQQ) ChannelAtMessageReceive(event *dto.WSPayload, data *dto.WSATMessageData) error {
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
 	log.Debugf("official qq: 收到文字频道消息：%v, %v", event, data)
 
@@ -181,7 +180,7 @@ func (pa *PlatformAdapterOfficialQQ) channelMsgToStdMsg(msgQQ *dto.WSATMessageDa
 }
 
 func (pa *PlatformAdapterOfficialQQ) GuildDirectMessageReceive(event *dto.WSPayload, data *dto.WSDirectMessageData) error {
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
 	log.Debugf("official qq: 收到频道私信消息：%v, %v", event, data)
 
@@ -209,7 +208,7 @@ func (pa *PlatformAdapterOfficialQQ) guildDirectMsgToStdMsg(msgQQ *dto.WSDirectM
 }
 
 func (pa *PlatformAdapterOfficialQQ) GroupAtMessageReceive(event *dto.WSPayload, data *dto.WSGroupATMessageData) error {
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
 	log.Debugf("official qq: 收到群聊消息：%v, %v", event, data)
 
@@ -236,7 +235,7 @@ func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(msgQQ *dto.WSGroupATMessag
 }
 func (pa *PlatformAdapterOfficialQQ) DoRelogin() bool {
 	pa.CancelFunc()
-	pa.Session.Parent.Logger.Infof("正在启用 official qq 服务")
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 official qq 服务")
 	pa.EndPoint.State = 0
 	pa.EndPoint.Enable = false
 	pa.Api = nil
@@ -247,7 +246,7 @@ func (pa *PlatformAdapterOfficialQQ) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterOfficialQQ) SetEnable(enable bool) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
 	if enable {
 		if pa.Ctx == nil {
@@ -281,7 +280,7 @@ func (pa *PlatformAdapterOfficialQQ) SendToPerson(ctx *MsgContext, uid string, t
 	userID, idType := pa.mustExtractID(uid)
 	if idType != OpenQQCHUser {
 		// 说明不是频道信息
-		pa.Session.Parent.Logger.Error("official qq 发送私聊消息失败：不支持该功能")
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 发送私聊消息失败：不支持该功能")
 		return
 	}
 	channelID, guildID, _ := pa.mustExtractTwoID(ctx.Group.ChannelID)
@@ -290,7 +289,7 @@ func (pa *PlatformAdapterOfficialQQ) SendToPerson(ctx *MsgContext, uid string, t
 		// 需要主动发起私聊
 		g, c, err := pa.createQQGuildDirectChannel(ctx, guildID, userID)
 		if err != nil {
-			pa.Session.Parent.Logger.Error("official qq 发送频道私信消息失败：", err.Error())
+			pa.EndPoint.Session.Parent.Logger.Error("official qq 发送频道私信消息失败：", err.Error())
 			return
 		}
 		guildID = g
@@ -302,7 +301,7 @@ func (pa *PlatformAdapterOfficialQQ) SendToPerson(ctx *MsgContext, uid string, t
 func (pa *PlatformAdapterOfficialQQ) createQQGuildDirectChannel( /* ctx */ _ *MsgContext, guildID, userID string) (string, string, error) {
 	if guildID == "" || userID == "" {
 		err := errors.New("创建私信频道的参数不全")
-		pa.Session.Parent.Logger.Error("official qq 创建私信频道失败：" + err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 创建私信频道失败：" + err.Error())
 		return "", "", err
 	}
 	qctx := context.Background()
@@ -312,7 +311,7 @@ func (pa *PlatformAdapterOfficialQQ) createQQGuildDirectChannel( /* ctx */ _ *Ms
 	}
 	info, err := pa.Api.CreateDirectMessage(qctx, toCreate)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("official qq 创建私信频道失败：" + err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 创建私信频道失败：" + err.Error())
 		return "", "", err
 	}
 	return info.GuildID, info.ChannelID, nil
@@ -344,7 +343,7 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGuildDirectMsgRaw( /* ctx */ _ *MsgCo
 		MsgID:   rowMsgID,
 	}
 	if _, err := pa.Api.PostDirectMessage(qctx, dMsg, toCreate); err != nil {
-		pa.Session.Parent.Logger.Error("official qq 发送频道私信消息失败：" + err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 发送频道私信消息失败：" + err.Error())
 	}
 }
 
@@ -352,7 +351,7 @@ func (pa *PlatformAdapterOfficialQQ) SendToGroup(ctx *MsgContext, uid string, te
 	rowID, ok := VarGetValueStr(ctx, "$tMsgID")
 	if !ok {
 		// TODO：允许主动消息发送，并校验频率
-		pa.Session.Parent.Logger.Error("official qq 发送群聊消息失败：无法直接发送消息")
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 发送群聊消息失败：无法直接发送消息")
 		return
 	}
 	groupId, idType := pa.mustExtractID(uid)
@@ -362,7 +361,7 @@ func (pa *PlatformAdapterOfficialQQ) SendToGroup(ctx *MsgContext, uid string, te
 	case OpenQQCHChannel:
 		pa.sendQQChannelMsgRaw(ctx, rowID, groupId, text)
 	default:
-		pa.Session.Parent.Logger.Errorf("official qq 发送群聊消息失败：错误的群聊id[%s]类型-%d", uid, idType)
+		pa.EndPoint.Session.Parent.Logger.Errorf("official qq 发送群聊消息失败：错误的群聊id[%s]类型-%d", uid, idType)
 		return
 	}
 }
@@ -385,14 +384,14 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw( /* ctx */ _ *MsgContext,
 			// QQ官方API中不能发送链接，所以全部进行转写绕过
 			content += textLinkStrip(elem.Content)
 		case *message.AtElement:
-			pa.Session.Parent.Logger.Warn("official qq 群聊消息暂不支持 AT 他人，跳过该部分")
+			pa.EndPoint.Session.Parent.Logger.Warn("official qq 群聊消息暂不支持 AT 他人，跳过该部分")
 		case *message.ImageElement:
 			url := elem.File.URL
 			// 目前不支持本地发送，检查一下url
 			if url == "" ||
 				strings.Contains(url, "localhost") ||
 				strings.Contains(url, "127.0.0.1") {
-				pa.Session.Parent.Logger.Warn("official qq 群聊消息暂不支持发送本地图片，跳过该部分")
+				pa.EndPoint.Session.Parent.Logger.Warn("official qq 群聊消息暂不支持发送本地图片，跳过该部分")
 			}
 			fMsg := &dto.MessageMediaToCreate{
 				FileType:   1,
@@ -401,7 +400,7 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw( /* ctx */ _ *MsgContext,
 			}
 			media, err := pa.Api.PostGroupFile(qctx, groupID, fMsg)
 			if err != nil {
-				pa.Session.Parent.Logger.Error("official qq 发送群聊消息时，准备图片信息失败：" + err.Error())
+				pa.EndPoint.Session.Parent.Logger.Error("official qq 发送群聊消息时，准备图片信息失败：" + err.Error())
 				continue
 			}
 
@@ -415,7 +414,7 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw( /* ctx */ _ *MsgContext,
 			if url == "" ||
 				strings.Contains(url, "localhost") ||
 				strings.Contains(url, "127.0.0.1") {
-				pa.Session.Parent.Logger.Warn("official qq 群聊消息暂不支持发送本地语音，跳过该部分")
+				pa.EndPoint.Session.Parent.Logger.Warn("official qq 群聊消息暂不支持发送本地语音，跳过该部分")
 			}
 			fMsg := &dto.MessageMediaToCreate{
 				FileType:   3,
@@ -424,7 +423,7 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw( /* ctx */ _ *MsgContext,
 			}
 			media, err := pa.Api.PostGroupFile(qctx, groupID, fMsg)
 			if err != nil {
-				pa.Session.Parent.Logger.Error("official qq 发送群聊消息时，准备语音信息失败：" + err.Error())
+				pa.EndPoint.Session.Parent.Logger.Error("official qq 发送群聊消息时，准备语音信息失败：" + err.Error())
 				continue
 			}
 
@@ -438,7 +437,7 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw( /* ctx */ _ *MsgContext,
 	toCreate.Content = content
 
 	if _, err := pa.Api.PostGroupMessage(qctx, groupID, toCreate); err != nil {
-		pa.Session.Parent.Logger.Error("official qq 发送群聊消息失败：" + err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 发送群聊消息失败：" + err.Error())
 	}
 }
 
@@ -471,13 +470,13 @@ func (pa *PlatformAdapterOfficialQQ) sendQQChannelMsgRaw( /* ctx */ _ *MsgContex
 		MsgID:   rowMsgID,
 	}
 	if _, err := pa.Api.PostMessage(qctx, channelID, toCreate); err != nil {
-		pa.Session.Parent.Logger.Error("official qq 发送频道消息失败：" + err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("official qq 发送频道消息失败：" + err.Error())
 	}
 }
 
 func (pa *PlatformAdapterOfficialQQ) GetGroupInfoAsync(groupID string) {
 	// 警告太频繁了，拿掉
-	// pa.Session.Parent.Logger.Infof("official qq 更新群信息失败：不支持该功能")
+	// pa.EndPoint.Session.Parent.Logger.Infof("official qq 更新群信息失败：不支持该功能")
 }
 
 func formatDiceIDOfficialQQCh(userID string) string {
@@ -562,19 +561,19 @@ func (pa *PlatformAdapterOfficialQQ) SendFileToGroup(ctx *MsgContext, uid string
 }
 
 func (pa *PlatformAdapterOfficialQQ) QuitGroup(_ *MsgContext, _ string) {
-	pa.Session.Parent.Logger.Error("official qq 退出群组失败：不支持该功能")
+	pa.EndPoint.Session.Parent.Logger.Error("official qq 退出群组失败：不支持该功能")
 }
 
 func (pa *PlatformAdapterOfficialQQ) SetGroupCardName(_ *MsgContext, _ string) {
-	pa.Session.Parent.Logger.Error("official qq 修改名片失败：不支持该功能")
+	pa.EndPoint.Session.Parent.Logger.Error("official qq 修改名片失败：不支持该功能")
 }
 
 func (pa *PlatformAdapterOfficialQQ) MemberBan(_ string, _ string, _ int64) {
-	pa.Session.Parent.Logger.Error("official qq 禁言用户失败：不支持该功能")
+	pa.EndPoint.Session.Parent.Logger.Error("official qq 禁言用户失败：不支持该功能")
 }
 
 func (pa *PlatformAdapterOfficialQQ) MemberKick(_ string, _ string) {
-	pa.Session.Parent.Logger.Error("official qq 踢出用户失败：不支持该功能")
+	pa.EndPoint.Session.Parent.Logger.Error("official qq 踢出用户失败：不支持该功能")
 }
 
 func (pa *PlatformAdapterOfficialQQ) EditMessage(_ *MsgContext, _, _ string) {}

--- a/dice/platform_adapter_official_qq_helper.go
+++ b/dice/platform_adapter_official_qq_helper.go
@@ -35,7 +35,7 @@ func ServerOfficialQQ(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" && ep.ProtocolType == "official" {
 		conn := ep.Adapter.(*PlatformAdapterOfficialQQ)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("official qq 尝试连接")
 		if conn.Serve() != 0 {
 			d.Logger.Infof("official qq 连接失败")

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -29,7 +29,6 @@ import (
 )
 
 type PlatformAdapterOnebot struct {
-	Session             *IMSession    `json:"-"                     yaml:"-"`
 	EndPoint            *EndPointInfo `json:"-"                     yaml:"-"`
 	Token               string        `json:"token"                 yaml:"token"`                 // 正向或者反向时，使用的Token
 	ConnectURL          string        `json:"connectUrl"            yaml:"connectUrl"`            // 正向时 连接地址
@@ -155,9 +154,10 @@ func (p *PlatformAdapterOnebot) SendGroupForwardMsg(ctx *MsgContext, groupID str
 		GroupID:  rawGroupID,
 		Messages: nodes,
 	})
-	if err == nil && p.Session != nil {
+	session := p.EndPoint.Session
+	if err == nil && session != nil {
 		sendText := forwardNodesToText(nodes)
-		p.Session.OnMessageSend(ctx, &Message{
+		session.OnMessageSend(ctx, &Message{
 			Platform:    "QQ",
 			MessageType: "group",
 			GroupID:     groupID,
@@ -196,9 +196,10 @@ func (p *PlatformAdapterOnebot) SendPrivateForwardMsg(ctx *MsgContext, userID st
 		UserID:   rawUserID,
 		Messages: nodes,
 	})
-	if err == nil && p.Session != nil {
+	session := p.EndPoint.Session
+	if err == nil && session != nil {
 		sendText := forwardNodesToText(nodes)
-		p.Session.OnMessageSend(ctx, &Message{
+		session.OnMessageSend(ctx, &Message{
 			Platform:    "QQ",
 			MessageType: "private",
 			Message:     sendText,
@@ -241,11 +242,12 @@ func (p *PlatformAdapterOnebot) SendSegmentToGroup(ctx *MsgContext, groupID stri
 	sentSegments := make([]message.IMessageElement, 0, len(msg))
 
 	defer func() {
-		if !sentAnything || p.Session == nil || p.EndPoint == nil {
+		session := p.EndPoint.Session
+		if !sentAnything || session == nil || p.EndPoint == nil {
 			return
 		}
 		_, sentMsgText := convertSealMsgToMessageChain(sentSegments)
-		p.Session.OnMessageSend(ctx, &Message{
+		session.OnMessageSend(ctx, &Message{
 			Platform:    "QQ",
 			MessageType: "group",
 			GroupID:     groupID,
@@ -340,11 +342,12 @@ func (p *PlatformAdapterOnebot) SendSegmentToPerson(ctx *MsgContext, userID stri
 	sentSegments := make([]message.IMessageElement, 0, len(msg))
 
 	defer func() {
-		if !sentAnything || p.Session == nil || p.EndPoint == nil {
+		session := p.EndPoint.Session
+		if !sentAnything || session == nil || p.EndPoint == nil {
 			return
 		}
 		_, sentMsgText := convertSealMsgToMessageChain(sentSegments)
-		p.Session.OnMessageSend(ctx, &Message{
+		session.OnMessageSend(ctx, &Message{
 			Platform:    "QQ",
 			MessageType: "private",
 			Segment:     sentSegments,
@@ -435,7 +438,8 @@ func (p *PlatformAdapterOnebot) GetGroupInfoAsync(groupID string) {
 
 func (p *PlatformAdapterOnebot) GetGroupInfoSync(diceGroupID string) *GroupCache {
 	// TODO：去掉这个MsgContext的需求 以及这个函数设计的一坨
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	rawGroupID := ExtractQQEmitterGroupID(diceGroupID)
 	groupInfoResp, err := p.sendEmitter.GetGroupInfo(p.ctx, rawGroupID, true)
 	if err != nil {
@@ -452,25 +456,25 @@ func (p *PlatformAdapterOnebot) GetGroupInfoSync(diceGroupID string) *GroupCache
 		MaxMemberCount: groupInfoResp.MaxMemberCount,
 	}
 	_ = p.groupCache.Set(diceGroupID, result)
-	p.Session.Parent.Parent.GroupNameCache.Store(diceGroupID, &GroupNameCacheItem{
+	session.Parent.Parent.GroupNameCache.Store(diceGroupID, &GroupNameCacheItem{
 		Name: result.GroupName,
 		time: time.Now().Unix(),
 	})
 	// 存储群组相关信息
-	groupInfo, ok := p.Session.ServiceAtNew.Load(diceGroupID)
+	groupInfo, ok := session.ServiceAtNew.Load(diceGroupID)
 	if !ok {
 		return result
 	}
 	// 群名有更新的情况
 	if result.GroupName != groupInfo.GroupName {
 		groupInfo.GroupName = result.GroupName
-		groupInfo.MarkDirty(p.Session.Parent)
+		groupInfo.MarkDirty(session.Parent)
 	}
 	// 群信息获取不到，可能退群的情况，删除群信息
 	if result.MaxMemberCount == 0 {
 		if _, exists := groupInfo.DiceIDExistsMap.Load(p.EndPoint.UserID); exists {
 			groupInfo.DiceIDExistsMap.Delete(p.EndPoint.UserID)
-			groupInfo.MarkDirty(p.Session.Parent)
+			groupInfo.MarkDirty(session.Parent)
 		}
 	}
 	// 发现群情况不对，可能要退群的情况。 放在这里是因为可能这个群已经被邀请进入了
@@ -904,10 +908,11 @@ func (p *PlatformAdapterOnebot) retryConnect() {
 }
 
 func (p *PlatformAdapterOnebot) updateAndSave() {
-	if p.Session == nil || p.Session.Parent == nil {
+	session := p.EndPoint.Session
+	if session == nil || session.Parent == nil {
 		return
 	}
-	d := p.Session.Parent
+	d := session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 }

--- a/dice/platform_adapter_onebot_helper.go
+++ b/dice/platform_adapter_onebot_helper.go
@@ -39,8 +39,7 @@ func ServePureOnebot(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" {
 		conn := ep.Adapter.(*PlatformAdapterOnebot)
-		conn.EndPoint = ep
-		conn.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Pure Onebot V11尝试连接")
 		if conn.Serve() != 0 {
 			d.Logger.Errorf("连接Pure Onebot V11失败")

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -151,7 +151,6 @@ func newPureOnebotTestAdapter(t *testing.T) (*Dice, *PlatformAdapterOnebot, *one
 	d, ep, _, cleanup := newExecuteNewTestDice(t)
 	d.ExtList = nil
 	pa := &PlatformAdapterOnebot{
-		Session:  d.ImSession,
 		EndPoint: ep,
 		ctx:      t.Context(),
 		logger:   d.Logger,
@@ -257,7 +256,7 @@ func TestPureOnebotGroupInviteRejectStopsWithoutApprove(t *testing.T) {
 		"group_id":"66666"
 	}`)
 
-	pa.Session.Parent.Config.RefuseGroupInvite = true
+	pa.EndPoint.Session.Parent.Config.RefuseGroupInvite = true
 
 	if err := pa.handleReqGroupAction(req, nil); err != nil {
 		t.Fatalf("handleReqGroupAction returned error: %v", err)
@@ -725,7 +724,7 @@ func TestPureOnebotHandleJoinGroupStoresInviterForSelfJoin(t *testing.T) {
 		t.Fatalf("handleJoinGroupAction returned error: %v", err)
 	}
 
-	group, ok := pa.Session.ServiceAtNew.Load("QQ-Group:66666")
+	group, ok := pa.EndPoint.Session.ServiceAtNew.Load("QQ-Group:66666")
 	if !ok {
 		t.Fatalf("expected group to be initialized")
 	}

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -87,12 +87,13 @@ func (p *PlatformAdapterOnebot) onOnebotMessageEvent(ep *evsocket.EventPayload) 
 		p.logger.Errorf("收到消息但无法进行处理，原因为 %s", err)
 		return
 	}
+	session := p.EndPoint.Session
 	// 注册消息发送人的缓存，以兼容dice_manager
 	if msg.Sender.UserID != "" && msg.Sender.Nickname != "" {
-		p.Session.Parent.Parent.UserNameCache.Store(msg.Sender.UserID, &GroupNameCacheItem{Name: msg.Sender.Nickname, time: time.Now().Unix()})
+		session.Parent.Parent.UserNameCache.Store(msg.Sender.UserID, &GroupNameCacheItem{Name: msg.Sender.Nickname, time: time.Now().Unix()})
 	}
 
-	p.Session.ExecuteNew(p.EndPoint, msg)
+	session.ExecuteNew(p.EndPoint, msg)
 }
 
 func (p *PlatformAdapterOnebot) onOnebotRequestEvent(ep *evsocket.EventPayload) {
@@ -130,11 +131,12 @@ func (p *PlatformAdapterOnebot) OnebotNoticeEvent(ep *evsocket.EventPayload) {
 }
 
 func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *evsocket.EventPayload) error {
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	subType := req.Get("sub_type").String()
 	switch subType {
 	case "kick_me":
-		p.Session.OnGroupLeave(ctx, &events.GroupLeaveEvent{
+		session.OnGroupLeave(ctx, &events.GroupLeaveEvent{
 			GroupID:    canonicalOnebotGroupID(req.Get("group_id").String()),
 			UserID:     canonicalOnebotUserID(req.Get("user_id").String()),
 			OperatorID: canonicalOnebotUserID(req.Get("operator_id").String()),
@@ -149,22 +151,22 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 			return nil
 		}
 		groupId := canonicalOnebotGroupID(req.Get("group_id").String())
-		pendingQuit := p.Session.ConsumePendingQuit(groupId, p.EndPoint.UserID)
-		groupName := p.Session.Parent.Parent.TryGetGroupName(groupId)
+		pendingQuit := session.ConsumePendingQuit(groupId, p.EndPoint.UserID)
+		groupName := session.Parent.Parent.TryGetGroupName(groupId)
 		txt := fmt.Sprintf("离开群组或群解散: <%s>(%s)", groupName, groupId)
-		group, exists := p.Session.ServiceAtNew.Load(groupId)
+		group, exists := session.ServiceAtNew.Load(groupId)
 		if !exists {
 			txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, groupId)
 			p.logger.Error(txtErr)
-			if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !p.Session.Parent.Config.QuitInactiveNoticeSummaryMode {
+			if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
 				ctx.Notice(txtErr)
 			}
 			return nil
 		}
 		group.DiceIDExistsMap.Delete(p.EndPoint.UserID)
-		group.MarkDirty(p.Session.Parent)
+		group.MarkDirty(session.Parent)
 		p.logger.Info(txt)
-		if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !p.Session.Parent.Config.QuitInactiveNoticeSummaryMode {
+		if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
 			ctx.Notice(txt)
 		}
 	}
@@ -174,14 +176,15 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 
 func (p *PlatformAdapterOnebot) handleGroupPokeAction(req gjson.Result, _ *evsocket.EventPayload) error {
 	go func() {
-		defer ErrorLogAndContinue(p.Session.Parent)
+		session := p.EndPoint.Session
+		defer ErrorLogAndContinue(session.Parent)
 		msgContext := p.makeCtx(req)
 		isPrivate := msgContext.MessageType == "private"
 		groupID := ""
 		if req.Get("group_id").Exists() {
 			groupID = FormatDiceIDQQGroup(req.Get("group_id").String())
 		}
-		p.Session.OnPoke(msgContext, &events.PokeEvent{
+		session.OnPoke(msgContext, &events.PokeEvent{
 			GroupID:   groupID,
 			SenderID:  FormatDiceIDQQ(req.Get("user_id").String()),
 			TargetID:  FormatDiceIDQQ(req.Get("target_id").String()),
@@ -192,17 +195,19 @@ func (p *PlatformAdapterOnebot) handleGroupPokeAction(req gjson.Result, _ *evsoc
 }
 
 func (p *PlatformAdapterOnebot) handleGroupRecallAction(_ gjson.Result, ep *evsocket.EventPayload) error {
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	msg, err := arrayByte2SealdiceMessage(p.logger, ep.Data)
 	if err != nil {
 		return err
 	}
-	p.Session.OnMessageDeleted(ctx, msg)
+	session.OnMessageDeleted(ctx, msg)
 	return nil
 }
 
 func (p *PlatformAdapterOnebot) handleGroupBanAction(req gjson.Result, _ *evsocket.EventPayload) error {
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	subType := req.Get("sub_type").String()
 	userID := canonicalOnebotUserID(req.Get("user_id").String())
 	selfID := canonicalOnebotUserID(req.Get("self_id").String())
@@ -213,8 +218,8 @@ func (p *PlatformAdapterOnebot) handleGroupBanAction(req gjson.Result, _ *evsock
 	switch subType {
 	case "ban":
 		if userID == selfID {
-			groupName := p.Session.Parent.Parent.TryGetGroupName(groupId)
-			userName := p.Session.Parent.Parent.TryGetUserName(operatorID)
+			groupName := session.Parent.Parent.TryGetGroupName(groupId)
+			userName := session.Parent.Parent.TryGetUserName(operatorID)
 			ctx.Dice.Config.BanList.AddScoreByGroupMuted(operatorID, groupId, ctx)
 			txt := fmt.Sprintf("被禁言: 在群组<%s>(%s)中被禁言，时长%d秒，操作者:<%s>(%s)", groupName, groupId, duration, userName, operatorID)
 			p.logger.Info(txt)
@@ -225,7 +230,8 @@ func (p *PlatformAdapterOnebot) handleGroupBanAction(req gjson.Result, _ *evsock
 }
 
 func (p *PlatformAdapterOnebot) handleAddFriendAction(req gjson.Result, _ *evsocket.EventPayload) error {
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	msg, err := arrayByte2SealdiceMessage(p.logger, []byte(req.String()))
 	if err != nil {
 		return err
@@ -259,7 +265,8 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 	// 入群要做的事情：
 	// 1. 如果发现进群的是自己，要和大家发入群致辞
 	// 2. 如果发现进群的不是自己，对他进行节流的迎新
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	msg, err := arrayByte2SealdiceMessage(p.logger, []byte(req.String()))
 	if err != nil {
 		return err
@@ -331,13 +338,14 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 // 加群：被好友邀请-> 获取群信息 -> 根据获取的群信息，判断是否应该加群
 func (p *PlatformAdapterOnebot) handleReqGroupAction(req gjson.Result, _ *evsocket.EventPayload) error {
 	// 创建虚拟Context
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	session := p.EndPoint.Session
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	switch req.Get("sub_type").String() {
 	case "invite":
 		// 获取群信息
 		diceGroupId := canonicalOnebotGroupID(req.Get("group_id").String())
 		diceUserId := canonicalOnebotUserID(req.Get("user_id").String())
-		userName := p.Session.Parent.Parent.TryGetUserName(diceUserId)
+		userName := session.Parent.Parent.TryGetUserName(diceUserId)
 		res := p.GetGroupCacheInfo(diceGroupId)
 		if res == nil {
 			// 没有群信息，默认群信息创建
@@ -401,9 +409,10 @@ func (p *PlatformAdapterOnebot) handleReqFriendAction(req gjson.Result, _ *evsoc
 		comment = normalizeOnebotFriendRequestComment(req.Get("comment").String())
 	}
 	// 将匹配的验证问题
-	toMatch := strings.TrimSpace(p.Session.Parent.Config.FriendAddComment)
+	session := p.EndPoint.Session
+	toMatch := strings.TrimSpace(session.Parent.Config.FriendAddComment)
 	// 创建虚构MsgContext
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: p.Session, Dice: p.Session.Parent}
+	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	var extra string
 	// 匹配验证问题检查
 	passQuestion := toMatch == "" || comment == DiceFormat(ctx, toMatch) || checkMultiFriendAddVerify(comment, toMatch)
@@ -1035,7 +1044,7 @@ func ExtractQQEmitterGroupID(id string) int64 {
 
 func (p *PlatformAdapterOnebot) makeCtx(req gjson.Result) *MsgContext {
 	ep := p.EndPoint
-	session := p.Session
+	session := ep.Session
 	var messageType = "private"
 	if req.Get("group_id").Exists() {
 		messageType = "group"

--- a/dice/platform_adapter_red.go
+++ b/dice/platform_adapter_red.go
@@ -26,7 +26,6 @@ import (
 )
 
 type PlatformAdapterRed struct {
-	Session     *IMSession    `json:"-" yaml:"-"`
 	EndPoint    *EndPointInfo `json:"-" yaml:"-"`
 	DiceServing bool          `yaml:"-"` // 是否正在连接中
 
@@ -351,9 +350,9 @@ type GroupMember struct {
 
 func (pa *PlatformAdapterRed) Serve() int {
 	ep := pa.EndPoint
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
-	dm := pa.Session.Parent.Parent
+	dm := pa.EndPoint.Session.Parent.Parent
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
@@ -417,10 +416,10 @@ func (pa *PlatformAdapterRed) Serve() int {
 	botInfo := pa.getBotInfo()
 	ep.Nickname = botInfo.Name
 	ep.UserID = botInfo.SelfId
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
-	pa.Session.Parent.Logger.Infof("red 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
+	pa.EndPoint.Session.Parent.Logger.Infof("red 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
 
 	// 获得好友列表
 	refreshFriends := func() {
@@ -460,7 +459,7 @@ func (pa *PlatformAdapterRed) Serve() int {
 					_ = json.Unmarshal(msgData, &msgRow)
 					log.Debug("recv: %+v", msgRow)
 					for _, msg := range *msgRow.Payload {
-						pa.Session.Execute(pa.EndPoint, pa.decodeMessage(msg), false)
+						pa.EndPoint.Session.Execute(pa.EndPoint, pa.decodeMessage(msg), false)
 					}
 				}
 			case websocket.BinaryMessage:
@@ -495,7 +494,7 @@ func (pa *PlatformAdapterRed) Serve() int {
 }
 
 func (pa *PlatformAdapterRed) DoRelogin() bool {
-	pa.Session.Parent.Logger.Infof("正在启用 red 连接……")
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 red 连接……")
 	pa.EndPoint.State = 0
 	pa.EndPoint.Enable = false
 	if pa.conn != nil {
@@ -506,7 +505,7 @@ func (pa *PlatformAdapterRed) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterRed) SetEnable(enable bool) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	e := pa.EndPoint
 	if enable {
 		e.Enable = true
@@ -528,7 +527,7 @@ func (pa *PlatformAdapterRed) SetEnable(enable bool) {
 }
 
 func (pa *PlatformAdapterRed) QuitGroup(_ *MsgContext, id string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Warnf("red: 尝试退出群组(%s)，但尚不支持该功能", id)
 }
 
@@ -616,7 +615,7 @@ func (pa *PlatformAdapterRed) sendRow(redMsg *RedMessageSend) {
 	pa.muxSend.Lock()
 	defer pa.muxSend.Unlock()
 	if pa.conn != nil {
-		log := pa.Session.Parent.Logger
+		log := pa.EndPoint.Session.Parent.Logger
 		conn := pa.conn
 
 		param := &RedPack[RedMessageSend]{
@@ -644,7 +643,7 @@ func (pa *PlatformAdapterRed) mustExtractId(id string) (int64, RedChatType) {
 }
 
 func (pa *PlatformAdapterRed) SetGroupCardName(ctx *MsgContext, name string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Warn("red: 尚未实现该功能")
 }
 
@@ -666,10 +665,10 @@ func (pa *PlatformAdapterRed) RecallMessage(_ *MsgContext, _ string) {}
 
 func (pa *PlatformAdapterRed) GetGroupInfoAsync(_ string) {
 	// 触发更新群信息
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	dm := d.Parent
 	ep := pa.EndPoint
-	s := pa.Session
+	s := pa.EndPoint.Session
 	session := s
 	if pa.memberMap == nil {
 		// Pinenutn: 不清楚在这种情况下，内部结构的兼容性如何，只能是走一步看一步
@@ -786,7 +785,7 @@ func (pa *PlatformAdapterRed) getMemberList(group string, size int) (members []*
 	}
 	groupID, err := strconv.ParseInt(group, 10, 64)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("red 获取群成员失败", err)
+		pa.EndPoint.Session.Parent.Logger.Error("red 获取群成员失败", err)
 		return members
 	}
 	paramData, err := json.Marshal(map[string]interface{}{
@@ -794,12 +793,12 @@ func (pa *PlatformAdapterRed) getMemberList(group string, size int) (members []*
 		"size":  size,
 	})
 	if err != nil {
-		pa.Session.Parent.Logger.Error("red 获取群成员失败", err)
+		pa.EndPoint.Session.Parent.Logger.Error("red 获取群成员失败", err)
 		return members
 	}
 	data, err := pa.httpDo("POST", "group/getMemberList", nil, bytes.NewBuffer(paramData))
 	if err != nil {
-		pa.Session.Parent.Logger.Error("red 获取群成员失败", err)
+		pa.EndPoint.Session.Parent.Logger.Error("red 获取群成员失败", err)
 		return members
 	}
 	type memberInfo struct {
@@ -809,7 +808,7 @@ func (pa *PlatformAdapterRed) getMemberList(group string, size int) (members []*
 	var body []memberInfo
 	err = json.Unmarshal(data, &body)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("red 获取群成员失败", err)
+		pa.EndPoint.Session.Parent.Logger.Error("red 获取群成员失败", err)
 		return []*GroupMember{}
 	}
 	members = lo.Map(body, func(item memberInfo, _ int) *GroupMember {
@@ -946,7 +945,7 @@ func (pa *PlatformAdapterRed) encodeMessage( /* ctx */ _ *MsgContext, content st
 
 // decodeMessage 将 red 格式的信息解析成海豹所需格式
 func (pa *PlatformAdapterRed) decodeMessage(message *RedMessage) *Message {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	msg := new(Message)
 	if t, err := strconv.ParseInt(message.MsgTime, 10, 64); err == nil {
 		msg.Time = t
@@ -1039,7 +1038,7 @@ func (pa *PlatformAdapterRed) decodeMessage(message *RedMessage) *Message {
 	if message.ChatType == 1 {
 		// 私聊消息
 		msg.MessageType = "private"
-		dm := pa.Session.Parent.Parent
+		dm := pa.EndPoint.Session.Parent.Parent
 		if nick, ok := dm.UserNameCache.Load(uid); ok {
 			send.Nickname = nick.Name
 		}

--- a/dice/platform_adapter_satori.go
+++ b/dice/platform_adapter_satori.go
@@ -24,7 +24,6 @@ import (
 const SatoriProtocolVersion = "v1"
 
 type PlatformAdapterSatori struct {
-	Session     *IMSession    `json:"-" yaml:"-"`
 	EndPoint    *EndPointInfo `json:"-" yaml:"-"`
 	DiceServing bool          `yaml:"-"`
 
@@ -44,9 +43,9 @@ type PlatformAdapterSatori struct {
 
 func (pa *PlatformAdapterSatori) Serve() int {
 	ep := pa.EndPoint
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 
 	wsUrl := url.URL{
 		Scheme: "ws",
@@ -215,7 +214,7 @@ func (pa *PlatformAdapterSatori) Serve() int {
 
 // refreshFriends 更新好友信息
 func (pa *PlatformAdapterSatori) refreshFriends() {
-	session := pa.Session
+	session := pa.EndPoint.Session
 	d := session.Parent
 	log := d.Logger
 	dm := d.Parent
@@ -267,7 +266,7 @@ func (pa *PlatformAdapterSatori) refreshFriends() {
 
 // refreshGroups 更新群信息
 func (pa *PlatformAdapterSatori) refreshGroups() {
-	session := pa.Session
+	session := pa.EndPoint.Session
 	d := session.Parent
 	log := d.Logger
 	dm := d.Parent
@@ -329,7 +328,7 @@ func (pa *PlatformAdapterSatori) refreshGroups() {
 }
 
 func (pa *PlatformAdapterSatori) refreshMembers(group SatoriGuild) {
-	session := pa.Session
+	session := pa.EndPoint.Session
 	d := session.Parent
 	log := d.Logger
 
@@ -392,7 +391,7 @@ func (pa *PlatformAdapterSatori) refreshMembers(group SatoriGuild) {
 }
 
 func (pa *PlatformAdapterSatori) DoRelogin() bool {
-	pa.Session.Parent.Logger.Infof("正在启用 satori 连接，请稍后...")
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 satori 连接，请稍后...")
 	pa.EndPoint.State = 0
 	pa.EndPoint.Enable = false
 	if pa.CancelFunc != nil {
@@ -402,7 +401,7 @@ func (pa *PlatformAdapterSatori) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterSatori) SetEnable(enable bool) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	e := pa.EndPoint
 	if enable {
 		e.Enable = true
@@ -422,12 +421,12 @@ func (pa *PlatformAdapterSatori) SetEnable(enable bool) {
 }
 
 func (pa *PlatformAdapterSatori) QuitGroup(ctx *MsgContext, _ string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Errorf("satori %s 平台暂不支持退群", pa.Platform)
 }
 
 func (pa *PlatformAdapterSatori) SendToPerson(ctx *MsgContext, userID string, text string, flag string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	if pa.Platform == "QQ" {
 		id := UserIDExtract(userID)
 		pa.sendMsgRaw(ctx, "private:"+id, text, flag, "private")
@@ -441,7 +440,7 @@ func (pa *PlatformAdapterSatori) SendToGroup(ctx *MsgContext, groupID string, te
 }
 
 func (pa *PlatformAdapterSatori) sendMsgRaw( /* ctx */ _ *MsgContext, channelID string, text string /* flag */, _ string, msgType string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	req, err := json.Marshal(map[string]interface{}{
 		"channel_id": channelID,
 		"content":    pa.encodeMessage(text),
@@ -476,22 +475,22 @@ func (pa *PlatformAdapterSatori) SendSegmentToPerson(ctx *MsgContext, userID str
 }
 
 func (pa *PlatformAdapterSatori) SetGroupCardName(ctx *MsgContext, name string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Errorf("satori %s 平台暂不支持设置群成员名片", pa.Platform)
 }
 
 func (pa *PlatformAdapterSatori) SendFileToPerson(ctx *MsgContext, userID string, path string, flag string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Errorf("satori %s 平台暂不支持私聊文件发送", pa.Platform)
 }
 
 func (pa *PlatformAdapterSatori) SendFileToGroup(ctx *MsgContext, groupID string, path string, flag string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Errorf("satori %s 平台暂不支持群聊文件发送", pa.Platform)
 }
 
 func (pa *PlatformAdapterSatori) MemberBan(groupID string, userID string, duration int64) {
-	pa.Session.Parent.Logger.Errorf("satori %s 平台暂不支持禁言群(%s)内成员%s", pa.Platform, groupID, userID)
+	pa.EndPoint.Session.Parent.Logger.Errorf("satori %s 平台暂不支持禁言群(%s)内成员%s", pa.Platform, groupID, userID)
 }
 
 func (pa *PlatformAdapterSatori) MemberKick(groupID string, userID string) {
@@ -501,18 +500,18 @@ func (pa *PlatformAdapterSatori) MemberKick(groupID string, userID string) {
 		"permanent": false,
 	})
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("satori 踢出群(%s)内成员(%s)失败：%s", groupID, userID, err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("satori 踢出群(%s)内成员(%s)失败：%s", groupID, userID, err)
 		return
 	}
 	_, err = pa.post("guild.member.kick", bytes.NewBuffer(req))
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("satori 踢出群(%s)内成员(%s)失败：%s", groupID, userID, err)
+		pa.EndPoint.Session.Parent.Logger.Errorf("satori 踢出群(%s)内成员(%s)失败：%s", groupID, userID, err)
 		return
 	}
 }
 
 func (pa *PlatformAdapterSatori) GetGroupInfoAsync(groupID string) {
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	req, err := json.Marshal(map[string]interface{}{
 		"guild_id": UserIDExtract(groupID),
 	})
@@ -536,12 +535,12 @@ func (pa *PlatformAdapterSatori) GetGroupInfoAsync(groupID string) {
 }
 
 func (pa *PlatformAdapterSatori) EditMessage(ctx *MsgContext, msgID, message string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Errorf("satori %s 平台暂不支持编辑消息", pa.Platform)
 }
 
 func (pa *PlatformAdapterSatori) RecallMessage(ctx *MsgContext, msgID string) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	log.Errorf("satori %s 平台暂不支持撤回消息", pa.Platform)
 }
 
@@ -584,7 +583,7 @@ func (pa *PlatformAdapterSatori) post(resource string, body io.Reader) ([]byte, 
 }
 
 func (pa *PlatformAdapterSatori) toStdMessage(messageEvent *SatoriEvent) *Message {
-	session := pa.Session
+	session := pa.EndPoint.Session
 	d := session.Parent
 	log := d.Logger
 	dm := d.Parent
@@ -717,7 +716,7 @@ func (pa *PlatformAdapterSatori) encodeMessage(content string) string {
 }
 
 func (pa *PlatformAdapterSatori) handleEvent(event SatoriPayload[SatoriEvent]) {
-	s := pa.Session
+	s := pa.EndPoint.Session
 	switch event.Body.Type {
 	case "message-created": // 消息创建
 		msg := pa.toStdMessage(event.Body)
@@ -759,8 +758,8 @@ func (pa *PlatformAdapterSatori) deleteMessageHandle(e *SatoriEvent) {
 		msg.MessageType = "group"
 		msg.GroupID = formatDiceIDSatoriGroup(pa.Platform, e.Channel.ID)
 	}
-	mctx := &MsgContext{Session: pa.Session, EndPoint: pa.EndPoint, Dice: pa.Session.Parent, MessageType: msg.MessageType}
-	pa.Session.OnMessageDeleted(mctx, msg)
+	mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
+	pa.EndPoint.Session.OnMessageDeleted(mctx, msg)
 }
 
 func (pa *PlatformAdapterSatori) editMessageHandle(e *SatoriEvent) {
@@ -776,13 +775,13 @@ func (pa *PlatformAdapterSatori) editMessageHandle(e *SatoriEvent) {
 		msg.GroupID = formatDiceIDSatoriGroup(pa.Platform, e.Channel.ID)
 	}
 	mctx := &MsgContext{
-		Session:     pa.Session,
+		Session:     pa.EndPoint.Session,
 		EndPoint:    pa.EndPoint,
-		Dice:        pa.Session.Parent,
+		Dice:        pa.EndPoint.Session.Parent,
 		MessageType: msg.MessageType,
 		Player:      &GroupPlayerInfo{},
 	}
-	pa.Session.OnMessageEdit(mctx, msg)
+	pa.EndPoint.Session.OnMessageEdit(mctx, msg)
 }
 
 //nolint:unused
@@ -797,7 +796,7 @@ func (pa *PlatformAdapterSatori) guildRemovedHandle(e *SatoriEvent) {
 
 //nolint:unused
 func (pa *PlatformAdapterSatori) guildRequestHandle(e *SatoriEvent) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	dm := d.Parent
 	log := d.Logger
 
@@ -843,7 +842,7 @@ func (pa *PlatformAdapterSatori) guildRequestHandle(e *SatoriEvent) {
 //
 //nolint:unused
 func (pa *PlatformAdapterSatori) sendGuildRequestResult(id string, approve bool, comment string) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	log := d.Logger
 	req := map[string]any{
 		"message_id": id,
@@ -860,7 +859,7 @@ func (pa *PlatformAdapterSatori) sendGuildRequestResult(id string, approve bool,
 
 //nolint:unused
 func (pa *PlatformAdapterSatori) friendRequestHandle(e *SatoriEvent) {
-	s := pa.Session
+	s := pa.EndPoint.Session
 	d := s.Parent
 	dm := d.Parent
 	log := d.Logger
@@ -890,7 +889,7 @@ func (pa *PlatformAdapterSatori) friendRequestHandle(e *SatoriEvent) {
 //
 //nolint:unused
 func (pa *PlatformAdapterSatori) sendFriendRequestResult(id string, approve bool, comment string) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	log := d.Logger
 	req := map[string]any{
 		"message_id": id,

--- a/dice/platform_adapter_satori_helper.go
+++ b/dice/platform_adapter_satori_helper.go
@@ -28,7 +28,7 @@ func ServeSatori(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	conn := ep.Adapter.(*PlatformAdapterSatori)
 	d.Logger.Infof("satori 尝试连接")
-	ep.Session = d.ImSession
+	ep.BindRuntime(d.ImSession)
 	if conn.Serve() == 0 {
 	} else {
 		d.Logger.Errorf("连接 satori 服务失败")

--- a/dice/platform_adapter_sealchat.go
+++ b/dice/platform_adapter_sealchat.go
@@ -21,7 +21,6 @@ import (
 )
 
 type PlatformAdapterSealChat struct {
-	Session  *IMSession    `json:"-" yaml:"-"`
 	EndPoint *EndPointInfo `json:"-" yaml:"-"`
 
 	ConnectURL string                    `json:"connectUrl" yaml:"connectUrl"` // 连接地址
@@ -54,7 +53,7 @@ func (pa *PlatformAdapterSealChat) Serve() int {
 	pa.RetryTimesLimit = 15
 	// 初始化角色卡写入速率限制器: 60次/分钟，允许突发5次
 	pa.characterSetLimiter = rate.NewLimiter(rate.Every(time.Minute/60), 5)
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	pa.socketSetup()
@@ -74,13 +73,13 @@ func (pa *PlatformAdapterSealChat) _sendJSON(socket *gowebsocket.Socket, data an
 
 func (pa *PlatformAdapterSealChat) socketSetup() {
 	ep := pa.EndPoint
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	socket := pa.Socket
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		ep.State = 2
 		ep.Enable = true
 
-		d := pa.Session.Parent
+		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 
@@ -202,7 +201,7 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 }
 
 func (pa *PlatformAdapterSealChat) tryReconnect(socket gowebsocket.Socket) bool {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	if socket.IsConnected {
 		return true
 	}
@@ -236,7 +235,7 @@ func (pa *PlatformAdapterSealChat) startHeartbeat() {
 	pa.stopHeartbeat()
 	pa.heartbeatStop = make(chan struct{})
 	atomic.StoreInt64(&pa.lastPong, time.Now().Unix())
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 
 	go func() {
 		ticker := time.NewTicker(15 * time.Second)
@@ -466,7 +465,7 @@ func FormatDiceIDSealChatGroup(id string) string {
 }
 
 func (pa *PlatformAdapterSealChat) DoRelogin() bool {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	pa.Reconnecting = true
 	if pa.Socket != nil {
 		pa.Socket.Close()
@@ -482,7 +481,7 @@ func (pa *PlatformAdapterSealChat) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterSealChat) SetEnable(enable bool) {
-	log := pa.Session.Parent.Logger
+	log := pa.EndPoint.Session.Parent.Logger
 	if enable {
 		pa.EndPoint.Enable = true
 		log.Infof("Sealchat 连接中")
@@ -570,7 +569,7 @@ func (pa *PlatformAdapterSealChat) _sendTo(ctx *MsgContext, chId string, text st
 	text = strings.ReplaceAll(text, "&gt;", ">")
 	text = strings.ReplaceAll(text, "&amp;", "&")
 	text = strings.ReplaceAll(text, "&quot;", "\"")
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "SEALCHAT",
 		MessageType: msgType,
 		Message:     text,
@@ -591,7 +590,7 @@ func (pa *PlatformAdapterSealChat) SendSegmentToGroup(ctx *MsgContext, groupID s
 		"content":    encodedContent,
 	})
 
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "SEALCHAT",
 		MessageType: "group",
 		Message:     encodedContent,
@@ -616,7 +615,7 @@ func (pa *PlatformAdapterSealChat) SendSegmentToPerson(ctx *MsgContext, userID s
 		"content":    encodedContent,
 	})
 
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "SEALCHAT",
 		MessageType: "private",
 		Message:     encodedContent,
@@ -690,7 +689,7 @@ func (pa *PlatformAdapterSealChat) dispatchMessage(msg string) {
 	ev := satori.Event{}
 	err := json.Unmarshal([]byte(msg), &ev)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("PlatformAdapterSealChat.dispatchMessage", err)
+		pa.EndPoint.Session.Parent.Logger.Error("PlatformAdapterSealChat.dispatchMessage", err)
 		return
 	}
 
@@ -700,13 +699,13 @@ func (pa *PlatformAdapterSealChat) dispatchMessage(msg string) {
 			// 自己发的消息，不管
 			return
 		}
-		pa.Session.Execute(pa.EndPoint, pa.toStdMessage(ev.Message), false)
+		pa.EndPoint.Session.Execute(pa.EndPoint, pa.toStdMessage(ev.Message), false)
 		return
 	case satori.EventMessageDeleted:
 		stdMsg := pa.toStdMessage(ev.Message)
 		// 注; 缺少 User、Channel[导致MessageType出不来]
 		mctx := CreateTempCtx(pa.EndPoint, stdMsg)
-		pa.Session.OnMessageDeleted(mctx, stdMsg)
+		pa.EndPoint.Session.OnMessageDeleted(mctx, stdMsg)
 		return
 	default:
 		// fmt.Println("msg", ev.Type, "|", ev)
@@ -786,8 +785,8 @@ func (pa *PlatformAdapterSealChat) parseGroupRole(roles []string) string {
 
 // handleApiRequest 处理来自 SealChat 的 API 请求
 func (pa *PlatformAdapterSealChat) handleApiRequest(msg satori.ScApiMsgPayload) {
-	log := pa.Session.Parent.Logger
-	d := pa.Session.Parent
+	log := pa.EndPoint.Session.Parent.Logger
+	d := pa.EndPoint.Session.Parent
 
 	switch msg.Api {
 	case "character.get":

--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -15,7 +15,6 @@ import (
 )
 
 type PlatformAdapterSlack struct {
-	Session   *IMSession    `json:"-"        yaml:"-"`
 	EndPoint  *EndPointInfo `json:"-"        yaml:"-"`
 	Client    *sm.Client    `json:"-"        yaml:"-"`
 	BotToken  string        `json:"-" yaml:"botToken"`
@@ -27,7 +26,7 @@ type PlatformAdapterSlack struct {
 
 func (pa *PlatformAdapterSlack) Serve() int {
 	ep := pa.EndPoint
-	s := pa.Session
+	s := ep.Session
 	log := s.Parent.Logger
 	api := slack.New(pa.BotToken, slack.OptionAppLevelToken(pa.AppToken))
 	client := sm.New(api)
@@ -208,7 +207,7 @@ func (pa *PlatformAdapterSlack) SetEnable(enable bool) {
 }
 
 func (pa *PlatformAdapterSlack) QuitGroup(ctx *MsgContext, id string) {
-	pa.Session.Parent.Logger.Error("Slack 退出群组失败：暂不支持")
+	pa.EndPoint.Session.Parent.Logger.Error("Slack 退出群组失败：暂不支持")
 }
 
 func (pa *PlatformAdapterSlack) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {
@@ -219,7 +218,7 @@ func (pa *PlatformAdapterSlack) SendSegmentToPerson(ctx *MsgContext, userID stri
 
 func (pa *PlatformAdapterSlack) SendToPerson(ctx *MsgContext, userID string, text string, flag string) {
 	pa.send(ctx, ExtractSlackUserID(userID), text, flag)
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		MessageType: "private",
 		Platform:    "SLACK",
 		Message:     text,
@@ -232,7 +231,7 @@ func (pa *PlatformAdapterSlack) SendToPerson(ctx *MsgContext, userID string, tex
 
 func (pa *PlatformAdapterSlack) SendToGroup(ctx *MsgContext, groupID string, text string, flag string) {
 	pa.send(ctx, ExtractSlackChannelID(groupID), text, flag)
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		MessageType: "group",
 		Platform:    "SLACK",
 		Message:     text,
@@ -245,7 +244,7 @@ func (pa *PlatformAdapterSlack) SendToGroup(ctx *MsgContext, groupID string, tex
 }
 
 func (pa *PlatformAdapterSlack) SetGroupCardName(ctx *MsgContext, name string) {
-	pa.Session.Parent.Logger.Error("Slack 设置群名片失败：暂不支持")
+	pa.EndPoint.Session.Parent.Logger.Error("Slack 设置群名片失败：暂不支持")
 }
 
 func (pa *PlatformAdapterSlack) MemberBan(groupId string, userId string, duration int64) {
@@ -269,7 +268,7 @@ func (pa *PlatformAdapterSlack) send(_ *MsgContext, id string, text string, _ st
 	// 频道以 C 开头 用户以 U 开头 老粗暴了
 	messageCtx, s, s2, err := pa.Client.SendMessage(id, slack.MsgOptionText(text, false))
 	if err != nil {
-		pa.Session.Parent.Logger.Error("Slack 发送消息失败", messageCtx, s, s2, err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("Slack 发送消息失败", messageCtx, s, s2, err.Error())
 	}
 }
 
@@ -282,7 +281,7 @@ func (pa *PlatformAdapterSlack) getUser(user string) *slack.User {
 	}
 	info, err := pa.Client.GetUserInfo(user)
 	if err != nil {
-		pa.Session.Parent.Logger.Error("Slack 获取用户数据失败：", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Error("Slack 获取用户数据失败：", err.Error())
 		return &slack.User{}
 	}
 	pa.userCache.Store(user, info)

--- a/dice/platform_adapter_slack_helper.go
+++ b/dice/platform_adapter_slack_helper.go
@@ -25,9 +25,7 @@ func ServeSlack(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "SLACK" {
 		conn := ep.Adapter.(*PlatformAdapterSlack)
-		ep.Session = d.ImSession
-		conn.Session = d.ImSession
-		conn.EndPoint = ep
+		ep.BindRuntime(d.ImSession)
 		if conn.Serve() != 0 {
 			ep.State = 3
 			d.LastUpdatedTime = time.Now().Unix()

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -31,7 +31,6 @@ func (b *BotLoggerWrapper) Printf(format string, v ...interface{}) {
 }
 
 type PlatformAdapterTelegram struct {
-	Session       *IMSession       `json:"-"        yaml:"-"`
 	Token         string           `json:"-"    yaml:"token"`
 	ProxyURL      string           `json:"proxyURL" yaml:"proxyURL"`
 	EndPoint      *EndPointInfo    `json:"-"        yaml:"-"`
@@ -52,12 +51,12 @@ func (pa *PlatformAdapterTelegram) GetGroupInfoAsync(groupID string) {
 	if err != nil {
 		return
 	}
-	dm := pa.Session.Parent.Parent
+	dm := pa.EndPoint.Session.Parent.Parent
 	dm.GroupNameCache.Store(groupID, &GroupNameCacheItem{
 		Name: chat.Title,
 		time: time.Now().Unix(),
 	})
-	groupInfo, ok := pa.Session.ServiceAtNew.Load(groupID)
+	groupInfo, ok := pa.EndPoint.Session.ServiceAtNew.Load(groupID)
 	if ok {
 		groupInfo.GroupName = chat.Title
 	}
@@ -84,10 +83,10 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 		bot, err = tgbotapi.NewBotAPI(pa.Token)
 	}
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("与Telegram服务进行连接时出错:%s", err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("与Telegram服务进行连接时出错:%s", err.Error())
 		ep.State = 3
 		ep.Enable = false
-		d := pa.Session.Parent
+		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 		return 1
@@ -98,11 +97,11 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 	ep.Nickname = bot.Self.UserName
 	ep.State = 1
 	ep.Enable = true
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 
-	pa.Session.Parent.Logger.Infof("Telegram 服务连接成功，账号<%s>(%s)", bot.Self.UserName, pa.EndPoint.UserID)
+	pa.EndPoint.Session.Parent.Logger.Infof("Telegram 服务连接成功，账号<%s>(%s)", bot.Self.UserName, pa.EndPoint.UserID)
 
 	updateConfig := tgbotapi.NewUpdate(0)
 	updateConfig.Timeout = 30
@@ -124,17 +123,17 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 
 				msg := pa.toStdMessage(update.EditedMessage)
 				mctx := &MsgContext{
-					Session:     pa.Session,
+					Session:     pa.EndPoint.Session,
 					EndPoint:    pa.EndPoint,
-					Dice:        pa.Session.Parent,
+					Dice:        pa.EndPoint.Session.Parent,
 					MessageType: msg.MessageType,
 				}
-				if groupInfo, ok := pa.Session.ServiceAtNew.Load(msg.GroupID); ok {
+				if groupInfo, ok := pa.EndPoint.Session.ServiceAtNew.Load(msg.GroupID); ok {
 					if p, ok2 := groupInfo.Players.Load(msg.Sender.UserID); ok2 {
 						mctx.Player = p
 					}
 				}
-				go pa.Session.OnMessageEdit(mctx, msg)
+				go pa.EndPoint.Session.OnMessageEdit(mctx, msg)
 				continue
 			}
 
@@ -170,17 +169,17 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 				go pa.friendAdded(msg)
 				continue
 			}
-			go pa.Session.Execute(pa.EndPoint, msg, false)
+			go pa.EndPoint.Session.Execute(pa.EndPoint, msg, false)
 		}
 	}()
 	return 0
 }
 
 func (pa *PlatformAdapterTelegram) groupNewMember(msg *Message, msgRaw *tgbotapi.Message, member *tgbotapi.User) {
-	ucache := &pa.Session.Parent.Parent.UserIDCache
-	logger := pa.Session.Parent.Logger
+	ucache := &pa.EndPoint.Session.Parent.Parent.UserIDCache
+	logger := pa.EndPoint.Session.Parent.Logger
 	ep := pa.EndPoint
-	groupInfo, ok := pa.Session.ServiceAtNew.Load(msg.GroupID)
+	groupInfo, ok := pa.EndPoint.Session.ServiceAtNew.Load(msg.GroupID)
 	if member.UserName != "" {
 		_, cacheExist := ucache.Load(member.UserName)
 		if !cacheExist {
@@ -188,7 +187,7 @@ func (pa *PlatformAdapterTelegram) groupNewMember(msg *Message, msgRaw *tgbotapi
 		}
 	}
 	if ok && groupInfo.ShowGroupWelcome {
-		ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: pa.Session, Dice: pa.Session.Parent}
+		ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
 		ctx.Player = &GroupPlayerInfo{}
 		uidRaw := strconv.FormatInt(member.ID, 10)
 		VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
@@ -206,9 +205,9 @@ func (pa *PlatformAdapterTelegram) groupNewMember(msg *Message, msgRaw *tgbotapi
 }
 
 func (pa *PlatformAdapterTelegram) groupAdded(msg *Message, msgRaw *tgbotapi.Message) {
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	ep := pa.EndPoint
-	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: pa.Session, Dice: pa.Session.Parent}
+	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
 	gi := SetBotOnAtGroup(ctx, msg.GroupID)
 	gi.InviteUserID = msg.Sender.UserID
 	gi.EnteredTime = msg.Time
@@ -232,9 +231,9 @@ func (pa *PlatformAdapterTelegram) groupAdded(msg *Message, msgRaw *tgbotapi.Mes
 }
 
 func (pa *PlatformAdapterTelegram) friendAdded(msg *Message) {
-	logger := pa.Session.Parent.Logger
+	logger := pa.EndPoint.Session.Parent.Logger
 	ep := pa.EndPoint
-	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: pa.Session, Dice: pa.Session.Parent}
+	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: pa.EndPoint.Session, Dice: pa.EndPoint.Session.Parent}
 	ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
 	uid := msg.Sender.UserID
 	welcome := DiceFormatTmpl(ctx, "核心:骰子成为好友")
@@ -253,8 +252,8 @@ func (pa *PlatformAdapterTelegram) friendAdded(msg *Message) {
 }
 
 func (pa *PlatformAdapterTelegram) toStdMessage(m *tgbotapi.Message) *Message {
-	ucache := &pa.Session.Parent.Parent.UserIDCache
-	logger := pa.Session.Parent.Logger
+	ucache := &pa.EndPoint.Session.Parent.Parent.UserIDCache
+	logger := pa.EndPoint.Session.Parent.Logger
 	self := pa.IntentSession.Self
 	msg := new(Message)
 	msg.Time = int64(m.Date)
@@ -362,7 +361,7 @@ func (pa *PlatformAdapterTelegram) MemberBan(_ string, _ string, _ int64) {}
 func (pa *PlatformAdapterTelegram) MemberKick(_ string, _ string) {}
 
 func (pa *PlatformAdapterTelegram) DoRelogin() bool {
-	pa.Session.Parent.Logger.Infof("正在启用Telegram服务……")
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
 	if pa.IntentSession == nil {
 		go pa.Serve()
 		return true
@@ -378,7 +377,7 @@ func (pa *PlatformAdapterTelegram) DoRelogin() bool {
 func (pa *PlatformAdapterTelegram) SetEnable(enable bool) {
 	ep := pa.EndPoint
 	if enable {
-		pa.Session.Parent.Logger.Infof("正在启用Telegram服务……")
+		pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
 		if pa.IntentSession == nil {
 			go pa.Serve()
 			return
@@ -409,7 +408,7 @@ func (pa *PlatformAdapterTelegram) SendToPerson(ctx *MsgContext, userID string, 
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "TG",
 		MessageType: "private",
 		Message:     text,
@@ -426,7 +425,7 @@ func (pa *PlatformAdapterTelegram) SendToGroup(ctx *MsgContext, uid string, text
 	if err != nil {
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "TG",
 		MessageType: "group",
 		Message:     text,
@@ -443,7 +442,7 @@ func (pa *PlatformAdapterTelegram) SendFileToPerson(ctx *MsgContext, uid string,
 	userID := ExtractTelegramUserID(uid)
 	id, _ := strconv.ParseInt(userID, 10, 64)
 	bot := pa.IntentSession
-	dice := pa.Session.Parent
+	dice := pa.EndPoint.Session.Parent
 
 	e, err := message.FilepathToFileElement(path)
 	if err != nil {
@@ -457,7 +456,7 @@ func (pa *PlatformAdapterTelegram) SendFileToPerson(ctx *MsgContext, uid string,
 		dice.Logger.Errorf("向Telegram聊天#%d发送文件[path=%s]时出错:%s", id, path, err.Error())
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "TG",
 		MessageType: "private",
 		Segment: []message.IMessageElement{
@@ -477,7 +476,7 @@ func (pa *PlatformAdapterTelegram) SendFileToGroup(ctx *MsgContext, uid string, 
 	groupID := ExtractTelegramGroupID(uid)
 	id, _ := strconv.ParseInt(groupID, 10, 64)
 	bot := pa.IntentSession
-	dice := pa.Session.Parent
+	dice := pa.EndPoint.Session.Parent
 
 	e, err := message.FilepathToFileElement(path)
 	if err != nil {
@@ -491,7 +490,7 @@ func (pa *PlatformAdapterTelegram) SendFileToGroup(ctx *MsgContext, uid string, 
 		dice.Logger.Errorf("向Telegram聊天#%d发送文件[path=%s]时出错:%s", id, path, err.Error())
 		return
 	}
-	pa.Session.OnMessageSend(ctx, &Message{
+	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "TG",
 		MessageType: "group",
 		Segment: []message.IMessageElement{
@@ -550,7 +549,7 @@ func (pa *PlatformAdapterTelegram) SendToChatRaw(uid string, text string) (*tgbo
 		//		_, err = bot.Send(msg)
 		//	}
 		//	if err != nil {
-		//		pa.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
+		//		pa.EndPoint.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
 		//		return
 		//	}
 		//	msg = tgbotapi.NewMessage(id, "")
@@ -569,7 +568,7 @@ func (pa *PlatformAdapterTelegram) SendToChatRaw(uid string, text string) (*tgbo
 			f.Thumb = data
 			_, err = bot.Send(f)
 			if err != nil {
-				pa.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
+				pa.EndPoint.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
 				return nil, err
 			}
 		case *message.TTSElement:
@@ -577,20 +576,20 @@ func (pa *PlatformAdapterTelegram) SendToChatRaw(uid string, text string) (*tgbo
 		case *message.ReplyElement:
 			parseInt, errParse := strconv.ParseInt(e.ReplySeq, 10, 64)
 			if errParse != nil {
-				pa.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, errParse)
+				pa.EndPoint.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, errParse)
 				break
 			}
 			msg.ReplyToMessageID = int(parseInt)
 		}
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
+			pa.EndPoint.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
 			return nil, err
 		}
 	}
 	if msg.Text != "" || len(msg.Entities) > 0 {
 		resp, err := bot.Send(msg)
 		if err != nil {
-			pa.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
+			pa.EndPoint.Session.Parent.Logger.Errorf("向Telegram聊天#%d发送消息时出错:%s", id, err)
 		}
 		return &resp, err
 	}
@@ -600,13 +599,13 @@ func (pa *PlatformAdapterTelegram) SendToChatRaw(uid string, text string) (*tgbo
 func (pa *PlatformAdapterTelegram) QuitGroup(_ *MsgContext, id string) {
 	parseInt, err := strconv.ParseInt(ExtractTelegramGroupID(id), 10, 64)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("退出Telegram群组%s时出错:%s", id, err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("退出Telegram群组%s时出错:%s", id, err.Error())
 		return
 	}
 	msg := &tgbotapi.LeaveChatConfig{ChatID: parseInt}
 	_, err = pa.IntentSession.Send(msg)
 	if err != nil {
-		pa.Session.Parent.Logger.Errorf("退出Telegram群组%s时出错:%s", id, err.Error())
+		pa.EndPoint.Session.Parent.Logger.Errorf("退出Telegram群组%s时出错:%s", id, err.Error())
 	}
 }
 

--- a/dice/platform_adapter_telegram_helper.go
+++ b/dice/platform_adapter_telegram_helper.go
@@ -21,7 +21,7 @@ func ServeTelegram(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "TG" {
 		conn := ep.Adapter.(*PlatformAdapterTelegram)
-		ep.Session = d.ImSession
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Telegram 尝试连接")
 		conn.Serve()
 	}

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -25,7 +25,6 @@ import (
 
 type PlatformAdapterWalleQ struct {
 	EndPoint        *EndPointInfo       `json:"-"               yaml:"-"`
-	Session         *IMSession          `json:"-"               yaml:"-"`
 	Socket          *gowebsocket.Socket `json:"-"               yaml:"-"`
 	ConnectURL      string              `json:"connectUrl"      yaml:"connectUrl"`      // 连接地址
 	UseInPackWalleQ bool                `json:"useInPackWalleQ" yaml:"useInPackWalleQ"` // 是否使用内置的WalleQ
@@ -173,7 +172,7 @@ type OnebotV12UserInfo struct {
 func (pa *PlatformAdapterWalleQ) Serve() int {
 	pa.Implementation = "walle-q"
 	ep := pa.EndPoint
-	s := pa.Session
+	s := pa.EndPoint.Session
 	log := s.Parent.Logger
 	dm := s.Parent.Parent
 	interrupt := make(chan os.Signal, 1)
@@ -338,7 +337,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 				}
 			}
 
-			pa.Session.Execute(pa.EndPoint, msg, false) // wq 还没有频道支持，直接执行
+			pa.EndPoint.Session.Execute(pa.EndPoint, msg, false) // wq 还没有频道支持，直接执行
 		}
 
 		//nolint:nestif
@@ -622,7 +621,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 			case "get_self_info":
 				ep.Nickname = m["user_name"].(string)
 				ep.UserID = FormatDiceIDQQV12(m["user_id"].(string))
-				d := pa.Session.Parent
+				d := pa.EndPoint.Session.Parent
 				d.LastUpdatedTime = time.Now().Unix()
 				d.Save(false)
 				return
@@ -729,7 +728,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 /* 标准方法实现 */
 
 func (pa *PlatformAdapterWalleQ) DoRelogin() bool {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
 	if pa.Socket != nil {
 		go pa.Socket.Close()
@@ -753,7 +752,7 @@ func (pa *PlatformAdapterWalleQ) DoRelogin() bool {
 }
 
 func (pa *PlatformAdapterWalleQ) SetEnable(enable bool) {
-	d := pa.Session.Parent
+	d := pa.EndPoint.Session.Parent
 	c := pa.EndPoint
 	if enable {
 		c.Enable = true
@@ -1208,7 +1207,7 @@ func (pa *PlatformAdapterWalleQ) TextToMessageSegment(text string) []MessageSegm
 		}
 		pa2, err := filepath.Abs(path)
 		if err != nil {
-			pa.Session.Parent.Logger.Info("路径转换错误，将使用原路径", err)
+			pa.EndPoint.Session.Parent.Logger.Info("路径转换错误，将使用原路径", err)
 			pa2 = path
 		}
 		return pa2

--- a/dice/platform_adapter_walleq_helper.go
+++ b/dice/platform_adapter_walleq_helper.go
@@ -293,7 +293,7 @@ func (pa *PlatformAdapterWalleQ) SetQQProtocol(protocol int) bool {
 	uid := pa.EndPoint.UserID
 	log := pa.EndPoint.Session.Parent.Logger
 
-	wd := filepath.Join(pa.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
+	wd := filepath.Join(pa.EndPoint.Session.Parent.BaseConfig.DataDir, pa.EndPoint.RelWorkDir)
 	wdData, err := os.ReadFile(wd)
 	if err != nil {
 		log.Error("读取 Walle-q 配置文件失败，请检查！")

--- a/dice/utils.go
+++ b/dice/utils.go
@@ -533,12 +533,31 @@ func CheckDialErr(err error) syscall.Errno {
 
 // CreateTempCtx 制作ctx，需要msg.MessageType和msg.Sender.UserId，以及ep.Session
 func CreateTempCtx(ep *EndPointInfo, msg *Message) *MsgContext {
+	if ep == nil {
+		panic("CreateTempCtx: endpoint is nil")
+	}
+	if msg == nil {
+		panic("CreateTempCtx: message is nil")
+	}
+
 	session := ep.Session
+	if session == nil {
+		panic(fmt.Sprintf("CreateTempCtx: endpoint %s (%s) has nil session", ep.ID, ep.UserID))
+	}
+
+	liveEp, err := session.ResolveLiveEndpoint(ep)
+	if err != nil {
+		panic("CreateTempCtx: " + err.Error())
+	}
+	session = liveEp.Session
+	if session == nil || session.Parent == nil {
+		panic(fmt.Sprintf("CreateTempCtx: endpoint %s (%s) runtime not bound", liveEp.ID, liveEp.UserID))
+	}
 	// if msg.Sender.UserID == "" {
 	//	return nil
 	// }
 
-	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: ep, Session: session, Dice: session.Parent}
+	ctx := &MsgContext{MessageType: msg.MessageType, EndPoint: liveEp, Session: session, Dice: session.Parent}
 
 	switch msg.MessageType {
 	case "private":

--- a/main.go
+++ b/main.go
@@ -500,7 +500,7 @@ func diceServe(d *dice.Dice) {
 	d.UIEndpoint.ID = "1"
 	d.UIEndpoint.State = 1
 	d.UIEndpoint.UserID = "UI:1000"
-	d.UIEndpoint.Adapter = &dice.PlatformAdapterHTTP{Session: d.ImSession, EndPoint: d.UIEndpoint}
+	d.UIEndpoint.Adapter = &dice.PlatformAdapterHTTP{EndPoint: d.UIEndpoint}
 	d.UIEndpoint.Session = d.ImSession
 
 	dice.TextMapCompatibleCheckAll(d)


### PR DESCRIPTION
权宜之计，通过EndpointId获取新的Endpoint。

## Summary by Sourcery

在所有 IM 适配器中统一端点（endpoint）运行时绑定和会话（session）解析方式，确保消息上下文和插件始终使用实时（live）的端点/会话。

Bug 修复：
- 确保 `CreateTempCtx` 解析为当前活动的端点实例，而不是使用过期或部分绑定的端点，从而防止上下文/会话不匹配。
- 修复在 API 处理器和启动流程中对新创建端点的运行时接线（wiring），使适配器始终通过端点拥有有效会话，而不是依赖自身的 `Session` 字段。
- 通过集中绑定逻辑并在会话或端点为 `nil` 时加强错误处理，防止内部/UI 端点及各类适配器出现缺失会话的问题。

增强：
- 引入 `IMSession.ResolveLiveEndpoint` 和 `EndPointInfo.BindRuntime`，集中管理端点与会话的关联方式以及实时端点的解析方式。
- 重构所有平台适配器，通过其 `EndPoint` 访问 `IMSession`，而不是维护各自的 `Session` 引用，从而简化适配器状态并减少重复。
- 调整面向 JS 和 HTTP 的端点工具，使其适配新的端点绑定模型，并避免直接暴露内部切片（slice）。
- 为端点运行时绑定和 `CreateTempCtx` 行为添加测试，以验证实时端点解析和适配器接线（wiring）的正确性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize endpoint runtime binding and session resolution across IM adapters to ensure message contexts and plugins always use the live endpoint/session.

Bug Fixes:
- Ensure CreateTempCtx resolves to the currently active endpoint instance instead of using stale or partially bound endpoints, preventing context/session mismatches.
- Fix runtime wiring of newly created endpoints in API handlers and startup so adapters consistently have a valid session via the endpoint rather than their own Session field.
- Prevent missing-session issues for internal/UI endpoints and various adapters by centralizing binding logic and tightening error handling when sessions or endpoints are nil.

Enhancements:
- Introduce IMSession.ResolveLiveEndpoint and EndPointInfo.BindRuntime to centralize how endpoints are associated with a session and how a live endpoint is resolved.
- Refactor all platform adapters to access the IMSession through their EndPoint instead of maintaining their own Session reference, simplifying adapter state and reducing duplication.
- Adjust JS and HTTP-facing endpoint utilities to work with the new endpoint binding model and to avoid exposing internal slices directly.
- Add tests around endpoint runtime binding and CreateTempCtx behavior to verify correct live-endpoint resolution and adapter wiring.

</details>