### PR TITLE
feat(sn): 改名增加群管理权限检测 (#325)

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -134,74 +134,74 @@ func parseQQGroupRole(role string) (string, bool) {
 }
 
 // checkBotGroupRole 查询 bot 在指定群中归一化后的角色(owner/admin/member)。
-// 返回值: role 为归一化后的角色字符串; ok 表示该适配器是否支持并成功完成角色检查;
-// detail 在 ok=true 时为角色字符串(与 role 相同),在 ok=false 时为失败原因描述。
+// 返回值: ok 表示该适配器是否支持并成功完成角色检查;
+// detail 在 ok=true 时为归一化后的角色字符串,在 ok=false 时为失败原因描述。
 // 不支持角色检查的适配器返回 ok=false, 调用方应保持原有行为, 不做阻断。
-func checkBotGroupRole(ctx *MsgContext, groupID string) (role string, ok bool, detail string) {
+func checkBotGroupRole(ctx *MsgContext, groupID string) (detail string, ok bool) {
 	if ctx == nil || ctx.EndPoint == nil || ctx.EndPoint.Adapter == nil {
-		return "", false, "context invalid"
+		return "context invalid", false
 	}
 
 	switch pa := ctx.EndPoint.Adapter.(type) {
 	case *PlatformAdapterOnebot:
 		if pa.sendEmitter == nil {
-			return "", false, "onebot emitter unavailable"
+			return "onebot emitter unavailable", false
 		}
 		botID, ok := getOnebotBotQQID(ctx)
 		if !ok {
-			return "", false, "cannot resolve bot qq id"
+			return "cannot resolve bot qq id", false
 		}
 		memberInfo, err := pa.sendEmitter.GetGroupMemberInfo(pa.ctx, ExtractQQEmitterGroupID(groupID), botID, false)
 		if err != nil || memberInfo == nil {
 			if err != nil {
-				return "", false, fmt.Sprintf("get_group_member_info failed: %v", err)
+				return fmt.Sprintf("get_group_member_info failed: %v", err), false
 			}
-			return "", false, errGetGroupMemberInfoNil
+			return errGetGroupMemberInfoNil, false
 		}
-		role, ok = parseQQGroupRole(memberInfo.Role)
+		role, ok := parseQQGroupRole(memberInfo.Role)
 		if !ok {
-			return "", false, errGetGroupMemberInfoEmptyRole
+			return errGetGroupMemberInfoEmptyRole, false
 		}
-		return role, true, role
+		return role, true
 	case *PlatformAdapterGocq:
 		botIDRaw := strings.TrimSpace(UserIDExtract(ctx.EndPoint.UserID))
 		groupIDRaw := strings.TrimSpace(UserIDExtract(groupID))
 		if botIDRaw == "" || groupIDRaw == "" {
-			return "", false, "cannot resolve bot/group id"
+			return "cannot resolve bot/group id", false
 		}
 		memberInfo := pa.GetGroupMemberInfo(groupIDRaw, botIDRaw)
 		if memberInfo == nil {
-			return "", false, errGetGroupMemberInfoNil
+			return errGetGroupMemberInfoNil, false
 		}
 		role, ok := parseQQGroupRole(memberInfo.Role)
 		if !ok {
-			return "", false, errGetGroupMemberInfoEmptyRole
+			return errGetGroupMemberInfoEmptyRole, false
 		}
-		return role, true, role
+		return role, true
 	case *PlatformAdapterMilky:
 		memberInfo, err := pa.GetGroupMemberInfo(groupID, ctx.EndPoint.UserID)
 		if err != nil {
-			return "", false, fmt.Sprintf("get_group_member_info failed: %v", err)
+			return fmt.Sprintf("get_group_member_info failed: %v", err), false
 		}
 		if memberInfo == nil {
-			return "", false, errGetGroupMemberInfoNil
+			return errGetGroupMemberInfoNil, false
 		}
 		role, ok := parseQQGroupRole(memberInfo.Role)
 		if !ok {
-			return "", false, errGetGroupMemberInfoEmptyRole
+			return errGetGroupMemberInfoEmptyRole, false
 		}
-		return role, true, role
+		return role, true
 	default:
-		return "", false, "adapter does not support group role check"
+		return "adapter does not support group role check", false
 	}
 }
 
 func shouldDismissRequireOwnerConfirm(ctx *MsgContext, groupID string) (bool, bool, string) {
-	role, ok, detail := checkBotGroupRole(ctx, groupID)
+	detail, ok := checkBotGroupRole(ctx, groupID)
 	if !ok {
 		return false, false, detail
 	}
-	return role == "owner", true, role
+	return detail == "owner", true, detail
 }
 
 func normalizeDismissTargetGroupID(ctx *MsgContext, rawGroupID string) string {

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -134,9 +134,10 @@ func parseQQGroupRole(role string) (string, bool) {
 }
 
 // checkBotGroupRole 查询 bot 在指定群中归一化后的角色(owner/admin/member)。
-// 返回值: role 为归一化后的角色字符串; ok 表示该适配器是否支持并成功完成角色检查; errMsg 在失败时给出原因。
+// 返回值: role 为归一化后的角色字符串; ok 表示该适配器是否支持并成功完成角色检查;
+// detail 在 ok=true 时为角色字符串(与 role 相同),在 ok=false 时为失败原因描述。
 // 不支持角色检查的适配器返回 ok=false, 调用方应保持原有行为, 不做阻断。
-func checkBotGroupRole(ctx *MsgContext, groupID string) (role string, ok bool, errMsg string) {
+func checkBotGroupRole(ctx *MsgContext, groupID string) (role string, ok bool, detail string) {
 	if ctx == nil || ctx.EndPoint == nil || ctx.EndPoint.Adapter == nil {
 		return "", false, "context invalid"
 	}

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -133,63 +133,74 @@ func parseQQGroupRole(role string) (string, bool) {
 	return normalized, true
 }
 
-func shouldDismissRequireOwnerConfirm(ctx *MsgContext, groupID string) (bool, bool, string) {
+// checkBotGroupRole 查询 bot 在指定群中归一化后的角色(owner/admin/member)。
+// 返回值: role 为归一化后的角色字符串; ok 表示该适配器是否支持并成功完成角色检查; errMsg 在失败时给出原因。
+// 不支持角色检查的适配器返回 ok=false, 调用方应保持原有行为, 不做阻断。
+func checkBotGroupRole(ctx *MsgContext, groupID string) (role string, ok bool, errMsg string) {
 	if ctx == nil || ctx.EndPoint == nil || ctx.EndPoint.Adapter == nil {
-		return false, false, "context invalid"
+		return "", false, "context invalid"
 	}
 
 	switch pa := ctx.EndPoint.Adapter.(type) {
 	case *PlatformAdapterOnebot:
 		if pa.sendEmitter == nil {
-			return false, false, "onebot emitter unavailable"
+			return "", false, "onebot emitter unavailable"
 		}
 		botID, ok := getOnebotBotQQID(ctx)
 		if !ok {
-			return false, false, "cannot resolve bot qq id"
+			return "", false, "cannot resolve bot qq id"
 		}
 		memberInfo, err := pa.sendEmitter.GetGroupMemberInfo(pa.ctx, ExtractQQEmitterGroupID(groupID), botID, false)
 		if err != nil || memberInfo == nil {
 			if err != nil {
-				return false, false, fmt.Sprintf("get_group_member_info failed: %v", err)
+				return "", false, fmt.Sprintf("get_group_member_info failed: %v", err)
 			}
-			return false, false, errGetGroupMemberInfoNil
+			return "", false, errGetGroupMemberInfoNil
 		}
-		role, ok := parseQQGroupRole(memberInfo.Role)
+		role, ok = parseQQGroupRole(memberInfo.Role)
 		if !ok {
-			return false, false, errGetGroupMemberInfoEmptyRole
+			return "", false, errGetGroupMemberInfoEmptyRole
 		}
-		return role == "owner", true, role
+		return role, true, role
 	case *PlatformAdapterGocq:
 		botIDRaw := strings.TrimSpace(UserIDExtract(ctx.EndPoint.UserID))
 		groupIDRaw := strings.TrimSpace(UserIDExtract(groupID))
 		if botIDRaw == "" || groupIDRaw == "" {
-			return false, false, "cannot resolve bot/group id"
+			return "", false, "cannot resolve bot/group id"
 		}
 		memberInfo := pa.GetGroupMemberInfo(groupIDRaw, botIDRaw)
 		if memberInfo == nil {
-			return false, false, errGetGroupMemberInfoNil
+			return "", false, errGetGroupMemberInfoNil
 		}
 		role, ok := parseQQGroupRole(memberInfo.Role)
 		if !ok {
-			return false, false, errGetGroupMemberInfoEmptyRole
+			return "", false, errGetGroupMemberInfoEmptyRole
 		}
-		return role == "owner", true, role
+		return role, true, role
 	case *PlatformAdapterMilky:
 		memberInfo, err := pa.GetGroupMemberInfo(groupID, ctx.EndPoint.UserID)
 		if err != nil {
-			return false, false, fmt.Sprintf("get_group_member_info failed: %v", err)
+			return "", false, fmt.Sprintf("get_group_member_info failed: %v", err)
 		}
 		if memberInfo == nil {
-			return false, false, errGetGroupMemberInfoNil
+			return "", false, errGetGroupMemberInfoNil
 		}
 		role, ok := parseQQGroupRole(memberInfo.Role)
 		if !ok {
-			return false, false, errGetGroupMemberInfoEmptyRole
+			return "", false, errGetGroupMemberInfoEmptyRole
 		}
-		return role == "owner", true, role
+		return role, true, role
 	default:
-		return false, false, "adapter does not support group role check"
+		return "", false, "adapter does not support group role check"
 	}
+}
+
+func shouldDismissRequireOwnerConfirm(ctx *MsgContext, groupID string) (bool, bool, string) {
+	role, ok, detail := checkBotGroupRole(ctx, groupID)
+	if !ok {
+		return false, false, detail
+	}
+	return role == "owner", true, role
 }
 
 func normalizeDismissTargetGroupID(ctx *MsgContext, rawGroupID string) string {

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -802,6 +802,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 		},
 		Solve: func(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs) CmdExecuteResult {
 			val := cmdArgs.GetArgN(1)
+			valLower := strings.ToLower(val)
 
 			handleOverlong := func(ctx *MsgContext, msg *Message, card string) CmdExecuteResult {
 				ReplyToSender(ctx, msg, fmt.Sprintf(
@@ -814,14 +815,14 @@ func RegisterBuiltinExtLog(self *Dice) {
 			// sn 指令(除 help 外)需要骰子具有群管理员权限。提前检测 bot 在群中的角色,
 			// 若明确无管理权限则给出明确提示, 避免用户反复尝试。不支持角色检查的适配器
 			// 返回 ok=false, 此时保持原有行为(直接尝试设置)不做阻断。
-			if strings.ToLower(val) != "help" && ctx.Group != nil {
+			if valLower != "help" && ctx.Group != nil {
 				if role, ok, _ := checkBotGroupRole(ctx, ctx.Group.GroupID); ok && role != "owner" && role != "admin" {
 					ReplyToSender(ctx, msg, "设置群名片需要骰子具有群管理员权限，请在群内将骰子设为管理员后重试 .sn 指令。")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
 			}
 
-			switch strings.ToLower(val) {
+			switch valLower {
 			case "help":
 				return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 			case "coc", "coc7":

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -816,7 +816,7 @@ func RegisterBuiltinExtLog(self *Dice) {
 			// 若明确无管理权限则给出明确提示, 避免用户反复尝试。不支持角色检查的适配器
 			// 返回 ok=false, 此时保持原有行为(直接尝试设置)不做阻断。
 			if valLower != "help" && ctx.Group != nil {
-				if role, ok, _ := checkBotGroupRole(ctx, ctx.Group.GroupID); ok && role != "owner" && role != "admin" {
+				if detail, ok := checkBotGroupRole(ctx, ctx.Group.GroupID); ok && detail != "owner" && detail != "admin" {
 					ReplyToSender(ctx, msg, "设置群名片需要骰子具有群管理员权限，请在群内将骰子设为管理员后重试 .sn 指令。")
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}

--- a/dice/ext_log.go
+++ b/dice/ext_log.go
@@ -811,6 +811,16 @@ func RegisterBuiltinExtLog(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true}
 			}
 
+			// sn 指令(除 help 外)需要骰子具有群管理员权限。提前检测 bot 在群中的角色,
+			// 若明确无管理权限则给出明确提示, 避免用户反复尝试。不支持角色检查的适配器
+			// 返回 ok=false, 此时保持原有行为(直接尝试设置)不做阻断。
+			if strings.ToLower(val) != "help" && ctx.Group != nil {
+				if role, ok, _ := checkBotGroupRole(ctx, ctx.Group.GroupID); ok && role != "owner" && role != "admin" {
+					ReplyToSender(ctx, msg, "设置群名片需要骰子具有群管理员权限，请在群内将骰子设为管理员后重试 .sn 指令。")
+					return CmdExecuteResult{Matched: true, Solved: true}
+				}
+			}
+
 			switch strings.ToLower(val) {
 			case "help":
 				return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}


### PR DESCRIPTION
close #325

## Summary by Sourcery

添加集中化的机器人群组角色检查机制，并用它来保护敏感的群组操作。

新功能：
- 在执行会修改群组名片的非帮助类 `.sn` 命令前，要求机器人必须具有群管理员或群主角色。

改进：
- 将群组角色检查重构为可复用的 `checkBotGroupRole` 辅助函数，并在离职确认逻辑中复用该检查（由群主确认）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add centralized bot group-role checking and use it to guard sensitive group operations.

New Features:
- Require the bot to have group admin or owner role before executing non-help .sn commands that modify group name cards.

Enhancements:
- Refactor group role checking into a reusable checkBotGroupRole helper and reuse it in dismissal owner-confirmation logic.

</details>