### PR TITLE
feat(official-qq): QQ 官方机器人支持扫码登陆

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -299,6 +299,13 @@ func ImConnectionsQrcodeGet(c echo.Context) error {
 					"img": "data:image/png;base64," + base64.StdEncoding.EncodeToString(pa.QrCodeData),
 				})
 			}
+		case "official":
+			pa := i.Adapter.(*dice.PlatformAdapterOfficialQQ)
+			if pa.QrLoginState == dice.OfficialQQLoginStateQRWaitingForScan {
+				return c.JSON(http.StatusOK, map[string]string{
+					"img": "data:image/png;base64," + base64.StdEncoding.EncodeToString(pa.QrCodeData),
+				})
+			}
 		}
 		return c.JSON(http.StatusOK, i)
 	}
@@ -934,7 +941,6 @@ func ImConnectionsAddOfficialQQ(c echo.Context) error {
 
 	v := struct {
 		AppID       interface{} `json:"appID"         yaml:"appID"`
-		Token       string      `json:"token"         yaml:"token"`
 		AppSecret   string      `json:"appSecret"     yaml:"appSecret"`
 		OnlyQQGuild bool        `json:"onlyQQGuild"   yaml:"onlyQQGuild"`
 		// Webhook配置
@@ -959,7 +965,7 @@ func ImConnectionsAddOfficialQQ(c echo.Context) error {
 				appIDStr = fmt.Sprintf("%v", val)
 			}
 		}
-		conn := dice.NewOfficialQQConnItem(appIDStr, v.Token, v.AppSecret, v.OnlyQQGuild)
+		conn := dice.NewOfficialQQConnItem(appIDStr, v.AppSecret, v.OnlyQQGuild)
 		conn.BindRuntime(myDice.ImSession)
 		pa := conn.Adapter.(*dice.PlatformAdapterOfficialQQ)
 		// 设置Webhook配置

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -80,9 +80,7 @@ type PlatformAdapterOfficialQQ struct {
 
 func (pa *PlatformAdapterOfficialQQ) Serve() int {
 	ep := pa.EndPoint
-	s := pa.EndPoint.Session
-	log := s.Parent.Logger
-	d := pa.EndPoint.Session.Parent
+	log := pa.EndPoint.Session.Parent.Logger
 
 	if pa.Ctx != nil {
 		log.Info("official qq session already running, skip Serve")
@@ -93,24 +91,27 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 	pa.AppSecret = strings.TrimSpace(pa.AppSecret)
 
 	// AppID 为空时进入扫码登录分支：异步生成二维码并轮询，
-	// 扫码成功后凭据写入本 adapter，再回调 doServe 走正常连接流程
+	// 扫码成功后凭据写入本 adapter，直接调用 connect 启动连接
 	if pa.AppID == "" {
 		ctx, cancel := context.WithCancel(context.Background())
 		pa.Ctx, pa.CancelFunc = ctx, cancel
 		ep.State = 2
 		log.Info("official qq AppID 为空，进入扫码登录流程")
 		pa.serveQrLogin("sealdice", func() {
-			// 扫码成功后重新走 Serve，此时 AppID/AppSecret 已就绪
-			// 先清空 Ctx 以便重新进入
-			if pa.CancelFunc != nil {
-				pa.CancelFunc()
-			}
-			pa.Ctx = nil
-			pa.CancelFunc = nil
-			pa.Serve()
+			pa.connect()
 		})
 		return 0
 	}
+
+	return pa.connect()
+}
+
+// connect 执行真正的连接建立逻辑（token 初始化、OpenAPI 客户端、WebSocket/Webhook 启动）
+// 由 Serve() 和扫码成功后的回调共同调用，调用方需确保 AppID/AppSecret 已就绪
+func (pa *PlatformAdapterOfficialQQ) connect() int {
+	ep := pa.EndPoint
+	log := ep.Session.Parent.Logger
+	d := ep.Session.Parent
 
 	log.Debug("official qq server")
 	qqbot.SetLogger(NewDummyLogger())
@@ -2235,7 +2236,6 @@ func qqBotHttpPost(url string, body []byte) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		_ = resp.Body.Close()
 		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
 	}
 
@@ -2245,7 +2245,7 @@ func qqBotHttpPost(url string, body []byte) ([]byte, error) {
 // serveQrLogin 在 adapter 内执行扫码登录全流程
 // 由 Serve() 在 AppID 为空时调用，异步轮询绑定状态：
 //   - 生成二维码后写入 QrCodeData（供 qrcode 端点读取），状态置为 QRWaitingForScan
-//   - 二维码过期自动刷新
+//   - 二维码过期自动刷新并重新生成 QrCodeData
 //   - 扫码成功后写入 AppID/AppSecret，置状态为 Connecting，再回调 doServe() 走正常连接
 //   - 失败/取消置状态为 Failed
 //
@@ -2359,7 +2359,7 @@ func (pa *PlatformAdapterOfficialQQ) serveQrLogin(source string, doServe func())
 				return
 
 			case qqBotBindStatusExpired:
-				// 二维码过期，刷新任务
+				// 二维码过期，刷新任务并重新生成二维码图片
 				newTaskID, newKey, cerr := qqBotCreateBindTask()
 				if cerr != nil {
 					curSession.mu.Unlock()
@@ -2367,20 +2367,26 @@ func (pa *PlatformAdapterOfficialQQ) serveQrLogin(source string, doServe func())
 					pa.qrMu.Lock()
 					pa.QrLoginState = OfficialQQLoginStateFailed
 					pa.QrURL = ""
+					pa.QrCodeData = nil
 					pa.qrSession = nil
 					pa.qrMu.Unlock()
 					ep.State = 3
 					ep.Enable = false
 					return
 				}
+				newQrURL := qqBotBuildConnectURL(newTaskID, curSession.Source)
+				newQrCodeData, qerr := qrcode.Encode(newQrURL, qrcode.Medium, 256)
+				if qerr != nil {
+					log.Error("official qq 生成新二维码失败: ", qerr)
+				}
 				curSession.TaskID = newTaskID
 				curSession.Key = newKey
-				curSession.QrURL = qqBotBuildConnectURL(newTaskID, curSession.Source)
-				newQrURL := curSession.QrURL
+				curSession.QrURL = newQrURL
 				curSession.mu.Unlock()
 
 				pa.qrMu.Lock()
 				pa.QrURL = newQrURL
+				pa.QrCodeData = newQrCodeData
 				pa.QrLoginState = OfficialQQLoginStateQRWaitingForScan
 				pa.qrMu.Unlock()
 				log.Info("official qq 二维码已刷新")

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -1,7 +1,11 @@
 package dice
 
 import (
+	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	crand "crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -17,8 +21,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sealdice/botgo/event"
 	"github.com/sealdice/botgo/interaction/signature"
+	"github.com/skip2/go-qrcode"
 
 	qqbot "github.com/sealdice/botgo"
 	"github.com/sealdice/botgo/dto"
@@ -44,7 +50,6 @@ type PlatformAdapterOfficialQQ struct {
 
 	AppID       string `json:"appID"       yaml:"appID"`
 	AppSecret   string `json:"appSecret"   yaml:"appSecret"`
-	Token       string `json:"token"       yaml:"token"`
 	OnlyQQGuild bool   `json:"onlyQQGuild" yaml:"onlyQQGuild"`
 
 	// Webhook配置
@@ -63,6 +68,14 @@ type PlatformAdapterOfficialQQ struct {
 
 	paginationCache map[string]*PaginationItem `json:"-" yaml:"-"`
 	paginationMu    sync.Mutex                 `json:"-" yaml:"-"`
+
+	// 扫码登录状态（参考 milky 的 BuiltInLoginState / QrCodeData 设计）
+	// 当 AppID 为空时，Serve() 会进入扫码登录分支
+	QrLoginState OfficialQQLoginState      `json:"qrLoginState" yaml:"-"`
+	QrURL        string                    `json:"qrUrl"       yaml:"-"` // 当前二维码 URL
+	QrCodeData   []byte                    `json:"-"           yaml:"-"` // 当前二维码图片数据（PNG），参考 milky 的 QrCodeData
+	qrSession    *QQOfficialQrLoginSession `json:"-" yaml:"-"`
+	qrMu         sync.Mutex                `json:"-" yaml:"-"`
 }
 
 func (pa *PlatformAdapterOfficialQQ) Serve() int {
@@ -78,7 +91,26 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 
 	pa.AppID = strings.TrimSpace(pa.AppID)
 	pa.AppSecret = strings.TrimSpace(pa.AppSecret)
-	pa.Token = strings.TrimSpace(pa.Token)
+
+	// AppID 为空时进入扫码登录分支：异步生成二维码并轮询，
+	// 扫码成功后凭据写入本 adapter，再回调 doServe 走正常连接流程
+	if pa.AppID == "" {
+		ctx, cancel := context.WithCancel(context.Background())
+		pa.Ctx, pa.CancelFunc = ctx, cancel
+		ep.State = 2
+		log.Info("official qq AppID 为空，进入扫码登录流程")
+		pa.serveQrLogin("sealdice", func() {
+			// 扫码成功后重新走 Serve，此时 AppID/AppSecret 已就绪
+			// 先清空 Ctx 以便重新进入
+			if pa.CancelFunc != nil {
+				pa.CancelFunc()
+			}
+			pa.Ctx = nil
+			pa.CancelFunc = nil
+			pa.Serve()
+		})
+		return 0
+	}
 
 	log.Debug("official qq server")
 	qqbot.SetLogger(NewDummyLogger())
@@ -1998,4 +2030,364 @@ func (pa *PlatformAdapterOfficialQQ) parseBotSelfOpenID(event *dto.WSPayload) st
 		}
 	}
 	return ""
+}
+
+// ============================================================
+// QQ官方机器人扫码登录（第三方 Agent 接入）
+// 参考 https://bot.q.qq.com/wiki/agent-qqbot/#第三方-agent-接入
+// ============================================================
+
+// QQ官方机器人扫码登录相关常量
+const (
+	qqBotCreateBindTaskURL = "https://q.qq.com/lite/create_bind_task"
+	qqBotPollBindResultURL = "https://q.qq.com/lite/poll_bind_result"
+	qqBotConnectPageURL    = "https://q.qq.com/qqbot/openclaw/connect.html"
+
+	// 扫码绑定任务状态
+	qqBotBindStatusNone     = 0 // 未知/初始
+	qqBotBindStatusPending  = 1 // 等待扫码确认
+	qqBotBindStatusComplete = 2 // 扫码完成
+	qqBotBindStatusExpired  = 3 // 二维码已过期
+
+	qqBotBindTaskTimeout = 10 * time.Second // 单次HTTP请求超时
+)
+
+// OfficialQQLoginState 扫码登录状态（参考 milky 的 MilkyLoginState）
+type OfficialQQLoginState int64
+
+const (
+	OfficialQQLoginStateInit             OfficialQQLoginState = iota // 初始
+	OfficialQQLoginStateQRWaitingForScan                             // 等待扫码
+	OfficialQQLoginStateQRScanned                                    // 已扫码，等待确认（暂未细分使用）
+	OfficialQQLoginStateConnecting                                   // 扫码成功，正在连接
+	OfficialQQLoginStateFailed                                       // 失败/取消
+)
+
+// QQOfficialQrLoginSession 单次扫码登录会话
+type QQOfficialQrLoginSession struct {
+	ID        string
+	TaskID    string
+	Key       string // base64 编码的 32 字节随机密钥
+	Source    string // 接入平台标识
+	QrURL     string // 当前二维码对应的 URL
+	CreatedAt time.Time
+	mu        sync.Mutex
+	canceled  bool
+}
+
+// qqBotGenerateBindKey 生成 32 字节随机密钥并 base64 编码
+func qqBotGenerateBindKey() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := crand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf), nil
+}
+
+// qqBotBuildConnectURL 构造二维码扫描对应的 URL
+func qqBotBuildConnectURL(taskID, source string) string {
+	return fmt.Sprintf("%s?task_id=%s&source=%s&_wv=2",
+		qqBotConnectPageURL,
+		url.QueryEscape(taskID),
+		url.QueryEscape(source),
+	)
+}
+
+// qqBotCreateBindTask 创建绑定任务
+func qqBotCreateBindTask() (taskID string, key string, err error) {
+	key, err = qqBotGenerateBindKey()
+	if err != nil {
+		return "", "", fmt.Errorf("生成密钥失败: %w", err)
+	}
+
+	reqBody, _ := json.Marshal(map[string]string{"key": key})
+	resp, err := qqBotHttpPost(qqBotCreateBindTaskURL, reqBody)
+	if err != nil {
+		return "", "", fmt.Errorf("创建绑定任务失败: %w", err)
+	}
+
+	var result struct {
+		RetCode int    `json:"retcode"`
+		Msg     string `json:"msg"`
+		Data    struct {
+			TaskID string `json:"task_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return "", "", fmt.Errorf("解析创建任务响应失败: %w", err)
+	}
+	if result.RetCode != 0 {
+		msg := result.Msg
+		if msg == "" {
+			msg = "create_bind_task failed"
+		}
+		return "", "", errors.New(msg)
+	}
+	if result.Data.TaskID == "" {
+		return "", "", errors.New("create_bind_task: missing task_id")
+	}
+	return result.Data.TaskID, key, nil
+}
+
+// qqBotBindResult 轮询绑定结果
+type qqBotBindResult struct {
+	Status           int    // 绑定状态
+	BotAppID         string // 机器人 AppID
+	BotEncryptSecret string // 加密的 AppSecret
+	UserOpenID       string // 扫码用户 openid
+}
+
+func qqBotPollBindResult(taskID string) (*qqBotBindResult, error) {
+	reqBody, _ := json.Marshal(map[string]string{"task_id": taskID})
+	resp, err := qqBotHttpPost(qqBotPollBindResultURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("轮询绑定结果失败: %w", err)
+	}
+
+	var result struct {
+		RetCode int    `json:"retcode"`
+		Msg     string `json:"msg"`
+		Data    struct {
+			Status           int    `json:"status"`
+			BotAppID         any    `json:"bot_appid"`
+			BotEncryptSecret string `json:"bot_encrypt_secret"`
+			UserOpenID       string `json:"user_openid"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("解析轮询响应失败: %w", err)
+	}
+	if result.RetCode != 0 {
+		msg := result.Msg
+		if msg == "" {
+			msg = "poll_bind_result failed"
+		}
+		return nil, errors.New(msg)
+	}
+
+	return &qqBotBindResult{
+		Status:           result.Data.Status,
+		BotAppID:         fmt.Sprintf("%v", result.Data.BotAppID),
+		BotEncryptSecret: result.Data.BotEncryptSecret,
+		UserOpenID:       result.Data.UserOpenID,
+	}, nil
+}
+
+// qqBotDecryptSecret 使用 AES-256-GCM 解密 AppSecret
+// key 为 base64 编码的 32 字节密钥；encryptedSecret 为 base64 编码的
+// nonce(12B) || ciphertext || tag(16B)
+func qqBotDecryptSecret(encryptedSecret, key string) (string, error) {
+	keyBytes, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return "", fmt.Errorf("解码密钥失败: %w", err)
+	}
+	if len(keyBytes) != 32 {
+		return "", fmt.Errorf("密钥长度非法: %d", len(keyBytes))
+	}
+
+	data, err := base64.StdEncoding.DecodeString(encryptedSecret)
+	if err != nil {
+		return "", fmt.Errorf("解码密文失败: %w", err)
+	}
+	if len(data) < 12+16 {
+		return "", errors.New("密文长度不足")
+	}
+
+	nonce := data[:12]
+	tag := data[len(data)-16:]
+	ciphertext := data[12 : len(data)-16]
+
+	block, err := aes.NewCipher(keyBytes)
+	if err != nil {
+		return "", fmt.Errorf("创建 AES cipher 失败: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("创建 GCM 失败: %w", err)
+	}
+
+	// Go 的 GCM.Open 期望 ciphertext || tag
+	ct := make([]byte, 0, len(ciphertext)+len(tag))
+	ct = append(ct, ciphertext...)
+	ct = append(ct, tag...)
+
+	plaintext, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return "", fmt.Errorf("解密失败: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+// qqBotHttpPost 发送 JSON POST 请求
+func qqBotHttpPost(url string, body []byte) ([]byte, error) {
+	client := &http.Client{Timeout: qqBotBindTaskTimeout}
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// serveQrLogin 在 adapter 内执行扫码登录全流程
+// 由 Serve() 在 AppID 为空时调用，异步轮询绑定状态：
+//   - 生成二维码后写入 QrCodeData（供 qrcode 端点读取），状态置为 QRWaitingForScan
+//   - 二维码过期自动刷新
+//   - 扫码成功后写入 AppID/AppSecret，置状态为 Connecting，再回调 doServe() 走正常连接
+//   - 失败/取消置状态为 Failed
+//
+// 调用方传入 doServe 回调，用于扫码成功后启动真正的连接流程
+func (pa *PlatformAdapterOfficialQQ) serveQrLogin(source string, doServe func()) {
+	ep := pa.EndPoint
+	log := pa.EndPoint.Session.Parent.Logger
+
+	pa.qrMu.Lock()
+	pa.QrLoginState = OfficialQQLoginStateInit
+	pa.qrMu.Unlock()
+
+	// 启动扫码会话
+	taskID, key, err := qqBotCreateBindTask()
+	if err != nil {
+		log.Error("official qq 创建扫码任务失败: ", err)
+		pa.qrMu.Lock()
+		pa.QrLoginState = OfficialQQLoginStateFailed
+		pa.qrMu.Unlock()
+		ep.State = 3
+		ep.Enable = false
+		return
+	}
+
+	session := &QQOfficialQrLoginSession{
+		ID:        uuid.New().String(),
+		TaskID:    taskID,
+		Key:       key,
+		Source:    source,
+		QrURL:     qqBotBuildConnectURL(taskID, source),
+		CreatedAt: time.Now(),
+	}
+
+	qrCodeData, err := qrcode.Encode(session.QrURL, qrcode.Medium, 256)
+	if err != nil {
+		log.Error("official qq 生成二维码失败: ", err)
+	}
+
+	pa.qrMu.Lock()
+	pa.qrSession = session
+	pa.QrURL = session.QrURL
+	pa.QrCodeData = qrCodeData
+	pa.QrLoginState = OfficialQQLoginStateQRWaitingForScan
+	pa.qrMu.Unlock()
+	log.Info("official qq 扫码二维码已就绪")
+
+	// 轮询绑定结果
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-pa.Ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			pa.qrMu.Lock()
+			curSession := pa.qrSession
+			pa.qrMu.Unlock()
+			if curSession == nil {
+				return
+			}
+
+			curSession.mu.Lock()
+			if curSession.canceled {
+				curSession.mu.Unlock()
+				pa.qrMu.Lock()
+				pa.QrLoginState = OfficialQQLoginStateFailed
+				pa.QrURL = ""
+				pa.qrMu.Unlock()
+				log.Info("official qq 扫码登录已取消")
+				return
+			}
+
+			result, perr := qqBotPollBindResult(curSession.TaskID)
+			if perr != nil {
+				curSession.mu.Unlock()
+				// 单次轮询失败不终止，继续重试
+				log.Debugf("official qq 轮询扫码状态失败: %v", perr)
+				continue
+			}
+
+			switch result.Status {
+			case qqBotBindStatusComplete:
+				// 扫码成功，解密 AppSecret
+				secret, derr := qqBotDecryptSecret(result.BotEncryptSecret, curSession.Key)
+				curSession.mu.Unlock()
+				if derr != nil {
+					log.Error("official qq 解密 AppSecret 失败: ", derr)
+					pa.qrMu.Lock()
+					pa.QrLoginState = OfficialQQLoginStateFailed
+					pa.QrURL = ""
+					pa.qrSession = nil
+					pa.qrMu.Unlock()
+					ep.State = 3
+					ep.Enable = false
+					return
+				}
+				// 写入凭据
+				pa.AppID = result.BotAppID
+				pa.AppSecret = secret
+				pa.qrMu.Lock()
+				pa.QrLoginState = OfficialQQLoginStateConnecting
+				pa.QrURL = ""
+				pa.qrSession = nil
+				pa.qrMu.Unlock()
+				log.Infof("official qq 扫码成功，AppID=%s，开始连接", pa.AppID)
+				doServe()
+				return
+
+			case qqBotBindStatusExpired:
+				// 二维码过期，刷新任务
+				newTaskID, newKey, cerr := qqBotCreateBindTask()
+				if cerr != nil {
+					curSession.mu.Unlock()
+					log.Error("official qq 刷新扫码任务失败: ", cerr)
+					pa.qrMu.Lock()
+					pa.QrLoginState = OfficialQQLoginStateFailed
+					pa.QrURL = ""
+					pa.qrSession = nil
+					pa.qrMu.Unlock()
+					ep.State = 3
+					ep.Enable = false
+					return
+				}
+				curSession.TaskID = newTaskID
+				curSession.Key = newKey
+				curSession.QrURL = qqBotBuildConnectURL(newTaskID, curSession.Source)
+				newQrURL := curSession.QrURL
+				curSession.mu.Unlock()
+
+				pa.qrMu.Lock()
+				pa.QrURL = newQrURL
+				pa.QrLoginState = OfficialQQLoginStateQRWaitingForScan
+				pa.qrMu.Unlock()
+				log.Info("official qq 二维码已刷新")
+
+			default:
+				curSession.mu.Unlock()
+			}
+		}
+	}()
 }

--- a/dice/platform_adapter_official_qq_helper.go
+++ b/dice/platform_adapter_official_qq_helper.go
@@ -13,7 +13,7 @@ import (
 	logger "sealdice-core/logger"
 )
 
-func NewOfficialQQConnItem(appID string, token string, appSecret string, onlyQQGuild bool) *EndPointInfo {
+func NewOfficialQQConnItem(appID string, appSecret string, onlyQQGuild bool) *EndPointInfo {
 	conn := new(EndPointInfo)
 	conn.ID = uuid.New().String()
 	conn.Platform = "QQ"
@@ -23,7 +23,6 @@ func NewOfficialQQConnItem(appID string, token string, appSecret string, onlyQQG
 	conn.Adapter = &PlatformAdapterOfficialQQ{
 		EndPoint:    conn,
 		AppID:       appID,
-		Token:       token,
 		AppSecret:   appSecret,
 		OnlyQQGuild: onlyQQGuild,
 	}

--- a/go.mod
+++ b/go.mod
@@ -191,6 +191,7 @@ require (
 	github.com/sacOO7/go-logger v0.0.0-20180719173527-9ac9add5a50d // indirect
 	github.com/sergeymakinen/go-bmp v1.0.0 // indirect
 	github.com/sergeymakinen/go-ico v1.0.0-beta.0 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/sunshineplan/pdf v1.0.8 // indirect
 	github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af // indirect
 	github.com/tdewolff/parse/v2 v2.8.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
 github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=


### PR DESCRIPTION
https://github.com/sealdice/sealdice-ui/pull/304

## Summary by Sourcery

支持 QQ 官方机器人通过第三方代理二维码流程进行登录：生成并提供二维码、轮询绑定状态，并在扫码完成后填充凭证以建立标准连接。

新特性：
- 在未配置 AppID 的情况下，为 QQ 官方机器人添加基于二维码的登录流程，包括会话跟踪和状态管理。
- 通过现有的二维码 API 端点，为 QQ 官方连接暴露二维码图片。

改进：
- 通过移除未使用的 token 字段并相应更新构造函数，简化 QQ 官方连接的配置。
- 集成 QQ 官方代理绑定工作流，包括密钥生成、绑定任务创建、轮询以及密文解密，以动态填充 AppID/AppSecret。

构建：
- 添加 `go-qrcode` 作为间接依赖，用于生成 QQ 官方登录所需的二维码图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support QQ Official bot login via third-party agent QR code flow, generating and serving QR codes, polling bind status, and populating credentials to establish the standard connection once scanning completes.

New Features:
- Add QR code based login flow for Official QQ bots when AppID is not configured, including session tracking and state management.
- Expose QR code image for Official QQ connections via the existing QR code API endpoint.

Enhancements:
- Simplify Official QQ connection configuration by removing the unused token field and updating constructors accordingly.
- Integrate QQ official agent binding workflow, including key generation, bind task creation, polling, and secret decryption to populate AppID/AppSecret dynamically.

Build:
- Add go-qrcode as an indirect dependency for generating QR code images for Official QQ login.

</details>