### PR TITLE
fix: 避免解散群聊触发自身黑名单

### DIFF
--- a/dice/ext_core.go
+++ b/dice/ext_core.go
@@ -17,6 +17,12 @@ func RegisterBuiltinExtCore(dice *Dice) {
 		GetDescText: GetExtensionDesc,
 		OnGroupLeave: func(ctx *MsgContext, event *events.GroupLeaveEvent) {
 			if event.UserID == ctx.EndPoint.UserID {
+				// 骰子作为群主解散群聊时也会收到自操作离群事件，这并非被他人踢出。
+				// 此处直接返回而不复用 skip，避免继续发送“被踢出群”的误导通知。
+				if event.OperatorID == ctx.EndPoint.UserID {
+					return
+				}
+
 				opUID := event.OperatorID
 				groupName := ctx.Dice.Parent.TryGetGroupName(event.GroupID)
 				userName := ctx.Dice.Parent.TryGetUserName(opUID)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 避免在机器人解散其所拥有的群组时，错误地触发黑名单或“已被移出群组”的通知。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid incorrectly triggering blacklist or "kicked from group" notifications when the bot dissolves a group it owns.

</details>