### PR TITLE
feat(official-qq): 使用bot qq号统一身份并迁移历史数据

### DIFF
--- a/api/conn.go
+++ b/api/conn.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -934,45 +936,92 @@ func ImConnectionsAddOfficialQQ(c echo.Context) error {
 
 	v := struct {
 		AppID       interface{} `json:"appID"         yaml:"appID"`
-		Token       string      `json:"token"         yaml:"token"`
+		Token       string      `json:"token"         yaml:"token"` // Deprecated: preserved for old clients but never used.
 		AppSecret   string      `json:"appSecret"     yaml:"appSecret"`
+		TestOnly    bool        `json:"testOnly"      yaml:"testOnly"`
 		OnlyQQGuild bool        `json:"onlyQQGuild"   yaml:"onlyQQGuild"`
 		// Webhook配置
 		UseWebhook  bool   `json:"useWebhook"    yaml:"useWebhook"`
 		WebhookPath string `json:"webhookPath"   yaml:"webhookPath"`
 		WebhookPort int    `json:"webhookPort"   yaml:"webhookPort"`
 	}{}
-	err := c.Bind(&v)
-	if err == nil {
-		var appIDStr string
-		if v.AppID != nil {
-			switch val := v.AppID.(type) {
-			case string:
-				appIDStr = val
-			case float64:
-				appIDStr = strconv.FormatInt(int64(val), 10)
-			case int64:
-				appIDStr = strconv.FormatInt(val, 10)
-			case int:
-				appIDStr = strconv.Itoa(val)
-			default:
-				appIDStr = fmt.Sprintf("%v", val)
-			}
-		}
-		conn := dice.NewOfficialQQConnItem(appIDStr, v.Token, v.AppSecret, v.OnlyQQGuild)
-		conn.BindRuntime(myDice.ImSession)
-		pa := conn.Adapter.(*dice.PlatformAdapterOfficialQQ)
-		// 设置Webhook配置
-		pa.UseWebhook = v.UseWebhook
-		pa.WebhookPath = v.WebhookPath
-		pa.WebhookPort = v.WebhookPort
-		myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
-		myDice.LastUpdatedTime = time.Now().Unix()
-		myDice.Save(false)
-		go dice.ServerOfficialQQ(myDice, conn)
-		return Success(&c, Response{})
+	if err := c.Bind(&v); err != nil {
+		return c.String(430, "")
 	}
-	return c.String(430, "")
+
+	var appIDStr string
+	if v.AppID != nil {
+		switch val := v.AppID.(type) {
+		case string:
+			appIDStr = val
+		case float64:
+			appIDStr = strconv.FormatInt(int64(val), 10)
+		case int64:
+			appIDStr = strconv.FormatInt(val, 10)
+		case int:
+			appIDStr = strconv.Itoa(val)
+		default:
+			appIDStr = fmt.Sprintf("%v", val)
+		}
+	}
+	appIDStr = strings.TrimSpace(appIDStr)
+	appSecret := strings.TrimSpace(v.AppSecret)
+
+	probeCtx, cancel := context.WithTimeout(c.Request().Context(), 15*time.Second)
+	defer cancel()
+	probe, err := dice.ProbeOfficialQQAccount(probeCtx, appIDStr, appSecret)
+	if err != nil {
+		return Error(&c, err.Error(), Response{})
+	}
+
+	userID := "OpenQQ:" + probe.UIN
+	var existingEndpoint *dice.EndPointInfo
+	for _, endpoint := range myDice.ImSession.EndPoints {
+		if endpoint.Platform == "QQ" && endpoint.ProtocolType == "official" && endpoint.UserID == userID {
+			existingEndpoint = endpoint
+			break
+		}
+	}
+	if v.TestOnly {
+		result := Response{
+			"testOnly": true,
+			"userId":   userID,
+			"uin":      probe.UIN,
+			"nickname": probe.Nickname,
+			"exists":   existingEndpoint != nil,
+		}
+		if existingEndpoint != nil {
+			result["id"] = existingEndpoint.ID
+		}
+		return Success(&c, result)
+	}
+	if existingEndpoint != nil {
+		return Error(&c, "该 QQ 官方机器人账号已存在，请先删除已有账号后重新添加", Response{
+			"code":   CodeAlreadyExists,
+			"id":     existingEndpoint.ID,
+			"userId": existingEndpoint.UserID,
+			"uin":    probe.UIN,
+		})
+	}
+
+	conn := dice.NewOfficialQQConnItem(appIDStr, appSecret, probe.UIN, v.OnlyQQGuild)
+	conn.UserID = userID
+	conn.Nickname = probe.Nickname
+	conn.BindRuntime(myDice.ImSession)
+	pa := conn.Adapter.(*dice.PlatformAdapterOfficialQQ)
+	pa.Token = v.Token // Deprecated: preserve values submitted by old clients, but do not use them.
+	pa.UseWebhook = v.UseWebhook
+	pa.WebhookPath = v.WebhookPath
+	pa.WebhookPort = v.WebhookPort
+	myDice.ImSession.EndPoints = append(myDice.ImSession.EndPoints, conn)
+	myDice.LastUpdatedTime = time.Now().Unix()
+	myDice.Save(false)
+	go dice.ServerOfficialQQ(myDice, conn)
+	return Success(&c, Response{
+		"id":     conn.ID,
+		"userId": conn.UserID,
+		"uin":    probe.UIN,
+	})
 }
 
 func ImConnectionsAddSatori(c echo.Context) error {

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -1095,6 +1095,7 @@ func (d *Dice) PublicDiceEndpointRefresh() {
 		endpointItems = append(endpointItems, &public_dice.Endpoint{
 			Platform: i.Platform,
 			UID:      i.UserID,
+			AppID:    publicDiceEndpointAppID(i),
 			IsOnline: i.State == 1,
 		})
 	}
@@ -1142,6 +1143,7 @@ func (d *Dice) PublicDiceSetupTick() {
 			}
 			tickEndpointItems = append(tickEndpointItems, &public_dice.TickEndpoint{
 				UID:      i.UserID,
+				AppID:    publicDiceEndpointAppID(i),
 				IsOnline: i.State == 1,
 			})
 		}
@@ -1162,6 +1164,17 @@ func (d *Dice) PublicDiceSetupTick() {
 	}()
 
 	d.PublicDiceTimerId, _ = d.Cron.AddFunc("@every 3m", doTickUpdate)
+}
+
+func publicDiceEndpointAppID(endpoint *EndPointInfo) string {
+	if endpoint == nil || endpoint.Platform != "QQ" || endpoint.ProtocolType != "official" {
+		return ""
+	}
+	adapter, ok := endpoint.Adapter.(*PlatformAdapterOfficialQQ)
+	if !ok || adapter == nil {
+		return ""
+	}
+	return adapter.AppID
 }
 
 func (d *Dice) PublicDiceSetup() {

--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -1,0 +1,1093 @@
+package dice
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	ds "github.com/sealdice/dicescript"
+	"gorm.io/gorm"
+
+	"sealdice-core/model"
+	"sealdice-core/utils/constant"
+	"sealdice-core/utils/dboperator/engine"
+)
+
+type officialQQIdentityMigration struct {
+	appID          string
+	uin            string
+	oldEndpoint    string
+	newEndpoint    string
+	groups         map[string]string
+	users          map[string]string
+	characterNames map[string]string
+}
+
+type officialQQIdentityMigrationError struct {
+	cause error
+}
+
+func (e *officialQQIdentityMigrationError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *officialQQIdentityMigrationError) Unwrap() error {
+	return e.cause
+}
+
+func migratedCharacterName(baseName string, suffix int) string {
+	if baseName == "" {
+		baseName = "未命名角色"
+	}
+	suffixText := fmt.Sprintf(" (%d)", suffix)
+	const maxNameBytes = 90
+	maxBaseBytes := maxNameBytes - len(suffixText)
+	if len(baseName) > maxBaseBytes {
+		baseName = baseName[:maxBaseBytes]
+		for !utf8.ValidString(baseName) {
+			baseName = baseName[:len(baseName)-1]
+		}
+	}
+	return baseName + suffixText
+}
+
+func ensureOfficialQQIdentity(d *Dice, pa *PlatformAdapterOfficialQQ, botID, uin string) error {
+	if d == nil || pa == nil || pa.EndPoint == nil {
+		return errors.New("QQ 官方机器人运行时未初始化")
+	}
+	if strings.TrimSpace(uin) == "" {
+		return errors.New("QQ 官方机器人 UIN 为空")
+	}
+
+	expectedEndpoint := formatDiceIDOfficialQQ(uin)
+	oldEndpoint := formatDiceIDOfficialQQ(botID)
+	if current := pa.EndPoint.UserID; current != "" && current != oldEndpoint && current != expectedEndpoint {
+		return fmt.Errorf("无法识别旧账号 ID %q，期望 %q", current, oldEndpoint)
+	}
+	// Apply the remotely verified identity even if data migration fails. The
+	// adapter can keep running, and the same migration will be retried on the
+	// next connection or after the account is added again.
+	pa.UIN = uin
+	pa.EndPoint.UserID = expectedEndpoint
+
+	migration := &officialQQIdentityMigration{
+		appID:       pa.AppID,
+		uin:         uin,
+		oldEndpoint: oldEndpoint,
+		newEndpoint: expectedEndpoint,
+		groups:      map[string]string{},
+		users:       map[string]string{},
+	}
+	if err := migration.run(d); err != nil {
+		return &officialQQIdentityMigrationError{cause: err}
+	}
+
+	d.LastUpdatedTime = time.Now().Unix()
+	d.Save(false)
+	return nil
+}
+
+func (m *officialQQIdentityMigration) oldGroupPrefix() string {
+	return "OpenQQ-Group-T:" + m.appID + "-"
+}
+
+func (m *officialQQIdentityMigration) oldMemberPrefix(groupOpenID string) string {
+	return "OpenQQ-Member-T:" + m.appID + "-" + groupOpenID + "-"
+}
+
+func (m *officialQQIdentityMigration) addGroup(groupID string) bool {
+	groupOpenID, ok := strings.CutPrefix(groupID, m.oldGroupPrefix())
+	if !ok {
+		return false
+	}
+	// Some old releases persisted one synthetic group with an empty GroupOpenID.
+	// Keep its data under a deterministic non-QQ placeholder instead of dropping it.
+	if groupOpenID == "" {
+		groupOpenID = "legacy-empty-" + m.appID
+	}
+	m.groups[groupID] = formatDiceIDOfficialQQGroupOpenID(m.uin, groupOpenID)
+	return true
+}
+
+func (m *officialQQIdentityMigration) groupOpenID(groupID string) (string, bool) {
+	groupOpenID, ok := strings.CutPrefix(groupID, m.oldGroupPrefix())
+	return groupOpenID, ok
+}
+
+func (m *officialQQIdentityMigration) addMember(groupID, userID string) bool {
+	groupOpenID, ok := m.groupOpenID(groupID)
+	if !ok {
+		return false
+	}
+	memberOpenID, ok := strings.CutPrefix(userID, m.oldMemberPrefix(groupOpenID))
+	if !ok || memberOpenID == "" {
+		return false
+	}
+	m.users[userID] = formatDiceIDOfficialQQMemberOpenID(m.uin, groupOpenID, memberOpenID)
+	return true
+}
+
+func (m *officialQQIdentityMigration) addMemberID(userID string) bool {
+	if _, exists := m.users[userID]; exists {
+		return true
+	}
+	rest, ok := strings.CutPrefix(userID, "OpenQQ-Member-T:"+m.appID+"-")
+	if !ok {
+		return false
+	}
+	for _, oldGroupID := range m.sortedOldGroups() {
+		groupOpenID, exists := m.groupOpenID(oldGroupID)
+		if !exists {
+			continue
+		}
+		memberOpenID, matches := strings.CutPrefix(rest, groupOpenID+"-")
+		if matches && memberOpenID != "" {
+			m.users[userID] = formatDiceIDOfficialQQMemberOpenID(m.uin, groupOpenID, memberOpenID)
+			return true
+		}
+	}
+	separator := strings.LastIndexByte(rest, '-')
+	if separator <= 0 || separator == len(rest)-1 {
+		return false
+	}
+	memberOpenID := rest[separator+1:]
+	m.users[userID] = formatDiceIDOfficialQQMemberOpenID(m.uin, rest[:separator], memberOpenID)
+	return true
+}
+
+func (m *officialQQIdentityMigration) migrateGroupID(id string) string {
+	if value, ok := m.groups[id]; ok {
+		return value
+	}
+	return id
+}
+
+func (m *officialQQIdentityMigration) migrateUserID(id string) string {
+	if value, ok := m.users[id]; ok {
+		return value
+	}
+	if m.addMemberID(id) {
+		return m.users[id]
+	}
+	return id
+}
+
+func (m *officialQQIdentityMigration) migrateAnyID(id string) string {
+	if id == m.oldEndpoint {
+		return m.newEndpoint
+	}
+	if value := m.migrateGroupID(id); value != id {
+		return value
+	}
+	return m.migrateUserID(id)
+}
+
+func (m *officialQQIdentityMigration) migrateContextUserID(groupID, userID string) string {
+	if _, ok := m.users[userID]; !ok {
+		m.addMember(groupID, userID)
+	}
+	return m.migrateUserID(userID)
+}
+
+func (m *officialQQIdentityMigration) sortedOldGroups() []string {
+	groups := make([]string, 0, len(m.groups))
+	for groupID := range m.groups {
+		groups = append(groups, groupID)
+	}
+	sort.Slice(groups, func(i, j int) bool { return len(groups[i]) > len(groups[j]) })
+	return groups
+}
+
+func (m *officialQQIdentityMigration) migrateAttrsID(id, attrsType string) string {
+	if attrsType == "character" {
+		return id
+	}
+	if value := m.migrateAnyID(id); value != id {
+		return value
+	}
+	if attrsType != "" && attrsType != "group_user" {
+		return id
+	}
+	for _, oldGroupID := range m.sortedOldGroups() {
+		userID, ok := strings.CutPrefix(id, oldGroupID+"-")
+		if !ok || userID == "" {
+			continue
+		}
+		newUserID := m.migrateContextUserID(oldGroupID, userID)
+		if newUserID == userID {
+			return id
+		}
+		return m.groups[oldGroupID] + "-" + newUserID
+	}
+	return id
+}
+
+func (m *officialQQIdentityMigration) run(d *Dice) error {
+	if d.DBOperator != nil {
+		if err := m.collectDatabase(d.DBOperator); err != nil {
+			return err
+		}
+	}
+	m.collectMemory(d)
+
+	if d.AttrsManager != nil {
+		if err := d.AttrsManager.CheckForSave(); err != nil {
+			return fmt.Errorf("迁移前保存属性数据失败: %w", err)
+		}
+	}
+	if d.DBOperator != nil {
+		if err := m.migrateDataDB(d.DBOperator); err != nil {
+			return fmt.Errorf("迁移主数据库失败: %w", err)
+		}
+		if err := m.migrateLogDB(d.DBOperator); err != nil {
+			return fmt.Errorf("迁移日志数据库失败: %w", err)
+		}
+		if err := m.migrateCensorDB(d.DBOperator); err != nil {
+			return fmt.Errorf("迁移敏感词数据库失败: %w", err)
+		}
+		if err := m.syncCharacterCache(d, d.DBOperator); err != nil {
+			return fmt.Errorf("同步角色卡缓存失败: %w", err)
+		}
+	}
+	m.migrateMemory(d)
+	return nil
+}
+
+func (m *officialQQIdentityMigration) syncCharacterCache(d *Dice, operator engine.DatabaseOperator) error {
+	if d.AttrsManager == nil {
+		return nil
+	}
+	var ids []string
+	d.AttrsManager.m.Range(func(id string, _ *AttributesItem) bool {
+		ids = append(ids, id)
+		return true
+	})
+	if len(ids) == 0 {
+		return nil
+	}
+
+	db := operator.GetDataDB(constant.READ)
+	if !hasTable(db, &model.AttributesItemModel{}) {
+		return nil
+	}
+	var rows []model.AttributesItemModel
+	if err := db.Select("id, name").Where("attrs_type = ? AND id IN ?", "character", ids).Find(&rows).Error; err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if item, ok := d.AttrsManager.m.Load(row.Id); ok && item != nil {
+			item.Name = row.Name
+			item.IsSaved = true
+		}
+	}
+	return nil
+}
+
+func hasTable(db *gorm.DB, value any) bool {
+	return db != nil && db.Migrator().HasTable(value)
+}
+
+func (m *officialQQIdentityMigration) collectDatabase(operator engine.DatabaseOperator) error {
+	dataDB := operator.GetDataDB(constant.READ)
+	if hasTable(dataDB, &model.GroupInfo{}) {
+		var rows []model.GroupInfo
+		if err := dataDB.Where("id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			m.addGroup(row.ID)
+		}
+	}
+	if hasTable(dataDB, &model.GroupPlayerInfoBase{}) {
+		var rows []model.GroupPlayerInfoBase
+		if err := dataDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			m.addGroup(row.GroupID)
+			m.addMember(row.GroupID, row.UserID)
+		}
+	}
+
+	logDB := operator.GetLogDB(constant.READ)
+	if hasTable(logDB, &model.LogInfo{}) {
+		var rows []model.LogInfo
+		if err := logDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			m.addGroup(row.GroupID)
+		}
+	}
+	if hasTable(logDB, &model.LogOneItem{}) {
+		var rows []model.LogOneItem
+		if err := logDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			m.addGroup(row.GroupID)
+			m.addMember(row.GroupID, row.IMUserID)
+			m.addMember(row.GroupID, row.UniformID)
+		}
+	}
+
+	censorDB := operator.GetCensorDB(constant.READ)
+	if hasTable(censorDB, &model.CensorLog{}) {
+		var rows []model.CensorLog
+		if err := censorDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			m.addGroup(row.GroupID)
+			m.addMember(row.GroupID, row.UserID)
+		}
+	}
+
+	if hasTable(dataDB, &model.AttributesItemModel{}) {
+		var rows []model.AttributesItemModel
+		query := "id LIKE ? OR id LIKE ? OR owner_id LIKE ?"
+		if err := dataDB.Where(query, m.oldGroupPrefix()+"%", "%"+"OpenQQ-Member-T:"+m.appID+"-%", "OpenQQ-Member-T:"+m.appID+"-%").Find(&rows).Error; err != nil {
+			return err
+		}
+		groupUserMarker := "-OpenQQ-Member-T:" + m.appID + "-"
+		for _, row := range rows {
+			if marker := strings.Index(row.Id, groupUserMarker); marker > 0 {
+				oldGroupID := row.Id[:marker]
+				if m.addGroup(oldGroupID) {
+					m.addMember(oldGroupID, row.Id[marker+1:])
+				}
+			} else if strings.HasPrefix(row.Id, m.oldGroupPrefix()) {
+				m.addGroup(row.Id)
+			}
+			m.addMemberID(row.Id)
+			m.addMemberID(row.OwnerId)
+		}
+	}
+
+	if hasTable(dataDB, &model.BanInfo{}) {
+		var rows []model.BanInfo
+		if err := dataDB.Where("id LIKE ? OR id LIKE ?", m.oldGroupPrefix()+"%", "OpenQQ-Member-T:"+m.appID+"-%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			var item BanListInfoItem
+			if json.Unmarshal(row.Data, &item) != nil {
+				continue
+			}
+			for _, place := range item.Places {
+				m.addGroup(place)
+				m.addMember(place, row.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func (m *officialQQIdentityMigration) collectMemory(d *Dice) {
+	if d.ImSession != nil && d.ImSession.ServiceAtNew != nil {
+		d.ImSession.ServiceAtNew.Range(func(groupID string, group *GroupInfo) bool {
+			if !m.addGroup(groupID) {
+				return true
+			}
+			if group != nil {
+				m.addMember(groupID, group.InviteUserID)
+				if group.Players != nil {
+					group.Players.Range(func(userID string, _ *GroupPlayerInfo) bool {
+						m.addMember(groupID, userID)
+						return true
+					})
+				}
+			}
+			return true
+		})
+	}
+	if d.Config.BanList != nil && d.Config.BanList.Map != nil {
+		d.Config.BanList.Map.Range(func(id string, item *BanListInfoItem) bool {
+			if item != nil {
+				for _, place := range item.Places {
+					m.addGroup(place)
+					m.addMember(place, id)
+				}
+			}
+			return true
+		})
+	}
+}
+
+func ensureNoTarget(db *gorm.DB, value any, where string, args ...any) error {
+	var count int64
+	if err := db.Model(value).Where(where, args...).Count(&count).Error; err != nil {
+		return err
+	}
+	if count != 0 {
+		return fmt.Errorf("目标数据已存在: %s %v", where, args)
+	}
+	return nil
+}
+
+func mergeOfficialQQUserAttrs(rows []model.AttributesItemModel) (model.AttributesItemModel, error) {
+	if len(rows) == 0 {
+		return model.AttributesItemModel{}, errors.New("没有可合并的 QQ 官方用户属性")
+	}
+
+	ordered := append([]model.AttributesItemModel(nil), rows...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].UpdatedAt != ordered[j].UpdatedAt {
+			return ordered[i].UpdatedAt < ordered[j].UpdatedAt
+		}
+		if ordered[i].CreatedAt != ordered[j].CreatedAt {
+			return ordered[i].CreatedAt < ordered[j].CreatedAt
+		}
+		return ordered[i].Id < ordered[j].Id
+	})
+
+	merged := &ds.ValueMap{}
+	createdAt := ordered[0].CreatedAt
+	updatedAt := ordered[0].UpdatedAt
+	for _, row := range ordered {
+		if row.AttrsType != "" && row.AttrsType != "user" {
+			return model.AttributesItemModel{}, fmt.Errorf("无法合并 QQ 官方用户属性 %s: attrs_type=%q", row.Id, row.AttrsType)
+		}
+		if row.BindingSheetId != "" {
+			return model.AttributesItemModel{}, fmt.Errorf("无法合并带角色绑定的 QQ 官方用户属性 %s", row.Id)
+		}
+		value, err := ds.VMValueFromJSON(row.Data)
+		if err != nil {
+			return model.AttributesItemModel{}, fmt.Errorf("解析 QQ 官方用户属性 %s 失败: %w", row.Id, err)
+		}
+		dict, ok := value.ReadDictData()
+		if !ok {
+			return model.AttributesItemModel{}, fmt.Errorf("QQ 官方用户属性 %s 不是字典", row.Id)
+		}
+		if dict.Dict != nil {
+			dict.Dict.Range(func(key string, value *ds.VMValue) bool {
+				merged.Store(key, value)
+				return true
+			})
+		}
+		if row.CreatedAt < createdAt {
+			createdAt = row.CreatedAt
+		}
+		if row.UpdatedAt > updatedAt {
+			updatedAt = row.UpdatedAt
+		}
+	}
+
+	data, err := ds.NewDictVal(merged).V().ToJSON()
+	if err != nil {
+		return model.AttributesItemModel{}, fmt.Errorf("序列化合并后的 QQ 官方用户属性失败: %w", err)
+	}
+	result := ordered[len(ordered)-1]
+	result.Data = data
+	result.AttrsType = "user"
+	result.BindingSheetId = ""
+	result.CreatedAt = createdAt
+	result.UpdatedAt = updatedAt
+	return result, nil
+}
+
+func (m *officialQQIdentityMigration) mergeCollidingUserAttrs(tx *gorm.DB, rows []model.AttributesItemModel) (map[string]struct{}, error) {
+	byTarget := map[string][]model.AttributesItemModel{}
+	for _, row := range rows {
+		newID := m.migrateUserID(row.Id)
+		if newID == row.Id {
+			continue
+		}
+		byTarget[newID] = append(byTarget[newID], row)
+	}
+
+	targets := make([]string, 0, len(byTarget))
+	for target, sources := range byTarget {
+		if len(sources) > 1 {
+			targets = append(targets, target)
+		}
+	}
+	sort.Strings(targets)
+
+	mergedSourceIDs := map[string]struct{}{}
+	for _, target := range targets {
+		sources := byTarget[target]
+		var existing model.AttributesItemModel
+		result := tx.Where("id = ?", target).Limit(1).Find(&existing)
+		if result.Error != nil {
+			return nil, result.Error
+		}
+		if result.RowsAffected != 0 {
+			sources = append(sources, existing)
+		}
+
+		merged, err := mergeOfficialQQUserAttrs(sources)
+		if err != nil {
+			return nil, err
+		}
+		merged.Id = target
+		merged.OwnerId = m.migrateUserID(merged.OwnerId)
+
+		ids := make([]string, 0, len(sources))
+		for _, source := range sources {
+			ids = append(ids, source.Id)
+			if source.Id != target {
+				mergedSourceIDs[source.Id] = struct{}{}
+			}
+		}
+		if err := tx.Where("id IN ?", ids).Delete(&model.AttributesItemModel{}).Error; err != nil {
+			return nil, err
+		}
+		if err := tx.Create(&merged).Error; err != nil {
+			return nil, err
+		}
+	}
+	return mergedSourceIDs, nil
+}
+
+func (m *officialQQIdentityMigration) planCharacterNames(tx *gorm.DB, rows []model.AttributesItemModel) (map[string]string, error) {
+	type ownerName struct {
+		owner string
+		name  string
+	}
+	type candidate struct {
+		id        string
+		owner     string
+		name      string
+		createdAt int64
+	}
+
+	owners := map[string]struct{}{}
+	groups := map[ownerName][]candidate{}
+	for _, row := range rows {
+		newOwnerID := m.migrateUserID(row.OwnerId)
+		if row.AttrsType != "character" || newOwnerID == row.OwnerId {
+			continue
+		}
+		owners[newOwnerID] = struct{}{}
+		key := ownerName{owner: newOwnerID, name: row.Name}
+		groups[key] = append(groups[key], candidate{
+			id:        row.Id,
+			owner:     newOwnerID,
+			name:      row.Name,
+			createdAt: row.CreatedAt,
+		})
+	}
+	if len(owners) == 0 {
+		return map[string]string{}, nil
+	}
+
+	ownerIDs := make([]string, 0, len(owners))
+	for ownerID := range owners {
+		ownerIDs = append(ownerIDs, ownerID)
+	}
+	var existing []model.AttributesItemModel
+	if err := tx.Where("attrs_type = ? AND owner_id IN ?", "character", ownerIDs).Find(&existing).Error; err != nil {
+		return nil, err
+	}
+
+	usedNames := map[string]map[string]struct{}{}
+	for ownerID := range owners {
+		usedNames[ownerID] = map[string]struct{}{}
+	}
+	for _, row := range existing {
+		usedNames[row.OwnerId][row.Name] = struct{}{}
+	}
+
+	keys := make([]ownerName, 0, len(groups))
+	for key := range groups {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].owner != keys[j].owner {
+			return keys[i].owner < keys[j].owner
+		}
+		return keys[i].name < keys[j].name
+	})
+
+	var duplicates []candidate
+	for _, key := range keys {
+		items := groups[key]
+		sort.Slice(items, func(i, j int) bool {
+			if items[i].createdAt != items[j].createdAt {
+				return items[i].createdAt < items[j].createdAt
+			}
+			return items[i].id < items[j].id
+		})
+		if _, exists := usedNames[key.owner][key.name]; !exists {
+			usedNames[key.owner][key.name] = struct{}{}
+			items = items[1:]
+		}
+		duplicates = append(duplicates, items...)
+	}
+
+	sort.Slice(duplicates, func(i, j int) bool {
+		if duplicates[i].owner != duplicates[j].owner {
+			return duplicates[i].owner < duplicates[j].owner
+		}
+		if duplicates[i].createdAt != duplicates[j].createdAt {
+			return duplicates[i].createdAt < duplicates[j].createdAt
+		}
+		return duplicates[i].id < duplicates[j].id
+	})
+
+	renames := map[string]string{}
+	for _, item := range duplicates {
+		for suffix := 2; ; suffix++ {
+			newName := migratedCharacterName(item.name, suffix)
+			if _, exists := usedNames[item.owner][newName]; exists {
+				continue
+			}
+			usedNames[item.owner][newName] = struct{}{}
+			renames[item.id] = newName
+			break
+		}
+	}
+	m.characterNames = renames
+	return renames, nil
+}
+
+func (m *officialQQIdentityMigration) migrateDataDB(operator engine.DatabaseOperator) error {
+	db := operator.GetDataDB(constant.WRITE)
+	if db == nil {
+		return nil
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		if hasTable(tx, &model.GroupInfo{}) {
+			var rows []model.GroupInfo
+			if err := tx.Where("id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+				return err
+			}
+			for _, row := range rows {
+				newID := m.migrateGroupID(row.ID)
+				if newID == row.ID {
+					continue
+				}
+				if err := ensureNoTarget(tx, &model.GroupInfo{}, "id = ?", newID); err != nil {
+					return err
+				}
+				var group GroupInfo
+				if err := json.Unmarshal(row.Data, &group); err != nil {
+					return fmt.Errorf("解析群组 %s 失败: %w", row.ID, err)
+				}
+				m.migrateGroup(&group, row.ID)
+				data, err := json.Marshal(&group)
+				if err != nil {
+					return err
+				}
+				if err := tx.Model(&model.GroupInfo{}).Where("id = ?", row.ID).Updates(map[string]any{"id": newID, "data": data}).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		if hasTable(tx, &model.GroupPlayerInfoBase{}) {
+			var rows []model.GroupPlayerInfoBase
+			if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+				return err
+			}
+			for _, row := range rows {
+				newGroupID := m.migrateGroupID(row.GroupID)
+				newUserID := m.migrateContextUserID(row.GroupID, row.UserID)
+				if err := tx.Model(&model.GroupPlayerInfoBase{}).Where("id = ?", row.ID).Updates(map[string]any{"group_id": newGroupID, "user_id": newUserID}).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		if hasTable(tx, &model.AttributesItemModel{}) {
+			var rows []model.AttributesItemModel
+			query := "id LIKE ? OR id LIKE ? OR owner_id LIKE ?"
+			if err := tx.Where(query, m.oldGroupPrefix()+"%", "%"+"OpenQQ-Member-T:"+m.appID+"-%", "OpenQQ-Member-T:"+m.appID+"-%").Find(&rows).Error; err != nil {
+				return err
+			}
+			characterNames, err := m.planCharacterNames(tx, rows)
+			if err != nil {
+				return err
+			}
+			mergedUserAttrs, err := m.mergeCollidingUserAttrs(tx, rows)
+			if err != nil {
+				return err
+			}
+			for _, row := range rows {
+				if _, merged := mergedUserAttrs[row.Id]; merged {
+					continue
+				}
+				newID := m.migrateAttrsID(row.Id, row.AttrsType)
+				newOwnerID := m.migrateUserID(row.OwnerId)
+				newName, rename := characterNames[row.Id]
+				if newID == row.Id && newOwnerID == row.OwnerId && !rename {
+					continue
+				}
+				if newID != row.Id {
+					if err := ensureNoTarget(tx, &model.AttributesItemModel{}, "id = ?", newID); err != nil {
+						return err
+					}
+				}
+				updates := map[string]any{"id": newID, "owner_id": newOwnerID}
+				if rename {
+					updates["name"] = newName
+				}
+				if err := tx.Model(&model.AttributesItemModel{}).Where("id = ?", row.Id).Updates(updates).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		if hasTable(tx, &model.BanInfo{}) {
+			var rows []model.BanInfo
+			if err := tx.Find(&rows).Error; err != nil {
+				return err
+			}
+			for _, row := range rows {
+				newID := m.migrateAnyID(row.ID)
+				var item BanListInfoItem
+				if err := json.Unmarshal(row.Data, &item); err != nil {
+					continue
+				}
+				m.migrateBanItem(&item)
+				data, err := json.Marshal(&item)
+				if err != nil {
+					return err
+				}
+				if newID != row.ID {
+					if err := ensureNoTarget(tx, &model.BanInfo{}, "id = ?", newID); err != nil {
+						return err
+					}
+				}
+				if err := tx.Model(&model.BanInfo{}).Where("id = ?", row.ID).Updates(map[string]any{"id": newID, "data": data}).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		if hasTable(tx, &model.EndpointInfo{}) {
+			var old model.EndpointInfo
+			result := tx.Where("user_id = ?", m.oldEndpoint).Limit(1).Find(&old)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected != 0 {
+				var target model.EndpointInfo
+				targetResult := tx.Where("user_id = ?", m.newEndpoint).Limit(1).Find(&target)
+				if targetResult.Error != nil {
+					return targetResult.Error
+				}
+				if targetResult.RowsAffected == 0 {
+					if err := tx.Model(&model.EndpointInfo{}).Where("user_id = ?", m.oldEndpoint).Update("user_id", m.newEndpoint).Error; err != nil {
+						return err
+					}
+				} else {
+					updates := map[string]any{
+						"cmd_num":       max(old.CmdNum, target.CmdNum),
+						"cmd_last_time": max(old.CmdLastTime, target.CmdLastTime),
+						"online_time":   max(old.OnlineTime, target.OnlineTime),
+						"updated_at":    max(old.UpdatedAt, target.UpdatedAt),
+					}
+					if err := tx.Model(&model.EndpointInfo{}).Where("user_id = ?", m.newEndpoint).Updates(updates).Error; err != nil {
+						return err
+					}
+					if err := tx.Where("user_id = ?", m.oldEndpoint).Delete(&model.EndpointInfo{}).Error; err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func (m *officialQQIdentityMigration) migrateLogDB(operator engine.DatabaseOperator) error {
+	db := operator.GetLogDB(constant.WRITE)
+	if db == nil {
+		return nil
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		if hasTable(tx, &model.LogInfo{}) {
+			var rows []model.LogInfo
+			if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+				return err
+			}
+			for _, row := range rows {
+				newGroupID := m.migrateGroupID(row.GroupID)
+				if err := ensureNoTarget(tx, &model.LogInfo{}, "group_id = ? AND name = ?", newGroupID, row.Name); err != nil {
+					return err
+				}
+				if err := tx.Model(&model.LogInfo{}).Where("id = ?", row.ID).Update("group_id", newGroupID).Error; err != nil {
+					return err
+				}
+			}
+		}
+		if hasTable(tx, &model.LogOneItem{}) {
+			var rows []model.LogOneItem
+			if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+				return err
+			}
+			for _, row := range rows {
+				updates := map[string]any{
+					"group_id":        m.migrateGroupID(row.GroupID),
+					"im_userid":       m.migrateContextUserID(row.GroupID, row.IMUserID),
+					"user_uniform_id": m.migrateContextUserID(row.GroupID, row.UniformID),
+				}
+				if err := tx.Model(&model.LogOneItem{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func (m *officialQQIdentityMigration) migrateCensorDB(operator engine.DatabaseOperator) error {
+	db := operator.GetCensorDB(constant.WRITE)
+	if db == nil || !hasTable(db, &model.CensorLog{}) {
+		return nil
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		var rows []model.CensorLog
+		if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			return err
+		}
+		for _, row := range rows {
+			updates := map[string]any{
+				"group_id": m.migrateGroupID(row.GroupID),
+				"user_id":  m.migrateContextUserID(row.GroupID, row.UserID),
+			}
+			if err := tx.Model(&model.CensorLog{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func migrateBoolMapKeys(values *SyncMap[string, bool], migrate func(string) string) {
+	if values == nil {
+		return
+	}
+	type entry struct {
+		old   string
+		value bool
+	}
+	var entries []entry
+	values.Range(func(key string, value bool) bool {
+		if newKey := migrate(key); newKey != key {
+			entries = append(entries, entry{old: key, value: value})
+		}
+		return true
+	})
+	for _, item := range entries {
+		values.Delete(item.old)
+		values.Store(migrate(item.old), item.value)
+	}
+}
+
+func (m *officialQQIdentityMigration) migrateGroup(group *GroupInfo, oldGroupID string) {
+	if group == nil {
+		return
+	}
+	group.GroupID = m.migrateGroupID(oldGroupID)
+	group.GuildID = m.migrateAnyID(group.GuildID)
+	group.ChannelID = m.migrateAnyID(group.ChannelID)
+	group.InviteUserID = m.migrateContextUserID(oldGroupID, group.InviteUserID)
+	migrateBoolMapKeys(group.DiceIDActiveMap, m.migrateAnyID)
+	migrateBoolMapKeys(group.DiceIDExistsMap, m.migrateAnyID)
+	migrateBoolMapKeys(group.BotList, m.migrateAnyID)
+
+	if group.Players != nil {
+		type playerEntry struct {
+			old    string
+			player *GroupPlayerInfo
+		}
+		var players []playerEntry
+		group.Players.Range(func(userID string, player *GroupPlayerInfo) bool {
+			players = append(players, playerEntry{old: userID, player: player})
+			return true
+		})
+		for _, item := range players {
+			newUserID := m.migrateContextUserID(oldGroupID, item.old)
+			if item.player != nil {
+				item.player.UserID = newUserID
+				item.player.GroupID = group.GroupID
+			}
+			if newUserID != item.old {
+				group.Players.Delete(item.old)
+				group.Players.Store(newUserID, item.player)
+			}
+		}
+	}
+
+	if group.PlayerGroups != nil {
+		type teamEntry struct {
+			old    string
+			values []string
+		}
+		var teams []teamEntry
+		group.PlayerGroups.Range(func(key string, values []string) bool {
+			teams = append(teams, teamEntry{old: key, values: values})
+			return true
+		})
+		for _, item := range teams {
+			newKey := m.migrateAnyID(item.old)
+			for index, value := range item.values {
+				item.values[index] = m.migrateAnyID(value)
+			}
+			if newKey != item.old {
+				group.PlayerGroups.Delete(item.old)
+			}
+			group.PlayerGroups.Store(newKey, item.values)
+		}
+	}
+}
+
+func (m *officialQQIdentityMigration) migrateBanItem(item *BanListInfoItem) {
+	if item == nil {
+		return
+	}
+	item.ID = m.migrateAnyID(item.ID)
+	for index, place := range item.Places {
+		item.Places[index] = m.migrateAnyID(place)
+	}
+}
+
+func (m *officialQQIdentityMigration) migrateMemory(d *Dice) {
+	if d.ImSession != nil && d.ImSession.ServiceAtNew != nil {
+		type groupEntry struct {
+			old   string
+			group *GroupInfo
+		}
+		var groups []groupEntry
+		d.ImSession.ServiceAtNew.Range(func(groupID string, group *GroupInfo) bool {
+			if _, ok := m.groups[groupID]; ok {
+				groups = append(groups, groupEntry{old: groupID, group: group})
+			}
+			return true
+		})
+		for _, item := range groups {
+			m.migrateGroup(item.group, item.old)
+			d.ImSession.ServiceAtNew.Delete(item.old)
+			d.ImSession.ServiceAtNew.Store(m.groups[item.old], item.group)
+		}
+	}
+	if d.ImSession != nil && d.ImSession.PendingQuits != nil {
+		type pendingQuitEntry struct {
+			old  string
+			info *PendingQuitInfo
+		}
+		var entries []pendingQuitEntry
+		d.ImSession.PendingQuits.Range(func(key string, info *PendingQuitInfo) bool {
+			groupID, endpointID, ok := strings.Cut(key, "\x00")
+			if !ok {
+				return true
+			}
+			newKey := makePendingQuitKey(m.migrateGroupID(groupID), m.migrateAnyID(endpointID))
+			if newKey != key {
+				entries = append(entries, pendingQuitEntry{old: key, info: info})
+			}
+			return true
+		})
+		for _, entry := range entries {
+			groupID, endpointID, _ := strings.Cut(entry.old, "\x00")
+			d.ImSession.PendingQuits.Delete(entry.old)
+			d.ImSession.PendingQuits.Store(makePendingQuitKey(m.migrateGroupID(groupID), m.migrateAnyID(endpointID)), entry.info)
+		}
+	}
+
+	if d.DirtyGroups != nil {
+		type dirtyEntry struct {
+			old   string
+			value int64
+		}
+		var entries []dirtyEntry
+		d.DirtyGroups.Range(func(groupID string, value int64) bool {
+			if _, ok := m.groups[groupID]; ok {
+				entries = append(entries, dirtyEntry{old: groupID, value: value})
+			}
+			return true
+		})
+		for _, item := range entries {
+			d.DirtyGroups.Delete(item.old)
+			d.DirtyGroups.Store(m.groups[item.old], item.value)
+		}
+	}
+
+	if d.AttrsManager != nil {
+		type attrsEntry struct {
+			old  string
+			item *AttributesItem
+		}
+		var entries []attrsEntry
+		d.AttrsManager.m.Range(func(id string, item *AttributesItem) bool {
+			if newName, ok := m.characterNames[id]; ok && item != nil {
+				item.Name = newName
+				item.IsSaved = true
+			}
+			newID := m.migrateAttrsID(id, "group_user")
+			if newID != id {
+				entries = append(entries, attrsEntry{old: id, item: item})
+			}
+			return true
+		})
+		for _, entry := range entries {
+			newID := m.migrateAttrsID(entry.old, "group_user")
+			d.AttrsManager.m.Delete(entry.old)
+			entry.item.ID = newID
+			d.AttrsManager.m.Store(newID, entry.item)
+		}
+	}
+
+	if d.Config.BanList != nil && d.Config.BanList.Map != nil {
+		type banEntry struct {
+			old  string
+			item *BanListInfoItem
+		}
+		var entries []banEntry
+		d.Config.BanList.Map.Range(func(id string, item *BanListInfoItem) bool {
+			if newID := m.migrateAnyID(id); newID != id {
+				entries = append(entries, banEntry{old: id, item: item})
+			} else {
+				m.migrateBanItem(item)
+			}
+			return true
+		})
+		for _, entry := range entries {
+			newID := m.migrateAnyID(entry.old)
+			d.Config.BanList.Map.Delete(entry.old)
+			m.migrateBanItem(entry.item)
+			d.Config.BanList.Map.Store(newID, entry.item)
+		}
+	}
+
+	for index, id := range d.DiceMasters {
+		d.DiceMasters[index] = m.migrateAnyID(id)
+	}
+	for index, id := range d.Config.NoticeIDs {
+		d.Config.NoticeIDs[index] = m.migrateAnyID(id)
+	}
+	d.Config.UpgradeWindowID = m.migrateAnyID(d.Config.UpgradeWindowID)
+
+	if d.Parent != nil {
+		m.migrateNameCache(&d.Parent.GroupNameCache, m.migrateGroupID)
+		m.migrateNameCache(&d.Parent.UserNameCache, m.migrateUserID)
+	}
+}
+
+func (m *officialQQIdentityMigration) migrateNameCache(cache *SyncMap[string, *GroupNameCacheItem], migrate func(string) string) {
+	if cache == nil {
+		return
+	}
+	type cacheEntry struct {
+		old  string
+		item *GroupNameCacheItem
+	}
+	var entries []cacheEntry
+	cache.Range(func(id string, item *GroupNameCacheItem) bool {
+		if newID := migrate(id); newID != id {
+			entries = append(entries, cacheEntry{old: id, item: item})
+		}
+		return true
+	})
+	for _, entry := range entries {
+		cache.Delete(entry.old)
+		cache.Store(migrate(entry.old), entry.item)
+	}
+}

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -13,10 +13,12 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	qqconstant "github.com/sealdice/botgo/constant"
 	"github.com/sealdice/botgo/event"
 	"github.com/sealdice/botgo/interaction/signature"
 
@@ -43,8 +45,9 @@ type PlatformAdapterOfficialQQ struct {
 	DiceServing bool          `yaml:"-"`
 
 	AppID       string `json:"appID"       yaml:"appID"`
-	AppSecret   string `json:"appSecret"   yaml:"appSecret"`
-	Token       string `json:"token"       yaml:"token"`
+	AppSecret   string `json:"-"           yaml:"appSecret"`
+	Token       string `json:"-"           yaml:"token,omitempty"` // Deprecated: preserved for old configurations and never used.
+	UIN         string `json:"uin"         yaml:"uin,omitempty"`
 	OnlyQQGuild bool   `json:"onlyQQGuild" yaml:"onlyQQGuild"`
 
 	// Webhook配置
@@ -57,12 +60,174 @@ type PlatformAdapterOfficialQQ struct {
 	Ctx            context.Context      `json:"-" yaml:"-"`
 	CancelFunc     context.CancelFunc   `json:"-" yaml:"-"`
 	tokenSource    oauth2.TokenSource   `json:"-" yaml:"-"`
+	botID          string               `json:"-" yaml:"-"`
 
 	// Webhook服务
 	webhookServer *http.Server `json:"-" yaml:"-"`
 
 	paginationCache map[string]*PaginationItem `json:"-" yaml:"-"`
 	paginationMu    sync.Mutex                 `json:"-" yaml:"-"`
+}
+
+type officialQQAdapterJSON struct {
+	AppID               string `json:"appID"`
+	UIN                 string `json:"uin"`
+	AppSecretConfigured bool   `json:"appSecretConfigured"`
+	OnlyQQGuild         bool   `json:"onlyQQGuild"`
+	UseWebhook          bool   `json:"useWebhook"`
+	WebhookPath         string `json:"webhookPath"`
+	WebhookPort         int    `json:"webhookPort"`
+}
+
+func (pa *PlatformAdapterOfficialQQ) MarshalJSON() ([]byte, error) {
+	return json.Marshal(officialQQAdapterJSON{
+		AppID:               pa.AppID,
+		UIN:                 pa.UIN,
+		AppSecretConfigured: strings.TrimSpace(pa.AppSecret) != "",
+		OnlyQQGuild:         pa.OnlyQQGuild,
+		UseWebhook:          pa.UseWebhook,
+		WebhookPath:         pa.WebhookPath,
+		WebhookPort:         pa.WebhookPort,
+	})
+}
+
+type OfficialQQAccountProbeResult struct {
+	UIN      string
+	BotID    string
+	Nickname string
+}
+
+type officialQQBotInfoResponse struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	ShareURL string `json:"share_url"`
+}
+
+type officialQQTransport interface {
+	Transport(ctx context.Context, method, url string, body interface{}) ([]byte, error)
+}
+
+func extractOfficialQQBotUIN(link string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(link))
+	if err != nil {
+		return "", fmt.Errorf("解析机器人分享链接失败: %w", err)
+	}
+	uin := strings.TrimSpace(parsed.Query().Get("robot_uin"))
+	if uin == "" {
+		return "", errors.New("机器人分享链接中缺少 robot_uin")
+	}
+	value, err := strconv.ParseUint(uin, 10, 64)
+	if err != nil || value == 0 {
+		return "", fmt.Errorf("机器人 UIN 无效: %q", uin)
+	}
+	return uin, nil
+}
+
+func extractOfficialQQBotUINFromResponse(body []byte) (string, error) {
+	var response struct {
+		URL     string `json:"url"`
+		URLLink string `json:"url_link"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("解析机器人分享链接响应失败: %w", err)
+	}
+	link := strings.TrimSpace(response.URLLink)
+	if link == "" {
+		link = strings.TrimSpace(response.URL) // Compatibility with SDKs that expose this field as url.
+	}
+	if link == "" {
+		return "", errors.New("机器人分享链接响应中缺少 url_link")
+	}
+	return extractOfficialQQBotUIN(link)
+}
+
+func getOfficialQQBotUINFromGeneratedLink(ctx context.Context, api officialQQTransport) (string, error) {
+	body, err := api.Transport(
+		ctx,
+		http.MethodPost,
+		qqconstant.APIDomain+"/v2/generate_url_link",
+		map[string]string{"callback_data": "sealdice"},
+	)
+	if err != nil {
+		return "", fmt.Errorf("生成机器人分享链接失败: %w", err)
+	}
+	return extractOfficialQQBotUINFromResponse(body)
+}
+
+func parseOfficialQQBotInfo(body []byte) (*officialQQBotInfoResponse, error) {
+	var response officialQQBotInfoResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("解析机器人信息失败: %w", err)
+	}
+	response.ID = strings.TrimSpace(response.ID)
+	response.Username = strings.TrimSpace(response.Username)
+	response.ShareURL = strings.TrimSpace(response.ShareURL)
+	if response.ID == "" {
+		return nil, errors.New("机器人信息响应中缺少 id")
+	}
+	return &response, nil
+}
+
+func getOfficialQQBotInfo(ctx context.Context, api officialQQTransport) (*OfficialQQAccountProbeResult, error) {
+	body, err := api.Transport(ctx, http.MethodGet, qqconstant.APIDomain+"/users/@me", nil)
+	if err != nil {
+		return nil, fmt.Errorf("获取机器人信息失败: %w", err)
+	}
+	botInfo, err := parseOfficialQQBotInfo(body)
+	if err != nil {
+		return nil, err
+	}
+
+	var shareURLErr error
+	if botInfo.ShareURL != "" {
+		if uin, err := extractOfficialQQBotUIN(botInfo.ShareURL); err == nil {
+			return &OfficialQQAccountProbeResult{UIN: uin, BotID: botInfo.ID, Nickname: botInfo.Username}, nil
+		} else {
+			shareURLErr = err
+		}
+	} else {
+		shareURLErr = errors.New("机器人信息响应中缺少 share_url")
+	}
+
+	// Older deployments may not include share_url in /users/@me yet.
+	uin, generatedLinkErr := getOfficialQQBotUINFromGeneratedLink(ctx, api)
+	if generatedLinkErr != nil {
+		return nil, fmt.Errorf("无法从机器人信息或生成的分享链接获取 UIN: %w; %w", shareURLErr, generatedLinkErr)
+	}
+	return &OfficialQQAccountProbeResult{UIN: uin, BotID: botInfo.ID, Nickname: botInfo.Username}, nil
+}
+
+func ProbeOfficialQQAccount(ctx context.Context, appID, appSecret string) (*OfficialQQAccountProbeResult, error) {
+	appID = strings.TrimSpace(appID)
+	appSecret = strings.TrimSpace(appSecret)
+	if appID == "" {
+		return nil, errors.New("AppID 不能为空")
+	}
+	if appSecret == "" {
+		return nil, errors.New("AppSecret 不能为空")
+	}
+	qqbot.SetLogger(NewDummyLogger())
+
+	tokenSource := qqtoken.NewQQBotTokenSource(&qqtoken.QQBotCredentials{
+		AppID:     appID,
+		AppSecret: appSecret,
+	})
+	if _, err := tokenSource.Token(); err != nil {
+		return nil, fmt.Errorf("获取 Access Token 失败: %w", err)
+	}
+	api := qqbot.NewOpenAPI(appID, tokenSource).WithTimeout(5 * time.Second)
+	botInfo, err := getOfficialQQBotInfo(ctx, api)
+	if err != nil {
+		return nil, err
+	}
+	ws, err := api.WS(ctx, nil, "")
+	if err != nil {
+		return nil, fmt.Errorf("获取 QQ 官方机器人网关接入点失败，请检查 IP 白名单: %w", err)
+	}
+	if ws == nil {
+		return nil, errors.New("QQ 官方机器人未返回网关接入点，请检查 IP 白名单")
+	}
+	return botInfo, nil
 }
 
 func (pa *PlatformAdapterOfficialQQ) Serve() int {
@@ -78,7 +243,7 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 
 	pa.AppID = strings.TrimSpace(pa.AppID)
 	pa.AppSecret = strings.TrimSpace(pa.AppSecret)
-	pa.Token = strings.TrimSpace(pa.Token)
+	pa.UIN = strings.TrimSpace(pa.UIN)
 
 	log.Debug("official qq server")
 	qqbot.SetLogger(NewDummyLogger())
@@ -108,14 +273,8 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 	// 创建 OpenAPI 客户端
 	pa.Api = qqbot.NewOpenAPI(pa.AppID, pa.tokenSource).WithTimeout(3 * time.Second)
 
-	// 注册事件处理器
-	event.RegisterHandlersByAppID(
-		pa.AppID,
-		pa.makeHandlers()...,
-	)
-
-	// 获取机器人信息
-	botInfo, err := pa.Api.Me(ctx)
+	// 获取机器人信息和 UIN。使用原始响应读取 botgo DTO 尚未包含的 share_url。
+	botInfo, err := getOfficialQQBotInfo(ctx, pa.Api)
 	if err != nil {
 		log.Error("official qq 获取机器人信息失败: ", err)
 		ep.State = 3
@@ -128,8 +287,43 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 		return 1
 	}
 
-	ep.UserID = formatDiceIDOfficialQQ(botInfo.ID)
-	ep.Nickname = botInfo.Username
+	uin := botInfo.UIN
+	if pa.UIN != "" && pa.UIN != uin {
+		log.Errorf("official qq UIN 校验失败: 配置为 %s，远端返回 %s", pa.UIN, uin)
+		ep.State = 3
+		if pa.CancelFunc != nil {
+			pa.CancelFunc()
+		}
+		pa.Api = nil
+		pa.Ctx = nil
+		pa.CancelFunc = nil
+		return 1
+	}
+	if err := ensureOfficialQQIdentity(d, pa, botInfo.BotID, uin); err != nil {
+		var migrationErr *officialQQIdentityMigrationError
+		if errors.As(err, &migrationErr) {
+			log.Error("official qq 身份数据迁移失败，将继续启动并在下次连接时重试: ", err)
+		} else {
+			log.Error("official qq 身份初始化失败: ", err)
+			ep.State = 3
+			if pa.CancelFunc != nil {
+				pa.CancelFunc()
+			}
+			pa.Api = nil
+			pa.Ctx = nil
+			pa.CancelFunc = nil
+			return 1
+		}
+	}
+
+	pa.botID = botInfo.BotID
+	ep.Nickname = botInfo.Nickname
+
+	// 身份校验和迁移完成后再开始接收事件。
+	event.RegisterHandlersByAppID(
+		pa.AppID,
+		pa.makeHandlers()...,
+	)
 
 	// 区分 Webhook 还是 WebSocket 模式
 	if pa.UseWebhook {
@@ -405,8 +599,7 @@ func (pa *PlatformAdapterOfficialQQ) InteractionReceive(eventRaw *dto.WSPayload,
 			log.Errorf("official qq 翻页发送群聊消息失败：%v", err)
 		} else if msg != nil {
 			ctx.MessageType = "group"
-			appID := pa.AppID
-			groupID := formatDiceIDOfficialQQGroupOpenID(appID, data.GroupOpenID)
+			groupID := formatDiceIDOfficialQQGroupOpenID(pa.UIN, data.GroupOpenID)
 			pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 				Platform:    "QQ",
 				MessageType: "group",
@@ -444,8 +637,7 @@ func (pa *PlatformAdapterOfficialQQ) InteractionReceive(eventRaw *dto.WSPayload,
 				log.Errorf("official qq 翻页发送群聊消息失败： %v", err)
 			} else if msg != nil {
 				ctx.MessageType = "group"
-				appID := pa.AppID
-				groupID := formatDiceIDOfficialQQGroupOpenID(appID, data.GroupOpenID)
+				groupID := formatDiceIDOfficialQQGroupOpenID(pa.UIN, data.GroupOpenID)
 				pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 					Platform:    "QQ",
 					MessageType: "group",
@@ -567,7 +759,6 @@ func (pa *PlatformAdapterOfficialQQ) GroupAtMessageReceive(event *dto.WSPayload,
 }
 
 func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(event *dto.WSPayload, msgQQ *dto.WSGroupATMessageData) *Message {
-	appID := pa.AppID
 	msg := new(Message)
 	timestamp, _ := msgQQ.Timestamp.Time()
 	msg.Time = timestamp.Unix()
@@ -575,7 +766,7 @@ func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(event *dto.WSPayload, msgQ
 	msg.Message = msgQQ.Content
 	msg.RawID = msgQQ.ID
 	msg.Platform = "OpenQQ"
-	msg.GroupID = formatDiceIDOfficialQQGroupOpenID(appID, msgQQ.GroupOpenID)
+	msg.GroupID = formatDiceIDOfficialQQGroupOpenID(pa.UIN, msgQQ.GroupOpenID)
 	if msgQQ.Author != nil {
 		if msgQQ.Author.Username != "" {
 			msg.Sender.Nickname = msgQQ.Author.Username
@@ -584,16 +775,14 @@ func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(event *dto.WSPayload, msgQ
 		} else {
 			msg.Sender.Nickname = "用户"
 		}
-		msg.Sender.UserID = formatDiceIDOfficialQQMemberOpenID(appID, msgQQ.GroupOpenID, msgQQ.Author.MemberOpenID)
+		msg.Sender.UserID = formatDiceIDOfficialQQMemberOpenID(pa.UIN, msgQQ.GroupOpenID, msgQQ.Author.MemberOpenID)
 		msg.Sender.GroupRole = msgQQ.Author.MemberRole
 	}
 
 	botSelfOpenID := pa.parseBotSelfOpenID(event)
 
 	if botSelfOpenID == "" {
-		botSelfOpenID = pa.EndPoint.UserID
-		botSelfOpenID = strings.TrimPrefix(botSelfOpenID, "OpenQQ:")
-		botSelfOpenID = strings.TrimPrefix(botSelfOpenID, "QQ:")
+		botSelfOpenID = pa.botID
 	}
 
 	m := officialQQAtRegex.FindStringSubmatch(msgQQ.Content)
@@ -621,7 +810,6 @@ func (pa *PlatformAdapterOfficialQQ) GroupMessageReceive(event *dto.WSPayload, d
 
 // groupNormalMsgToStdMsg 将群聊普通消息转换为标准消息
 func (pa *PlatformAdapterOfficialQQ) groupNormalMsgToStdMsg(event *dto.WSPayload, msgQQ *dto.WSGroupMessageData) *Message {
-	appID := pa.AppID
 	msg := new(Message)
 	timestamp, _ := msgQQ.Timestamp.Time()
 	msg.Time = timestamp.Unix()
@@ -629,7 +817,7 @@ func (pa *PlatformAdapterOfficialQQ) groupNormalMsgToStdMsg(event *dto.WSPayload
 	msg.Message = msgQQ.Content
 	msg.RawID = msgQQ.ID
 	msg.Platform = "OpenQQ"
-	msg.GroupID = formatDiceIDOfficialQQGroupOpenID(appID, msgQQ.GroupOpenID)
+	msg.GroupID = formatDiceIDOfficialQQGroupOpenID(pa.UIN, msgQQ.GroupOpenID)
 	if msgQQ.Author != nil {
 		if msgQQ.Author.Username != "" {
 			msg.Sender.Nickname = msgQQ.Author.Username
@@ -638,16 +826,14 @@ func (pa *PlatformAdapterOfficialQQ) groupNormalMsgToStdMsg(event *dto.WSPayload
 		} else {
 			msg.Sender.Nickname = "用户"
 		}
-		msg.Sender.UserID = formatDiceIDOfficialQQMemberOpenID(appID, msgQQ.GroupOpenID, msgQQ.Author.MemberOpenID)
+		msg.Sender.UserID = formatDiceIDOfficialQQMemberOpenID(pa.UIN, msgQQ.GroupOpenID, msgQQ.Author.MemberOpenID)
 		msg.Sender.GroupRole = msgQQ.Author.MemberRole
 	}
 
 	botSelfOpenID := pa.parseBotSelfOpenID(event)
 
 	if botSelfOpenID == "" {
-		botSelfOpenID = pa.EndPoint.UserID
-		botSelfOpenID = strings.TrimPrefix(botSelfOpenID, "OpenQQ:")
-		botSelfOpenID = strings.TrimPrefix(botSelfOpenID, "QQ:")
+		botSelfOpenID = pa.botID
 	}
 
 	for _, match := range officialQQAtRegex.FindAllStringSubmatch(msgQQ.Content, -1) {
@@ -675,7 +861,6 @@ func (pa *PlatformAdapterOfficialQQ) C2CMessageReceiveFromEvent(payload *dto.WSP
 
 // c2cMsgToStdMsg 将单聊消息转换为标准消息
 func (pa *PlatformAdapterOfficialQQ) c2cMsgToStdMsg(msgQQ *dto.WSC2CMessageData) *Message {
-	appID := pa.AppID
 	msg := new(Message)
 	timestamp, _ := msgQQ.Timestamp.Time()
 	msg.Time = timestamp.Unix()
@@ -692,7 +877,7 @@ func (pa *PlatformAdapterOfficialQQ) c2cMsgToStdMsg(msgQQ *dto.WSC2CMessageData)
 		} else {
 			msg.Sender.Nickname = "用户"
 		}
-		msg.Sender.UserID = formatDiceIDOfficialQQUserOpenID(appID, userOpenID)
+		msg.Sender.UserID = formatDiceIDOfficialQQUserOpenID(pa.UIN, userOpenID)
 	}
 	appendAttachmentsToMessage(msg, msgQQ.Attachments)
 	return msg
@@ -704,9 +889,8 @@ func (pa *PlatformAdapterOfficialQQ) GroupMemberAddReceive(event *dto.WSPayload,
 	log := s.Parent.Logger
 	log.Debugf("official qq: 收到群成员增加事件：%v, %v", event, data)
 
-	appID := pa.AppID
-	groupID := formatDiceIDOfficialQQGroupOpenID(appID, data.GroupOpenID)
-	userID := formatDiceIDOfficialQQMemberOpenID(appID, data.GroupOpenID, data.MemberOpenID)
+	groupID := formatDiceIDOfficialQQGroupOpenID(pa.UIN, data.GroupOpenID)
+	userID := formatDiceIDOfficialQQMemberOpenID(pa.UIN, data.GroupOpenID, data.MemberOpenID)
 
 	// 如果是机器人自己加入群聊
 	if userID == pa.EndPoint.UserID || data.MemberOpenID == "" || data.MemberOpenID == "BOT" {
@@ -764,9 +948,8 @@ func (pa *PlatformAdapterOfficialQQ) GroupMemberRemoveReceive(event *dto.WSPaylo
 	log := s.Parent.Logger
 	log.Debugf("official qq: 收到群成员减少事件：%v, %v", event, data)
 
-	appID := pa.AppID
-	groupID := formatDiceIDOfficialQQGroupOpenID(appID, data.GroupOpenID)
-	userID := formatDiceIDOfficialQQMemberOpenID(appID, data.GroupOpenID, data.MemberOpenID)
+	groupID := formatDiceIDOfficialQQGroupOpenID(pa.UIN, data.GroupOpenID)
+	userID := formatDiceIDOfficialQQMemberOpenID(pa.UIN, data.GroupOpenID, data.MemberOpenID)
 
 	// 如果是机器人自己被移出群
 	if userID == pa.EndPoint.UserID || data.MemberOpenID == "" || data.MemberOpenID == "BOT" {
@@ -825,8 +1008,7 @@ func (pa *PlatformAdapterOfficialQQ) C2CFriendReceive(event *dto.WSPayload, data
 
 	switch event.Type {
 	case dto.EventC2CFriendAdd:
-		appID := pa.AppID
-		userID := formatDiceIDOfficialQQUserOpenID(appID, data.OpenID)
+		userID := formatDiceIDOfficialQQUserOpenID(pa.UIN, data.OpenID)
 
 		ctx := &MsgContext{EndPoint: pa.EndPoint, Session: s, Dice: s.Parent}
 		if event != nil && event.EventID != "" {
@@ -866,8 +1048,7 @@ func (pa *PlatformAdapterOfficialQQ) C2CFriendReceive(event *dto.WSPayload, data
 			}
 		}()
 	case dto.EventC2CFriendDel:
-		appID := pa.AppID
-		userID := formatDiceIDOfficialQQUserOpenID(appID, data.OpenID)
+		userID := formatDiceIDOfficialQQUserOpenID(pa.UIN, data.OpenID)
 		log.Infof("official qq: 与 %s 解除好友关系", userID)
 	default:
 		// 忽略其他事件
@@ -1672,23 +1853,23 @@ func formatDiceIDOfficialQQChannel(guildID, channelID string) string {
 	return fmt.Sprintf("OpenQQCH-Channel:%s-%s", guildID, channelID)
 }
 
-func formatDiceIDOfficialQQ(userUnionID string) string {
-	return fmt.Sprintf("OpenQQ:%s", userUnionID)
+func formatDiceIDOfficialQQ(uin string) string {
+	return fmt.Sprintf("OpenQQ:%s", uin)
 }
 
-func formatDiceIDOfficialQQGroupOpenID(botID, groupOpenID string) string {
+func formatDiceIDOfficialQQGroupOpenID(uin, groupOpenID string) string {
 	// 官方QQ群ID格式
-	return fmt.Sprintf("OpenQQ-Group:%s", groupOpenID)
+	return fmt.Sprintf("OpenQQ-Group:%s-%s", uin, groupOpenID)
 }
 
-func formatDiceIDOfficialQQMemberOpenID(botID, groupOpenID, memberOpenID string) string {
+func formatDiceIDOfficialQQMemberOpenID(uin, _ string, memberOpenID string) string {
 	// 官方QQ群成员ID格式
-	return fmt.Sprintf("OpenQQ:%s", memberOpenID)
+	return fmt.Sprintf("OpenQQ:%s-%s", uin, memberOpenID)
 }
 
-func formatDiceIDOfficialQQUserOpenID(botID, userOpenID string) string {
+func formatDiceIDOfficialQQUserOpenID(uin, userOpenID string) string {
 	// 官方QQ单聊用户ID格式
-	return fmt.Sprintf("OpenQQ:%s", userOpenID)
+	return fmt.Sprintf("OpenQQ:%s-%s", uin, userOpenID)
 }
 
 type OpenQQIDType = int
@@ -1712,43 +1893,22 @@ func (pa *PlatformAdapterOfficialQQ) mustExtractID(text string) (string, OpenQQI
 }
 
 func (pa *PlatformAdapterOfficialQQ) mustExtractTwoID(text string) (string, string, OpenQQIDType) {
-	if strings.HasPrefix(text, "OpenQQ-Group:") {
-		temp := text[len("OpenQQ-Group:"):]
-		lst := strings.Split(temp, "-")
-		if len(lst) >= 2 {
-			return lst[1], "", OpenQQGroupOpenid
+	if raw, ok := strings.CutPrefix(text, "OpenQQ-Group:"); ok {
+		groupOpenID, ok := strings.CutPrefix(raw, pa.UIN+"-")
+		if pa.UIN == "" || !ok || groupOpenID == "" {
+			return "", "", OpenQQUnknown
 		}
-		return lst[0], "", OpenQQGroupOpenid
+		return groupOpenID, "", OpenQQGroupOpenid
 	}
-	if strings.HasPrefix(text, "Group:") {
-		temp := text[len("Group:"):]
-		lst := strings.Split(temp, "-")
-		if len(lst) >= 2 {
-			return lst[1], "", OpenQQGroupOpenid
+	if raw, ok := strings.CutPrefix(text, "OpenQQ:"); ok {
+		if pa.UIN != "" && raw == pa.UIN {
+			return raw, "", OpenQQUser
 		}
-		return lst[0], "", OpenQQGroupOpenid
-	}
-	if idx := strings.Index(text, "-Group:"); idx != -1 {
-		temp := text[idx+len("-Group:"):]
-		lst := strings.Split(temp, "-")
-		if len(lst) >= 2 {
-			return lst[1], "", OpenQQGroupOpenid
+		userOpenID, ok := strings.CutPrefix(raw, pa.UIN+"-")
+		if pa.UIN == "" || !ok || userOpenID == "" {
+			return "", "", OpenQQUnknown
 		}
-		return lst[0], "", OpenQQGroupOpenid
-	}
-	if strings.HasPrefix(text, "OpenQQ:") {
-		id := text[len("OpenQQ:"):]
-		if id == pa.AppID {
-			return id, "", OpenQQUser
-		}
-		return id, "", OpenQQUserOpenid
-	}
-	if strings.HasPrefix(text, "QQ:") {
-		id := text[len("QQ:"):]
-		if id == pa.AppID {
-			return id, "", OpenQQUser
-		}
-		return id, "", OpenQQUserOpenid
+		return userOpenID, "", OpenQQUserOpenid
 	}
 	if strings.HasPrefix(text, "OpenQQCH:") {
 		return text[len("OpenQQCH:"):], "", OpenQQCHUser

--- a/dice/platform_adapter_official_qq_helper.go
+++ b/dice/platform_adapter_official_qq_helper.go
@@ -13,7 +13,7 @@ import (
 	logger "sealdice-core/logger"
 )
 
-func NewOfficialQQConnItem(appID string, token string, appSecret string, onlyQQGuild bool) *EndPointInfo {
+func NewOfficialQQConnItem(appID, appSecret, uin string, onlyQQGuild bool) *EndPointInfo {
 	conn := new(EndPointInfo)
 	conn.ID = uuid.New().String()
 	conn.Platform = "QQ"
@@ -23,8 +23,8 @@ func NewOfficialQQConnItem(appID string, token string, appSecret string, onlyQQG
 	conn.Adapter = &PlatformAdapterOfficialQQ{
 		EndPoint:    conn,
 		AppID:       appID,
-		Token:       token,
 		AppSecret:   appSecret,
+		UIN:         uin,
 		OnlyQQGuild: onlyQQGuild,
 	}
 	return conn
@@ -56,13 +56,9 @@ func NewDummyLogger() DummyLogger {
 	}
 }
 
-func (d DummyLogger) Debug(v ...interface{}) {
-	d.logger.Debug(output(v...))
-}
+func (d DummyLogger) Debug(_ ...interface{}) {}
 
-func (d DummyLogger) Info(v ...interface{}) {
-	d.logger.Debug(output(v...))
-}
+func (d DummyLogger) Info(_ ...interface{}) {}
 
 func (d DummyLogger) Warn(v ...interface{}) {
 	d.logger.Warn(output(v...))
@@ -72,13 +68,9 @@ func (d DummyLogger) Error(v ...interface{}) {
 	d.logger.Error(output(v...))
 }
 
-func (d DummyLogger) Debugf(format string, v ...interface{}) {
-	d.logger.Debug(output(fmt.Sprintf(format, v...)))
-}
+func (d DummyLogger) Debugf(_ string, _ ...interface{}) {}
 
-func (d DummyLogger) Infof(format string, v ...interface{}) {
-	d.logger.Debug(output(fmt.Sprintf(format, v...)))
-}
+func (d DummyLogger) Infof(_ string, _ ...interface{}) {}
 
 func (d DummyLogger) Warnf(format string, v ...interface{}) {
 	d.logger.Warn(output(fmt.Sprintf(format, v...)))

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -1,0 +1,685 @@
+//nolint:testpackage
+package dice
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/sealdice/botgo/dto"
+	ds "github.com/sealdice/dicescript"
+	"gopkg.in/yaml.v3"
+	"gorm.io/gorm"
+
+	sealdiceLogger "sealdice-core/logger"
+	"sealdice-core/model"
+)
+
+type officialQQTransportFunc func(ctx context.Context, method, url string, body interface{}) ([]byte, error)
+
+func (f officialQQTransportFunc) Transport(ctx context.Context, method, url string, body interface{}) ([]byte, error) {
+	return f(ctx, method, url, body)
+}
+
+func TestExtractOfficialQQBotUIN(t *testing.T) {
+	t.Parallel()
+
+	uin, err := extractOfficialQQBotUIN("https://qun.qq.com/qqweb/qunpro/share?_wv=3&robot_uin=1&robot_appid=123456789")
+	if err != nil {
+		t.Fatalf("extractOfficialQQBotUIN returned error: %v", err)
+	}
+	if uin != "1" {
+		t.Fatalf("uin = %q, want %q", uin, "1")
+	}
+
+	for _, link := range []string{
+		"https://example.com/share",
+		"https://example.com/share?robot_uin=not-a-number",
+		"https://example.com/share?robot_uin=0",
+	} {
+		if _, err := extractOfficialQQBotUIN(link); err == nil {
+			t.Fatalf("extractOfficialQQBotUIN(%q) unexpectedly succeeded", link)
+		}
+	}
+}
+
+func TestExtractOfficialQQBotUINFromResponse(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		`{"url":"https://qun.qq.com/qqweb/qunpro/share?robot_uin=1&robot_appid=123456789"}`,
+		`{"url_link":"https://qun.qq.com/qqweb/qunpro/share?robot_uin=1&robot_appid=123456789"}`,
+	} {
+		uin, err := extractOfficialQQBotUINFromResponse([]byte(body))
+		if err != nil {
+			t.Fatalf("extract response returned error: %v", err)
+		}
+		if uin != "1" {
+			t.Fatalf("uin = %q, want %q", uin, "1")
+		}
+	}
+
+	if _, err := extractOfficialQQBotUINFromResponse([]byte(`{}`)); err == nil {
+		t.Fatal("response without url unexpectedly succeeded")
+	}
+
+	// The documented url_link is authoritative when compatibility fields coexist.
+	uin, err := extractOfficialQQBotUINFromResponse([]byte(`{
+		"url":"https://example.com/short-link",
+		"url_link":"https://qun.qq.com/qunpro/robot/qunshare?robot_uin=2"
+	}`))
+	if err != nil || uin != "2" {
+		t.Fatalf("preferred url_link result = %q, %v", uin, err)
+	}
+}
+
+func TestParseOfficialQQBotInfo(t *testing.T) {
+	t.Parallel()
+
+	botInfo, err := parseOfficialQQBotInfo([]byte(`{
+		"id":"bot-open-id",
+		"username":"test bot",
+		"share_url":"https://qun.qq.com/qunpro/robot/qunshare?robot_uin=3&robot_appid=123456789"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if botInfo.ID != "bot-open-id" || botInfo.Username != "test bot" {
+		t.Fatalf("unexpected bot info: %#v", botInfo)
+	}
+	uin, err := extractOfficialQQBotUIN(botInfo.ShareURL)
+	if err != nil || uin != "3" {
+		t.Fatalf("share_url UIN = %q, %v", uin, err)
+	}
+
+	if _, err := parseOfficialQQBotInfo([]byte(`{"username":"missing id"}`)); err == nil {
+		t.Fatal("bot info without id unexpectedly succeeded")
+	}
+}
+
+func TestGetOfficialQQBotInfoUsesShareURL(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	api := officialQQTransportFunc(func(_ context.Context, method, requestURL string, _ interface{}) ([]byte, error) {
+		calls++
+		if method != http.MethodGet || !strings.HasSuffix(requestURL, "/users/@me") {
+			t.Fatalf("unexpected request: %s %s", method, requestURL)
+		}
+		return []byte(`{
+			"id":"bot-open-id",
+			"username":"test bot",
+			"share_url":"https://qun.qq.com/qunpro/robot/qunshare?robot_uin=3"
+		}`), nil
+	})
+
+	botInfo, err := getOfficialQQBotInfo(context.Background(), api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 || botInfo.UIN != "3" || botInfo.BotID != "bot-open-id" {
+		t.Fatalf("calls = %d, bot info = %#v", calls, botInfo)
+	}
+}
+
+func TestGetOfficialQQBotInfoGeneratedLinkFallback(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	api := officialQQTransportFunc(func(_ context.Context, method, requestURL string, _ interface{}) ([]byte, error) {
+		calls++
+		switch {
+		case method == http.MethodGet && strings.HasSuffix(requestURL, "/users/@me"):
+			return []byte(`{"id":"bot-open-id","username":"test bot"}`), nil
+		case method == http.MethodPost && strings.HasSuffix(requestURL, "/v2/generate_url_link"):
+			return []byte(`{"url_link":"https://qun.qq.com/qunpro/robot/qunshare?robot_uin=4"}`), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", method, requestURL)
+			return nil, nil
+		}
+	})
+
+	botInfo, err := getOfficialQQBotInfo(context.Background(), api)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 || botInfo.UIN != "4" || botInfo.BotID != "bot-open-id" {
+		t.Fatalf("calls = %d, bot info = %#v", calls, botInfo)
+	}
+}
+
+func TestOfficialQQIDRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uin         = "1"
+		groupOpenID = "group-open-id-with-hyphens"
+		userOpenID  = "user-open-id-with-hyphens"
+	)
+	pa := &PlatformAdapterOfficialQQ{UIN: uin}
+
+	groupID := formatDiceIDOfficialQQGroupOpenID(uin, groupOpenID)
+	if groupID != "OpenQQ-Group:1-"+groupOpenID {
+		t.Fatalf("group ID = %q", groupID)
+	}
+	if raw, kind := pa.mustExtractID(groupID); raw != groupOpenID || kind != OpenQQGroupOpenid {
+		t.Fatalf("group parse = (%q, %d)", raw, kind)
+	}
+
+	memberID := formatDiceIDOfficialQQMemberOpenID(uin, groupOpenID, userOpenID)
+	userID := formatDiceIDOfficialQQUserOpenID(uin, userOpenID)
+	if memberID != userID || userID != "OpenQQ:1-"+userOpenID {
+		t.Fatalf("member ID = %q, user ID = %q", memberID, userID)
+	}
+	if raw, kind := pa.mustExtractID(userID); raw != userOpenID || kind != OpenQQUserOpenid {
+		t.Fatalf("user parse = (%q, %d)", raw, kind)
+	}
+	if raw, kind := pa.mustExtractID(formatDiceIDOfficialQQ(uin)); raw != uin || kind != OpenQQUser {
+		t.Fatalf("bot parse = (%q, %d)", raw, kind)
+	}
+
+	for _, unsupported := range []string{
+		"OpenQQ-Group:" + groupOpenID,
+		"OpenQQ:" + userOpenID,
+		"OpenQQ-Group:other-" + groupOpenID,
+		"QQ:" + uin,
+	} {
+		if _, kind := pa.mustExtractID(unsupported); kind != OpenQQUnknown {
+			t.Fatalf("unsupported ID %q parsed as kind %d", unsupported, kind)
+		}
+	}
+}
+
+func TestOfficialQQLegacyEmptyGroupIdentity(t *testing.T) {
+	t.Parallel()
+
+	const (
+		appID        = "123456789"
+		uin          = "1"
+		memberOpenID = "member-open-id"
+	)
+	migration := &officialQQIdentityMigration{
+		appID:  appID,
+		uin:    uin,
+		groups: map[string]string{},
+		users:  map[string]string{},
+	}
+	oldGroupID := "OpenQQ-Group-T:" + appID + "-"
+	oldMemberID := "OpenQQ-Member-T:" + appID + "--" + memberOpenID
+
+	if !migration.addGroup(oldGroupID) {
+		t.Fatal("legacy empty group was not collected")
+	}
+	if !migration.addMember(oldGroupID, oldMemberID) {
+		t.Fatal("legacy empty-group member was not collected")
+	}
+	if got, want := migration.migrateGroupID(oldGroupID), "OpenQQ-Group:"+uin+"-legacy-empty-"+appID; got != want {
+		t.Fatalf("group ID = %q, want %q", got, want)
+	}
+	if got, want := migration.migrateUserID(oldMemberID), "OpenQQ:"+uin+"-"+memberOpenID; got != want {
+		t.Fatalf("member ID = %q, want %q", got, want)
+	}
+}
+
+func TestOfficialQQAtFallbackUsesBotOpenID(t *testing.T) {
+	t.Parallel()
+
+	pa := &PlatformAdapterOfficialQQ{UIN: "1", botID: "bot-open-id"}
+	msg := pa.groupMsgToStdMsg(nil, &dto.WSGroupATMessageData{Content: "hello", GroupOpenID: "group-open-id"})
+	if msg.TmpUID != "OpenQQ:bot-open-id" {
+		t.Fatalf("TmpUID = %q, want bot OpenID", msg.TmpUID)
+	}
+}
+
+func TestOfficialQQGroupMessagesPreserveMemberRole(t *testing.T) {
+	t.Parallel()
+
+	pa := &PlatformAdapterOfficialQQ{UIN: "1"}
+	author := &dto.User{MemberOpenID: "member-open-id", MemberRole: "admin"}
+
+	atMsg := pa.groupMsgToStdMsg(nil, &dto.WSGroupATMessageData{GroupOpenID: "group-open-id", Author: author})
+	normalMsg := pa.groupNormalMsgToStdMsg(nil, &dto.WSGroupMessageData{GroupOpenID: "group-open-id", Author: author})
+	for name, msg := range map[string]*Message{"at": atMsg, "normal": normalMsg} {
+		if msg.Sender.UserID != "OpenQQ:1-member-open-id" {
+			t.Errorf("%s message user ID = %q, want UIN-based ID", name, msg.Sender.UserID)
+		}
+		if msg.Sender.GroupRole != "admin" {
+			t.Errorf("%s message group role = %q, want admin", name, msg.Sender.GroupRole)
+		}
+	}
+}
+
+func TestMigratedCharacterNameLimit(t *testing.T) {
+	t.Parallel()
+
+	name := migratedCharacterName(strings.Repeat("角", 30), 2)
+	if len(name) > 90 || !strings.HasSuffix(name, " (2)") || !utf8.ValidString(name) {
+		t.Fatalf("migrated character name is invalid: %q (%d bytes)", name, len(name))
+	}
+}
+
+func TestOfficialQQAdapterSerializationDoesNotExposeSecrets(t *testing.T) {
+	t.Parallel()
+
+	adapter := &PlatformAdapterOfficialQQ{
+		AppID:     "123456789",
+		AppSecret: "secret-value",
+		Token:     "legacy-token-value",
+		UIN:       "1",
+	}
+	rawJSON, err := json.Marshal(adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonText := string(rawJSON)
+	if strings.Contains(jsonText, "secret-value") || strings.Contains(strings.ToLower(jsonText), "token") {
+		t.Fatalf("JSON exposed credentials: %s", jsonText)
+	}
+	if !strings.Contains(jsonText, `"appID":"123456789"`) || !strings.Contains(jsonText, `"uin":"1"`) {
+		t.Fatalf("JSON omitted public account identity: %s", jsonText)
+	}
+
+	conn := NewOfficialQQConnItem(adapter.AppID, adapter.AppSecret, adapter.UIN, false)
+	conn.Adapter.(*PlatformAdapterOfficialQQ).Token = adapter.Token
+	rawYAML, err := yaml.Marshal(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(rawYAML), "token: legacy-token-value") {
+		t.Fatalf("YAML did not preserve the deprecated token: %s", rawYAML)
+	}
+	if !strings.Contains(string(rawYAML), "uin: \"1\"") {
+		t.Fatalf("YAML omitted UIN: %s", rawYAML)
+	}
+}
+
+func TestPublicDiceEndpointAppID(t *testing.T) {
+	t.Parallel()
+
+	official := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{Platform: "QQ", ProtocolType: "official"},
+		Adapter:          &PlatformAdapterOfficialQQ{AppID: "123456789"},
+	}
+	if appID := publicDiceEndpointAppID(official); appID != "123456789" {
+		t.Fatalf("official appID = %q", appID)
+	}
+
+	ordinary := &EndPointInfo{EndPointInfoBase: EndPointInfoBase{Platform: "QQ", ProtocolType: "onebot"}}
+	if appID := publicDiceEndpointAppID(ordinary); appID != "" {
+		t.Fatalf("ordinary QQ appID = %q, want empty", appID)
+	}
+}
+
+func TestOfficialQQIdentityMigration(t *testing.T) {
+	const (
+		appID        = "123456789"
+		uin          = "1"
+		botID        = "bot-open-id"
+		groupOpenID  = "group-open-id-with-hyphens"
+		groupOpenID2 = "second-group-open-id"
+		memberID     = "member-open-id-with-hyphens"
+	)
+
+	dataDir := t.TempDir()
+	dbOperator, openErr := newMockDatabaseOperator(filepath.Join(dataDir, "official-qq-migration.db"))
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	t.Cleanup(dbOperator.Close)
+	db := dbOperator.db
+	if err := db.AutoMigrate(
+		&model.GroupInfo{},
+		&model.GroupPlayerInfoBase{},
+		&model.AttributesItemModel{},
+		&model.BanInfo{},
+		&model.EndpointInfo{},
+		&model.LogInfo{},
+		&model.LogOneItem{},
+		&model.CensorLog{},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	oldEndpoint := "OpenQQ:" + botID
+	newEndpoint := "OpenQQ:" + uin
+	oldGroupID := "OpenQQ-Group-T:" + appID + "-" + groupOpenID
+	newGroupID := "OpenQQ-Group:" + uin + "-" + groupOpenID
+	oldUserID := "OpenQQ-Member-T:" + appID + "-" + groupOpenID + "-" + memberID
+	newUserID := "OpenQQ:" + uin + "-" + memberID
+	oldAttrsID := oldGroupID + "-" + oldUserID
+	newAttrsID := newGroupID + "-" + newUserID
+	oldGroupID2 := "OpenQQ-Group-T:" + appID + "-" + groupOpenID2
+	newGroupID2 := "OpenQQ-Group:" + uin + "-" + groupOpenID2
+	oldUserID2 := "OpenQQ-Member-T:" + appID + "-" + groupOpenID2 + "-" + memberID
+	oldAttrsID2 := oldGroupID2 + "-" + oldUserID2
+	newAttrsID2 := newGroupID2 + "-" + newUserID
+	timestamp := int64(1)
+	if groupPart, userPart, ok := UnpackGroupUserId(newAttrsID); !ok || groupPart != newGroupID || userPart != newUserID {
+		t.Fatalf("UnpackGroupUserId(%q) = (%q, %q, %t)", newAttrsID, groupPart, userPart, ok)
+	}
+
+	persistedGroup := newOfficialQQMigrationTestGroup(oldGroupID, oldEndpoint, oldUserID)
+	groupData, marshalGroupErr := json.Marshal(persistedGroup)
+	if marshalGroupErr != nil {
+		t.Fatal(marshalGroupErr)
+	}
+	if err := db.Create(&model.GroupInfo{ID: oldGroupID, CreatedAt: timestamp, UpdatedAt: &timestamp, Data: groupData}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.GroupPlayerInfoBase{GroupID: oldGroupID, UserID: oldUserID, Name: "member", CreatedAt: 1, UpdatedAt: 1}).Error; err != nil {
+		t.Fatal(err)
+	}
+	secondGroupData, marshalSecondGroupErr := json.Marshal(newOfficialQQMigrationTestGroup(oldGroupID2, oldEndpoint, oldUserID2))
+	if marshalSecondGroupErr != nil {
+		t.Fatal(marshalSecondGroupErr)
+	}
+	if err := db.Create(&model.GroupInfo{ID: oldGroupID2, CreatedAt: timestamp, UpdatedAt: &timestamp, Data: secondGroupData}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.GroupPlayerInfoBase{GroupID: oldGroupID2, UserID: oldUserID2, Name: "member", CreatedAt: 1, UpdatedAt: 1}).Error; err != nil {
+		t.Fatal(err)
+	}
+	characters := []model.AttributesItemModel{
+		{Id: "character-a", AttrsType: "character", Name: "调查员", OwnerId: oldUserID, CreatedAt: 1, UpdatedAt: 1},
+		{Id: "character-b", AttrsType: "character", Name: "调查员", OwnerId: oldUserID2, CreatedAt: 2, UpdatedAt: 2},
+		{Id: "character-c", AttrsType: "character", Name: "调查员 (2)", OwnerId: oldUserID2, CreatedAt: 3, UpdatedAt: 3},
+	}
+	if err := db.Create(&characters).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.AttributesItemModel{Id: oldAttrsID, AttrsType: "group_user", OwnerId: oldUserID, BindingSheetId: "character-a", CreatedAt: timestamp, UpdatedAt: timestamp}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.AttributesItemModel{Id: oldAttrsID2, OwnerId: oldUserID2, BindingSheetId: "character-b", CreatedAt: timestamp, UpdatedAt: timestamp}).Error; err != nil {
+		t.Fatal(err)
+	}
+	olderUserAttrs := &ds.ValueMap{}
+	olderUserAttrs.Store("older-only", ds.NewIntVal(1))
+	olderUserAttrs.Store("shared", ds.NewIntVal(1))
+	olderUserData, encodeOlderErr := ds.NewDictVal(olderUserAttrs).V().ToJSON()
+	if encodeOlderErr != nil {
+		t.Fatal(encodeOlderErr)
+	}
+	newerUserAttrs := &ds.ValueMap{}
+	newerUserAttrs.Store("newer-only", ds.NewIntVal(2))
+	newerUserAttrs.Store("shared", ds.NewIntVal(2))
+	newerUserData, encodeNewerErr := ds.NewDictVal(newerUserAttrs).V().ToJSON()
+	if encodeNewerErr != nil {
+		t.Fatal(encodeNewerErr)
+	}
+	if err := db.Create(&model.AttributesItemModel{Id: oldUserID, AttrsType: "user", Data: olderUserData, CreatedAt: 1, UpdatedAt: 1}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.AttributesItemModel{Id: oldUserID2, AttrsType: "user", Data: newerUserData, CreatedAt: 2, UpdatedAt: 2}).Error; err != nil {
+		t.Fatal(err)
+	}
+	banItem := &BanListInfoItem{ID: oldUserID, Places: []string{oldGroupID}, Reasons: []string{"test"}}
+	banData, marshalBanErr := json.Marshal(banItem)
+	if marshalBanErr != nil {
+		t.Fatal(marshalBanErr)
+	}
+	if err := db.Create(&model.BanInfo{ID: oldUserID, UpdatedAt: 1, Data: banData}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.EndpointInfo{UserID: oldEndpoint, CmdNum: 12, OnlineTime: 34, UpdatedAt: timestamp}).Error; err != nil {
+		t.Fatal(err)
+	}
+	logInfo := &model.LogInfo{Name: "session", GroupID: oldGroupID, CreatedAt: timestamp, UpdatedAt: timestamp}
+	if err := db.Create(logInfo).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.LogOneItem{LogID: logInfo.ID, GroupID: oldGroupID, IMUserID: oldUserID, UniformID: oldUserID, Time: timestamp}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.CensorLog{GroupID: oldGroupID, UserID: oldUserID, Content: "test", CreatedAt: 1}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// The short-lived simplified format from the previous change is intentionally untouched.
+	const simplifiedGroupID = "OpenQQ-Group:simplified-group"
+	simplifiedData, marshalSimplifiedErr := json.Marshal(newOfficialQQMigrationTestGroup(simplifiedGroupID, oldEndpoint, "OpenQQ:simplified-user"))
+	if marshalSimplifiedErr != nil {
+		t.Fatal(marshalSimplifiedErr)
+	}
+	if err := db.Create(&model.GroupInfo{ID: simplifiedGroupID, CreatedAt: timestamp, UpdatedAt: &timestamp, Data: simplifiedData}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Dice{
+		BaseConfig: BaseConfig{DataDir: dataDir, Name: "default"},
+		DBOperator: dbOperator,
+		Logger:     sealdiceLogger.M(),
+		ImSession: &IMSession{
+			ServiceAtNew: new(SyncMap[string, *GroupInfo]),
+			PendingQuits: new(SyncMap[string, *PendingQuitInfo]),
+		},
+		DirtyGroups: new(SyncMap[string, int64]),
+		Parent:      &DiceManager{},
+	}
+	d.Config = NewConfig(d)
+	d.AttrsManager = &AttrsManager{db: dbOperator}
+	d.AttrsManager.m.Store("character-b", &AttributesItem{ID: "character-b", Name: "调查员", IsSaved: true})
+	memoryGroup := newOfficialQQMigrationTestGroup(oldGroupID, oldEndpoint, oldUserID)
+	memoryGroup.Players = new(SyncMap[string, *GroupPlayerInfo])
+	memoryGroup.Players.Store(oldUserID, &GroupPlayerInfo{UserID: oldUserID, GroupID: oldGroupID})
+	d.ImSession.ServiceAtNew.Store(oldGroupID, memoryGroup)
+	d.Config.BanList.Map.Store(oldUserID, banItem)
+	d.DiceMasters = []string{oldEndpoint, oldUserID}
+	d.Config.NoticeIDs = []string{oldUserID}
+	d.Config.UpgradeWindowID = oldGroupID
+	d.ImSession.MarkPendingQuit(oldGroupID, oldEndpoint, QuitOriginAutoInactive, 0)
+
+	endpoint := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			ID:           "re-added-official-qq",
+			Platform:     "QQ",
+			ProtocolType: "official",
+			UserID:       newEndpoint,
+		},
+	}
+	adapter := &PlatformAdapterOfficialQQ{EndPoint: endpoint, AppID: appID, UIN: uin}
+	endpoint.Adapter = adapter
+	endpoint.BindRuntime(d.ImSession)
+	d.ImSession.EndPoints = []*EndPointInfo{endpoint}
+
+	if err := ensureOfficialQQIdentity(d, adapter, botID, uin); err != nil {
+		t.Fatalf("first migration failed: %v", err)
+	}
+	// Simulate stale memory after the data phase succeeded but a later phase failed.
+	if cached, ok := d.AttrsManager.m.Load("character-b"); ok {
+		cached.Name = "调查员"
+	}
+	if err := ensureOfficialQQIdentity(d, adapter, botID, uin); err != nil {
+		t.Fatalf("idempotent migration failed: %v", err)
+	}
+
+	assertOfficialQQMigrationRow(t, db, &model.GroupInfo{}, "id = ?", newGroupID)
+	assertOfficialQQMigrationMissing(t, db, &model.GroupInfo{}, "id = ?", oldGroupID)
+	assertOfficialQQMigrationRow(t, db, &model.GroupPlayerInfoBase{}, "group_id = ? AND user_id = ?", newGroupID, newUserID)
+	assertOfficialQQMigrationRow(t, db, &model.AttributesItemModel{}, "id = ? AND owner_id = ? AND binding_sheet_id = ?", newAttrsID, newUserID, "character-a")
+	assertOfficialQQMigrationRow(t, db, &model.AttributesItemModel{}, "id = ? AND owner_id = ? AND binding_sheet_id = ?", newAttrsID2, newUserID, "character-b")
+	assertOfficialQQMigrationRow(t, db, &model.AttributesItemModel{}, "id = ? AND owner_id = ? AND name = ?", "character-a", newUserID, "调查员")
+	assertOfficialQQMigrationRow(t, db, &model.AttributesItemModel{}, "id = ? AND owner_id = ? AND name = ?", "character-b", newUserID, "调查员 (3)")
+	assertOfficialQQMigrationRow(t, db, &model.AttributesItemModel{}, "id = ? AND owner_id = ? AND name = ?", "character-c", newUserID, "调查员 (2)")
+	var mergedUserAttrs model.AttributesItemModel
+	if err := db.Where("id = ?", newUserID).First(&mergedUserAttrs).Error; err != nil {
+		t.Fatal(err)
+	}
+	mergedValue, decodeErr := ds.VMValueFromJSON(mergedUserAttrs.Data)
+	if decodeErr != nil {
+		t.Fatal(decodeErr)
+	}
+	mergedDict, ok := mergedValue.ReadDictData()
+	if !ok || mergedDict.Dict == nil {
+		t.Fatal("merged QQ user attrs are not a dictionary")
+	}
+	for key, want := range map[string]*ds.VMValue{
+		"older-only": ds.NewIntVal(1),
+		"newer-only": ds.NewIntVal(2),
+		"shared":     ds.NewIntVal(2),
+	} {
+		got, exists := mergedDict.Dict.Load(key)
+		if !exists || !ds.ValueEqual(got, want, false) {
+			t.Fatalf("merged QQ user attr %q = %#v, want %#v", key, got, want)
+		}
+	}
+	assertOfficialQQMigrationRow(t, db, &model.EndpointInfo{}, "user_id = ?", newEndpoint)
+	if endpoint.CmdExecutedNum != 12 {
+		t.Fatalf("re-added endpoint command count = %d, want 12", endpoint.CmdExecutedNum)
+	}
+	assertOfficialQQMigrationRow(t, db, &model.LogInfo{}, "group_id = ?", newGroupID)
+	assertOfficialQQMigrationRow(t, db, &model.LogOneItem{}, "group_id = ? AND im_userid = ?", newGroupID, newUserID)
+	assertOfficialQQMigrationRow(t, db, &model.CensorLog{}, "group_id = ? AND user_id = ?", newGroupID, newUserID)
+	assertOfficialQQMigrationRow(t, db, &model.BanInfo{}, "id = ?", newUserID)
+	assertOfficialQQMigrationRow(t, db, &model.GroupInfo{}, "id = ?", simplifiedGroupID)
+
+	group, ok := d.ImSession.ServiceAtNew.Load(newGroupID)
+	if !ok || group.GroupID != newGroupID || group.InviteUserID != newUserID {
+		t.Fatalf("memory group was not migrated: %#v", group)
+	}
+	if !group.DiceIDExistsMap.Exists(newEndpoint) || group.DiceIDExistsMap.Exists(oldEndpoint) {
+		t.Fatalf("endpoint membership map was not migrated")
+	}
+	if !group.Players.Exists(newUserID) || group.Players.Exists(oldUserID) {
+		t.Fatalf("memory players were not migrated")
+	}
+	if _, ok := d.Config.BanList.Map.Load(newUserID); !ok {
+		t.Fatalf("memory ban list was not migrated")
+	}
+	if d.DiceMasters[0] != newEndpoint || d.DiceMasters[1] != newUserID || d.Config.NoticeIDs[0] != newUserID || d.Config.UpgradeWindowID != newGroupID {
+		t.Fatalf("configuration references were not migrated")
+	}
+	if !d.ImSession.PendingQuits.Exists(makePendingQuitKey(newGroupID, newEndpoint)) {
+		t.Fatalf("pending quit reference was not migrated")
+	}
+	if cached, ok := d.AttrsManager.m.Load("character-b"); !ok || cached.Name != "调查员 (3)" {
+		t.Fatalf("cached character name was not migrated: %#v", cached)
+	}
+}
+
+func TestOfficialQQIdentityMigrationRetriesAfterFailure(t *testing.T) {
+	const (
+		appID    = "123456789"
+		uin      = "1"
+		botID    = "bot-open-id"
+		memberID = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	)
+
+	dataDir := t.TempDir()
+	dbOperator, openErr := newMockDatabaseOperator(filepath.Join(dataDir, "official-qq-retry.db"))
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	t.Cleanup(dbOperator.Close)
+	db := dbOperator.db
+	if err := db.AutoMigrate(&model.AttributesItemModel{}, &model.EndpointInfo{}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldUserID1 := "OpenQQ-Member-T:" + appID + "-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB-" + memberID
+	oldUserID2 := "OpenQQ-Member-T:" + appID + "-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC-" + memberID
+	newUserID := "OpenQQ:" + uin + "-" + memberID
+	for _, id := range []string{oldUserID1, oldUserID2} {
+		if err := db.Create(&model.AttributesItemModel{Id: id, AttrsType: "user", Data: []byte("{")}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	endpoint := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			ID:           "re-added-official-qq",
+			Platform:     "QQ",
+			ProtocolType: "official",
+			UserID:       formatDiceIDOfficialQQ(uin),
+		},
+	}
+	adapter := &PlatformAdapterOfficialQQ{EndPoint: endpoint, AppID: appID, UIN: uin}
+	endpoint.Adapter = adapter
+	d := &Dice{
+		BaseConfig: BaseConfig{DataDir: dataDir, Name: "default"},
+		DBOperator: dbOperator,
+		Logger:     sealdiceLogger.M(),
+		ImSession: &IMSession{
+			EndPoints:    []*EndPointInfo{endpoint},
+			ServiceAtNew: new(SyncMap[string, *GroupInfo]),
+			PendingQuits: new(SyncMap[string, *PendingQuitInfo]),
+		},
+		DirtyGroups: new(SyncMap[string, int64]),
+		Parent:      &DiceManager{},
+	}
+	d.ImSession.Parent = d
+	d.Config = NewConfig(d)
+	d.AttrsManager = &AttrsManager{db: dbOperator}
+	endpoint.BindRuntime(d.ImSession)
+
+	migrationErr := ensureOfficialQQIdentity(d, adapter, botID, uin)
+	if migrationErr == nil {
+		t.Fatal("migration with malformed attrs unexpectedly succeeded")
+	}
+	var migrationFailure *officialQQIdentityMigrationError
+	if !errors.As(migrationErr, &migrationFailure) {
+		t.Fatalf("migration error has wrong type: %T", migrationErr)
+	}
+	if adapter.UIN != uin || endpoint.UserID != formatDiceIDOfficialQQ(uin) {
+		t.Fatalf("resolved identity was discarded after migration failure: UIN=%q userID=%q", adapter.UIN, endpoint.UserID)
+	}
+
+	emptyData, encodeErr := ds.NewDictVal(&ds.ValueMap{}).V().ToJSON()
+	if encodeErr != nil {
+		t.Fatal(encodeErr)
+	}
+	if err := db.Model(&model.AttributesItemModel{}).Where("id IN ?", []string{oldUserID1, oldUserID2}).Update("data", emptyData).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureOfficialQQIdentity(d, adapter, botID, uin); err != nil {
+		t.Fatalf("migration retry failed: %v", err)
+	}
+	assertOfficialQQMigrationRow(t, db, &model.AttributesItemModel{}, "id = ?", newUserID)
+	assertOfficialQQMigrationMissing(t, db, &model.AttributesItemModel{}, "id IN ?", []string{oldUserID1, oldUserID2})
+}
+
+func newOfficialQQMigrationTestGroup(groupID, endpointID, userID string) *GroupInfo {
+	group := &GroupInfo{
+		GroupID:         groupID,
+		InviteUserID:    userID,
+		DiceIDActiveMap: new(SyncMap[string, bool]),
+		DiceIDExistsMap: new(SyncMap[string, bool]),
+		BotList:         new(SyncMap[string, bool]),
+		PlayerGroups:    new(SyncMap[string, []string]),
+	}
+	group.DiceIDActiveMap.Store(endpointID, true)
+	group.DiceIDExistsMap.Store(endpointID, true)
+	group.PlayerGroups.Store(userID, []string{groupID})
+	return group
+}
+
+func assertOfficialQQMigrationRow(t *testing.T, db interface {
+	Model(value any) *gorm.DB
+}, value any, query string, args ...any) {
+	t.Helper()
+	var count int64
+	if err := db.Model(value).Where(query, args...).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("query %q %v returned %d rows, want 1", query, args, count)
+	}
+}
+
+func assertOfficialQQMigrationMissing(t *testing.T, db interface {
+	Model(value any) *gorm.DB
+}, value any, query string, args ...any) {
+	t.Helper()
+	var count int64
+	if err := db.Model(value).Where(query, args...).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("query %q %v returned %d rows, want 0", query, args, count)
+	}
+}

--- a/dice/utils.go
+++ b/dice/utils.go
@@ -598,8 +598,7 @@ func UnpackGroupUserId(id string) (groupIdPart, userIdPart string, ok bool) {
 
 	// 遇到一个例子:
 	// QQ-CH-Group:33845581638279358-3047284-QQ-CH:144115218744389299
-	// OpenQQ-Group:102076784-89F06C35D4D418FE02BEFAEB8A6BAEB2-OpenQQ-Member:102076784-89F06C35D4D418FE02BEFAEB8A6BAEB2-FF4E7AAC8134661D05CF53E62F4037B4
-	// 应该是某一个测试版本，占比很少，这里忽略吧
+	// OpenQQ 的群内属性格式为 OpenQQ-Group:<UIN>-<GroupOpenID>-OpenQQ:<UIN>-<MemberOpenID>。
 
 	// 我们是否能做这样的假设：XX-Group:123 的用户ID形式是 XX:456 ？
 	// 但是 KOOK 就例外了

--- a/utils/public_dice/sdk.go
+++ b/utils/public_dice/sdk.go
@@ -38,6 +38,7 @@ func doReq[T any](c *PublicDiceClient, method string, path string, data any, par
 type Endpoint struct {
 	Platform  string `json:"platform"  msgpack:",omitempty"`
 	UID       string `json:"uid"       msgpack:",omitempty"`
+	AppID     string `json:"appId,omitempty" msgpack:",omitempty"`
 	InviteURL string `json:"inviteUrl" msgpack:",omitempty"`
 	IsOnline  bool   `json:"isOnline"  msgpack:",omitempty"`
 
@@ -150,6 +151,7 @@ type TickUpdateRequest struct {
 // TickEndpoint 公骰心跳端点信息
 type TickEndpoint struct {
 	UID      string `json:"uid"      msgpack:",omitempty"`
+	AppID    string `json:"appId,omitempty" msgpack:",omitempty"`
 	IsOnline bool   `json:"isOnline" msgpack:",omitempty"`
 }
 

--- a/utils/public_dice/sdk_test.go
+++ b/utils/public_dice/sdk_test.go
@@ -1,0 +1,37 @@
+package public_dice_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"sealdice-core/utils/public_dice"
+)
+
+func TestEndpointAppIDJSON(t *testing.T) {
+	t.Parallel()
+
+	official, err := json.Marshal(&public_dice.Endpoint{Platform: "QQ", UID: "OpenQQ:1", AppID: "123456789"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(official), `"appId":"123456789"`) {
+		t.Fatalf("official endpoint JSON = %s", official)
+	}
+
+	ordinary, err := json.Marshal(&public_dice.Endpoint{Platform: "QQ", UID: "QQ:123456"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(ordinary), "appId") {
+		t.Fatalf("ordinary endpoint JSON unexpectedly contains appId: %s", ordinary)
+	}
+
+	tick, err := json.Marshal(&public_dice.TickEndpoint{UID: "OpenQQ:1", AppID: "123456789"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(tick), `"appId":"123456789"`) {
+		t.Fatalf("official tick JSON = %s", tick)
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

将 QQ 官方机器人身份标识从基于 AppID 的 ID 迁移为基于 UIN 的 ID，在连接时进行探测和校验，并对历史数据和公共骰子元数据进行全面迁移，采用新格式并具备完善的测试覆盖。

New Features:
- 为 QQ 官方机器人连接增加基于 UIN 的身份标识，并在公共骰子接口数据中暴露机器人 AppID。
- 在 API 侧引入对 QQ 官方机器人账号的探测机制，以防止重复连接，并支持仅用于测试的校验流程。

Bug Fixes:
- 确保 QQ 官方 ID 的解析与格式化在使用 UIN 时能够一致地区分机器人、群组与成员身份。
- 在迁移过程中通过合并和重命名冲突记录，避免 QQ 官方用户属性数据的误复用或 ID 冲突。

Enhancements:
- 在切换到基于 UIN 的 ID 时，对历史 QQ 官方身份数据进行全面迁移，覆盖数据库、缓存、封禁记录、日志以及内存结构。
- 在 JSON 序列化中隐藏 QQ 官方 AppSecret 和旧版 token，同时在 YAML 中保留废弃 token 以兼容旧配置。
- 简化并静默 QQ SDK 使用中的虚拟日志记录器行为，以减少日志噪音。
- 增加单元测试，覆盖 QQ 官方 ID 提取、迁移行为、序列化，以及公共骰子 AppID 的 JSON 表示。

Tests:
- 为 QQ 官方适配器和身份迁移添加大量测试，以确保基于 UIN 的 ID 及数据转换的正确性。
- 添加测试验证公共骰子接口的 JSON 表示中现已包含 QQ 官方机器人的 AppID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate QQ official bot identity handling from AppID-based IDs to UIN-based IDs, including probing and validation on connection, and perform a thorough migration of historical data and public dice metadata to the new format with strong test coverage.

New Features:
- Add UIN-based identity for QQ official bot connections and expose bot AppID in public dice endpoint data.
- Introduce API-side probing of QQ official bot accounts to prevent duplicate connections and support test-only validation.

Bug Fixes:
- Ensure QQ official ID parsing and formatting consistently distinguishes bot, group, and member identities using UIN.
- Prevent accidental reuse or collision of QQ official user attribute data by merging and renaming conflicting records during migration.

Enhancements:
- Implement comprehensive migration of historical QQ official identity data across databases, caches, bans, logs, and in-memory structures when switching to UIN-based IDs.
- Hide QQ official AppSecret and legacy token from JSON serialization while preserving deprecated token in YAML for old configurations.
- Simplify and quiet dummy logger behavior for QQ SDK usage to reduce log noise.
- Add unit tests covering QQ official ID extraction, migration behavior, serialization, and public dice AppID JSON representation.

Tests:
- Add extensive tests for QQ official adapter and identity migration to ensure correctness of UIN-based IDs and data transformation.
- Add tests verifying JSON representation of public dice endpoints now includes AppID for QQ official bots.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 QQ 官方机器人身份标识从基于 AppID 的 ID 迁移为基于 UIN 的 ID，在连接时进行探测和校验，并对历史数据和公共骰子元数据进行全面迁移，采用新格式并具备完善的测试覆盖。

New Features:
- 为 QQ 官方机器人连接增加基于 UIN 的身份标识，并在公共骰子接口数据中暴露机器人 AppID。
- 在 API 侧引入对 QQ 官方机器人账号的探测机制，以防止重复连接，并支持仅用于测试的校验流程。

Bug Fixes:
- 确保 QQ 官方 ID 的解析与格式化在使用 UIN 时能够一致地区分机器人、群组与成员身份。
- 在迁移过程中通过合并和重命名冲突记录，避免 QQ 官方用户属性数据的误复用或 ID 冲突。

Enhancements:
- 在切换到基于 UIN 的 ID 时，对历史 QQ 官方身份数据进行全面迁移，覆盖数据库、缓存、封禁记录、日志以及内存结构。
- 在 JSON 序列化中隐藏 QQ 官方 AppSecret 和旧版 token，同时在 YAML 中保留废弃 token 以兼容旧配置。
- 简化并静默 QQ SDK 使用中的虚拟日志记录器行为，以减少日志噪音。
- 增加单元测试，覆盖 QQ 官方 ID 提取、迁移行为、序列化，以及公共骰子 AppID 的 JSON 表示。

Tests:
- 为 QQ 官方适配器和身份迁移添加大量测试，以确保基于 UIN 的 ID 及数据转换的正确性。
- 添加测试验证公共骰子接口的 JSON 表示中现已包含 QQ 官方机器人的 AppID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate QQ official bot identity handling from AppID-based IDs to UIN-based IDs, including probing and validation on connection, and perform a thorough migration of historical data and public dice metadata to the new format with strong test coverage.

New Features:
- Add UIN-based identity for QQ official bot connections and expose bot AppID in public dice endpoint data.
- Introduce API-side probing of QQ official bot accounts to prevent duplicate connections and support test-only validation.

Bug Fixes:
- Ensure QQ official ID parsing and formatting consistently distinguishes bot, group, and member identities using UIN.
- Prevent accidental reuse or collision of QQ official user attribute data by merging and renaming conflicting records during migration.

Enhancements:
- Implement comprehensive migration of historical QQ official identity data across databases, caches, bans, logs, and in-memory structures when switching to UIN-based IDs.
- Hide QQ official AppSecret and legacy token from JSON serialization while preserving deprecated token in YAML for old configurations.
- Simplify and quiet dummy logger behavior for QQ SDK usage to reduce log noise.
- Add unit tests covering QQ official ID extraction, migration behavior, serialization, and public dice AppID JSON representation.

Tests:
- Add extensive tests for QQ official adapter and identity migration to ensure correctness of UIN-based IDs and data transformation.
- Add tests verifying JSON representation of public dice endpoints now includes AppID for QQ official bots.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 QQ 官方机器人身份标识从基于 AppID 的 ID 迁移为基于 UIN 的 ID，在连接时进行探测和校验，并对历史数据和公共骰子元数据进行全面迁移，采用新格式并具备完善的测试覆盖。

New Features:
- 为 QQ 官方机器人连接增加基于 UIN 的身份标识，并在公共骰子接口数据中暴露机器人 AppID。
- 在 API 侧引入对 QQ 官方机器人账号的探测机制，以防止重复连接，并支持仅用于测试的校验流程。

Bug Fixes:
- 确保 QQ 官方 ID 的解析与格式化在使用 UIN 时能够一致地区分机器人、群组与成员身份。
- 在迁移过程中通过合并和重命名冲突记录，避免 QQ 官方用户属性数据的误复用或 ID 冲突。

Enhancements:
- 在切换到基于 UIN 的 ID 时，对历史 QQ 官方身份数据进行全面迁移，覆盖数据库、缓存、封禁记录、日志以及内存结构。
- 在 JSON 序列化中隐藏 QQ 官方 AppSecret 和旧版 token，同时在 YAML 中保留废弃 token 以兼容旧配置。
- 简化并静默 QQ SDK 使用中的虚拟日志记录器行为，以减少日志噪音。
- 增加单元测试，覆盖 QQ 官方 ID 提取、迁移行为、序列化，以及公共骰子 AppID 的 JSON 表示。

Tests:
- 为 QQ 官方适配器和身份迁移添加大量测试，以确保基于 UIN 的 ID 及数据转换的正确性。
- 添加测试验证公共骰子接口的 JSON 表示中现已包含 QQ 官方机器人的 AppID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate QQ official bot identity handling from AppID-based IDs to UIN-based IDs, including probing and validation on connection, and perform a thorough migration of historical data and public dice metadata to the new format with strong test coverage.

New Features:
- Add UIN-based identity for QQ official bot connections and expose bot AppID in public dice endpoint data.
- Introduce API-side probing of QQ official bot accounts to prevent duplicate connections and support test-only validation.

Bug Fixes:
- Ensure QQ official ID parsing and formatting consistently distinguishes bot, group, and member identities using UIN.
- Prevent accidental reuse or collision of QQ official user attribute data by merging and renaming conflicting records during migration.

Enhancements:
- Implement comprehensive migration of historical QQ official identity data across databases, caches, bans, logs, and in-memory structures when switching to UIN-based IDs.
- Hide QQ official AppSecret and legacy token from JSON serialization while preserving deprecated token in YAML for old configurations.
- Simplify and quiet dummy logger behavior for QQ SDK usage to reduce log noise.
- Add unit tests covering QQ official ID extraction, migration behavior, serialization, and public dice AppID JSON representation.

Tests:
- Add extensive tests for QQ official adapter and identity migration to ensure correctness of UIN-based IDs and data transformation.
- Add tests verifying JSON representation of public dice endpoints now includes AppID for QQ official bots.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 QQ 官方机器人身份标识从基于 AppID 的 ID 迁移为基于 UIN 的 ID，在连接时进行探测和校验，并对历史数据和公共骰子元数据进行全面迁移，采用新格式并具备完善的测试覆盖。

New Features:
- 为 QQ 官方机器人连接增加基于 UIN 的身份标识，并在公共骰子接口数据中暴露机器人 AppID。
- 在 API 侧引入对 QQ 官方机器人账号的探测机制，以防止重复连接，并支持仅用于测试的校验流程。

Bug Fixes:
- 确保 QQ 官方 ID 的解析与格式化在使用 UIN 时能够一致地区分机器人、群组与成员身份。
- 在迁移过程中通过合并和重命名冲突记录，避免 QQ 官方用户属性数据的误复用或 ID 冲突。

Enhancements:
- 在切换到基于 UIN 的 ID 时，对历史 QQ 官方身份数据进行全面迁移，覆盖数据库、缓存、封禁记录、日志以及内存结构。
- 在 JSON 序列化中隐藏 QQ 官方 AppSecret 和旧版 token，同时在 YAML 中保留废弃 token 以兼容旧配置。
- 简化并静默 QQ SDK 使用中的虚拟日志记录器行为，以减少日志噪音。
- 增加单元测试，覆盖 QQ 官方 ID 提取、迁移行为、序列化，以及公共骰子 AppID 的 JSON 表示。

Tests:
- 为 QQ 官方适配器和身份迁移添加大量测试，以确保基于 UIN 的 ID 及数据转换的正确性。
- 添加测试验证公共骰子接口的 JSON 表示中现已包含 QQ 官方机器人的 AppID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate QQ official bot identity handling from AppID-based IDs to UIN-based IDs, including probing and validation on connection, and perform a thorough migration of historical data and public dice metadata to the new format with strong test coverage.

New Features:
- Add UIN-based identity for QQ official bot connections and expose bot AppID in public dice endpoint data.
- Introduce API-side probing of QQ official bot accounts to prevent duplicate connections and support test-only validation.

Bug Fixes:
- Ensure QQ official ID parsing and formatting consistently distinguishes bot, group, and member identities using UIN.
- Prevent accidental reuse or collision of QQ official user attribute data by merging and renaming conflicting records during migration.

Enhancements:
- Implement comprehensive migration of historical QQ official identity data across databases, caches, bans, logs, and in-memory structures when switching to UIN-based IDs.
- Hide QQ official AppSecret and legacy token from JSON serialization while preserving deprecated token in YAML for old configurations.
- Simplify and quiet dummy logger behavior for QQ SDK usage to reduce log noise.
- Add unit tests covering QQ official ID extraction, migration behavior, serialization, and public dice AppID JSON representation.

Tests:
- Add extensive tests for QQ official adapter and identity migration to ensure correctness of UIN-based IDs and data transformation.
- Add tests verifying JSON representation of public dice endpoints now includes AppID for QQ official bots.

</details>

</details>

</details>