### PR TITLE
chore(deps): bump github.com/sealdice/botgo to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/samber/lo v1.52.0
 	github.com/schollz/progressbar/v3 v3.18.0
-	github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083 // replaced below
+	github.com/sealdice/botgo v0.0.0-20260723172410-174570888e38
 	github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070
 	github.com/slack-go/slack v0.17.3
 	github.com/sunshineplan/imgconv v1.1.14
@@ -241,7 +241,4 @@ replace (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0 => github.com/PaienNate/goja_nodejs v0.0.0-20250924024212-bac2e5ba5231
 	github.com/lonelyevil/kook v0.0.31 => github.com/sealdice/kook v0.0.3
 	github.com/sacOO7/gowebsocket v0.0.0-20221109081133-70ac927be105 => github.com/fy0/GoWebsocket v0.0.0-20231128163937-aa5c110b25c6
-	// QQ官方机器人: 指向 baiyu-yu/botgo fork (tongbu 分支)，支持 webhook + OAuth2 + C2C消息等
-	github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083 => github.com/baiyu-yu/botgo v0.0.0-20260624160657-82be3f005789
-// github.com/PaienNate/pineutil v0.0.0-20251014070632-4c5ebfdc92e5 => C:\Users\11018\Documents\goutil
 )

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
-github.com/baiyu-yu/botgo v0.0.0-20260624160657-82be3f005789 h1:4NDEwCYrevxCTij1GLhPehmLmLEk8ZPKGLhpWbxENzY=
-github.com/baiyu-yu/botgo v0.0.0-20260624160657-82be3f005789/go.mod h1:oQhXm1mfLdV+1/d27LhnUHVNfhtl5RYwdREQnb4cewI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.2.2/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
@@ -508,6 +506,8 @@ github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRo
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/schollz/progressbar/v3 v3.18.0 h1:uXdoHABRFmNIjUfte/Ex7WtuyVslrw2wVPQmCN62HpA=
 github.com/schollz/progressbar/v3 v3.18.0/go.mod h1:IsO3lpbaGuzh8zIMzgY3+J8l4C8GjO0Y9S69eFvNsec=
+github.com/sealdice/botgo v0.0.0-20260723172410-174570888e38 h1:pZT8k8bOe1V8iAraOnzItI2i31Zzds/hDKKIvX8UXcI=
+github.com/sealdice/botgo v0.0.0-20260723172410-174570888e38/go.mod h1:oQhXm1mfLdV+1/d27LhnUHVNfhtl5RYwdREQnb4cewI=
 github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070 h1:C5zwdWiRpgMl3g3Q68csBaDWJLdUhYKfPGwJUkHXed0=
 github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070/go.mod h1:uof752qJvEQ4Kze+NVag+RKGgj5C4K3kMHoK3e2vOLg=
 github.com/sealdice/kook v0.0.3 h1:STMtiKRMFjhSFmUxi0BU5ktNkCQ8qi7Y5EEfrmYKvWY=


### PR DESCRIPTION
## Summary by Sourcery

将 QQ 机器人依赖更新到最新的上游 botgo 版本，并在模块配置中移除自定义 fork 覆盖。

Enhancements:
- 在 QQ 机器人集成中，统一使用上游的 `github.com/sealdice/botgo` 模块，而不是在 `go.mod` 中使用分叉替代版本。

Build:
- 刷新 `go.mod` 中对 `github.com/sealdice/botgo` 的依赖到最新可用版本，并移除其 `replace` 指令。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update QQ bot dependency to the latest upstream botgo release and remove the custom fork override from module configuration.

Enhancements:
- Standardize QQ bot integration on the upstream github.com/sealdice/botgo module instead of a forked replacement in go.mod.

Build:
- Refresh go.mod dependency on github.com/sealdice/botgo to the latest available version and drop its replace directive.

</details>