### PR TITLE
feat(qq): 自动识别官方机器人账号

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -31,7 +31,8 @@ func (kwa *Kwarg) String() string {
 
 // [CQ:at,qq=22]
 type AtInfo struct {
-	UserID string `jsbind:"userId" json:"userId"`
+	UserID  string `jsbind:"userId"  json:"userId"`
+	IsRobot bool   `jsbind:"isRobot" json:"isRobot"`
 	// UID    string `json:"uid"`
 }
 
@@ -526,7 +527,8 @@ func parseAtInfo(cmdArgs *CmdArgs, msg *Message, botUserID string) {
 
 			// 记录@信息
 			atInfo = append(atInfo, &AtInfo{
-				UserID: userID,
+				UserID:  userID,
+				IsRobot: e.IsRobot,
 			})
 		}
 	}
@@ -756,6 +758,7 @@ func AtParse(cmd string, prefix string) (string, []*AtInfo) {
 		if len(i) == 2 {
 			at := new(AtInfo)
 			at.UserID = prefix + ":" + i[1]
+			at.IsRobot = prefix == "QQ" && isQQBotUserID(at.UserID)
 			ret = append(ret, at)
 		}
 	}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -36,6 +36,7 @@ import (
 type SenderBase struct {
 	Nickname  string `jsbind:"nickname" json:"nickname"`
 	UserID    string `jsbind:"userId"   json:"userId"`
+	IsRobot   bool   `jsbind:"isRobot"  json:"isRobot"`
 	GroupRole string `json:"-"` // 群内角色 admin管理员 owner群主
 }
 
@@ -1108,7 +1109,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 					// 屏蔽机器人发送的消息
 					if mctx.MessageType == "group" {
 						// fmt.Println("YYYYYYYYY", myuid, mctx.Group != nil)
-						if mctx.Group.BotList.Exists(msg.Sender.UserID) {
+						if mctx.Group.IsBot(msg.Sender.UserID, msg.Sender.IsRobot) {
 							log.Infof("忽略指令(机器人): 来自群(%s)内<%s>(%s): %s", msg.GroupID, msg.Sender.Nickname, msg.Sender.UserID, msg.Message)
 							return
 						}
@@ -1119,7 +1120,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 								// 忽略自己
 								continue
 							}
-							if mctx.Group.BotList.Exists(uid) {
+							if mctx.Group.IsBot(uid, i.IsRobot) {
 								return
 							}
 						}
@@ -1142,7 +1143,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 			// 试图匹配自定义回复
 			isSenderBot := false
 			if mctx.MessageType == "group" {
-				if mctx.Group != nil && mctx.Group.BotList.Exists(msg.Sender.UserID) {
+				if mctx.Group != nil && mctx.Group.IsBot(msg.Sender.UserID, msg.Sender.IsRobot) {
 					isSenderBot = true
 				}
 			}
@@ -1433,7 +1434,7 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 		// 试图匹配自定义回复
 		isSenderBot := false
 		if mctx.MessageType == "group" {
-			if mctx.Group != nil && mctx.Group.BotList.Exists(msg.Sender.UserID) {
+			if mctx.Group != nil && mctx.Group.IsBot(msg.Sender.UserID, msg.Sender.IsRobot) {
 				isSenderBot = true
 			}
 		}
@@ -1529,7 +1530,7 @@ func (s *IMSession) PreTriggerCommand(mctx *MsgContext, msg *Message, cmdArgs *C
 		// 屏蔽机器人发送的消息
 		if mctx.MessageType == "group" {
 			// fmt.Println("YYYYYYYYY", myuid, mctx.Group != nil)
-			if mctx.Group.BotList.Exists(msg.Sender.UserID) {
+			if mctx.Group.IsBot(msg.Sender.UserID, msg.Sender.IsRobot) {
 				log.Infof("忽略指令(机器人): 来自群(%s)内<%s>(%s): %s", msg.GroupID, msg.Sender.Nickname, msg.Sender.UserID, msg.Message)
 				return
 			}
@@ -1540,7 +1541,7 @@ func (s *IMSession) PreTriggerCommand(mctx *MsgContext, msg *Message, cmdArgs *C
 					// 忽略自己
 					continue
 				}
-				if mctx.Group.BotList.Exists(uid) {
+				if mctx.Group.IsBot(uid, i.IsRobot) {
 					return
 				}
 			}

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -108,6 +108,7 @@ type PlatformAdapterGocq struct {
 type Sender struct {
 	Age      int32           `json:"age"`
 	Card     string          `json:"card"`
+	IsRobot  bool            `json:"is_robot"`
 	Nickname string          `json:"nickname"`
 	Role     string          `json:"role"` // owner 群主
 	UserID   json.RawMessage `json:"user_id"`
@@ -262,6 +263,7 @@ func (msgQQ *MessageQQ) toStdMessage() *Message {
 		}
 		msg.Sender.GroupRole = msgQQ.Sender.Role
 		msg.Sender.UserID = FormatDiceIDQQ(string(msgQQ.Sender.UserID))
+		msg.Sender.IsRobot = msgQQ.Sender.IsRobot || isQQBotUserID(msg.Sender.UserID)
 	}
 	return msg
 }
@@ -1073,6 +1075,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			if msgQQ.MessageType == "private" {
 				if msg.Sender.UserID == "QQ:" {
 					msg.Sender.UserID = "QQ:" + string(msgQQ.UserID)
+					msg.Sender.IsRobot = isQQBotUserID(msg.Sender.UserID)
 				}
 				if msg.Sender.Nickname == "" {
 					msg.Sender.Nickname = "未知用户"

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -155,7 +155,8 @@ func (pa *PlatformAdapterMilky) Serve() int {
 			Time:     m.Time,
 			RawID:    m.MessageSeq,
 			Sender: SenderBase{
-				UserID: FormatDiceIDQQ(strconv.FormatInt(m.SenderId, 10)),
+				UserID:  FormatDiceIDQQ(strconv.FormatInt(m.SenderId, 10)),
+				IsRobot: isQQBotUIN(m.SenderId),
 			},
 		}
 		if msg.Sender.UserID == pa.EndPoint.UserID {
@@ -201,7 +202,8 @@ func (pa *PlatformAdapterMilky) Serve() int {
 				case *milky.AtElement:
 					log.Debugf(" At: %d", seg.UserID)
 					msg.Segment = append(msg.Segment, &message.AtElement{
-						Target: strconv.FormatInt(seg.UserID, 10),
+						Target:  strconv.FormatInt(seg.UserID, 10),
+						IsRobot: isQQBotUIN(seg.UserID),
 					})
 				case *milky.ReplyElement:
 					log.Debugf(" Reply to message ID: %d", seg.MessageSeq)

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -707,6 +707,7 @@ func (msgQQ *MessageOBQQ) toStdMessage() *Message {
 		}
 		msg.Sender.GroupRole = msgQQ.Sender.Role
 		msg.Sender.UserID = canonicalOnebotUserID(string(msgQQ.Sender.UserID))
+		msg.Sender.IsRobot = msgQQ.Sender.IsRobot || isQQBotUserID(msg.Sender.UserID)
 	}
 	return msg
 }
@@ -771,8 +772,12 @@ func arrayByte2SealdiceMessage(log *zap.SugaredLogger, raw []byte) (*Message, er
 			}
 			seg = append(seg, &recordRaw)
 		case "at":
-			_, _ = fmt.Fprintf(&cqMessage, "[CQ:at,qq=%v]", dataObj.Get("qq").String())
-			seg = append(seg, &message.AtElement{Target: dataObj.Get("qq").String()})
+			target := dataObj.Get("qq").String()
+			_, _ = fmt.Fprintf(&cqMessage, "[CQ:at,qq=%v]", target)
+			seg = append(seg, &message.AtElement{
+				Target:  target,
+				IsRobot: dataObj.Get("is_robot").Bool() || isQQBotUserID(canonicalOnebotUserID(target)),
+			})
 		case "poke":
 			cqMessage.WriteString("[CQ:poke]")
 			seg = append(seg, &message.PokeElement{})

--- a/dice/platform_adapter_qq_bot.go
+++ b/dice/platform_adapter_qq_bot.go
@@ -1,0 +1,42 @@
+package dice
+
+import (
+	"strconv"
+	"strings"
+)
+
+type qqBotUINRange struct {
+	min int64
+	max int64
+}
+
+var qqBotUINRanges = [...]qqBotUINRange{
+	{min: 3328144510, max: 3328144510},
+	{min: 2854196301, max: 2854216399},
+	{min: 66600000, max: 66600000},
+	{min: 3889000000, max: 3889999999},
+	{min: 4010000000, max: 4019999999},
+}
+
+func isQQBotUIN(uin int64) bool {
+	for _, uinRange := range qqBotUINRanges {
+		if uin >= uinRange.min && uin <= uinRange.max {
+			return true
+		}
+	}
+	return false
+}
+
+func isQQBotUserID(userID string) bool {
+	rawUIN, ok := strings.CutPrefix(userID, "QQ:")
+	if !ok || rawUIN == "" {
+		return false
+	}
+	for _, digit := range rawUIN {
+		if digit < '0' || digit > '9' {
+			return false
+		}
+	}
+	uin, err := strconv.ParseInt(rawUIN, 10, 64)
+	return err == nil && isQQBotUIN(uin)
+}

--- a/dice/platform_adapter_qq_bot_test.go
+++ b/dice/platform_adapter_qq_bot_test.go
@@ -1,0 +1,218 @@
+//nolint:testpackage // Tests cover unexported adapter conversion and dispatch helpers.
+package dice
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"sealdice-core/message"
+)
+
+func TestIsQQBotUserID(t *testing.T) {
+	tests := []struct {
+		name   string
+		userID string
+		want   bool
+	}{
+		{name: "single range 66600000", userID: "QQ:66600000", want: true},
+		{name: "below 66600000", userID: "QQ:66599999", want: false},
+		{name: "above 66600000", userID: "QQ:66600001", want: false},
+		{name: "range 2854 lower bound", userID: "QQ:2854196301", want: true},
+		{name: "range 2854 upper bound", userID: "QQ:2854216399", want: true},
+		{name: "below range 2854", userID: "QQ:2854196300", want: false},
+		{name: "above range 2854", userID: "QQ:2854216400", want: false},
+		{name: "single range 3328144510", userID: "QQ:3328144510", want: true},
+		{name: "below 3328144510", userID: "QQ:3328144509", want: false},
+		{name: "above 3328144510", userID: "QQ:3328144511", want: false},
+		{name: "range 3889 lower bound", userID: "QQ:3889000000", want: true},
+		{name: "range 3889 upper bound", userID: "QQ:3889999999", want: true},
+		{name: "below range 3889", userID: "QQ:3888999999", want: false},
+		{name: "above range 3889", userID: "QQ:3890000000", want: false},
+		{name: "range 4010 lower bound", userID: "QQ:4010000000", want: true},
+		{name: "range 4010 upper bound", userID: "QQ:4019999999", want: true},
+		{name: "below range 4010", userID: "QQ:4009999999", want: false},
+		{name: "above range 4010", userID: "QQ:4020000000", want: false},
+		{name: "empty UIN", userID: "QQ:", want: false},
+		{name: "invalid UIN", userID: "QQ:not-a-number", want: false},
+		{name: "signed UIN", userID: "QQ:+66600000", want: false},
+		{name: "UIN with suffix", userID: "QQ:66600000-extra", want: false},
+		{name: "QQ group", userID: "QQ-Group:4010000000", want: false},
+		{name: "official QQ OpenID", userID: "OpenQQ:4010000000-member-open-id", want: false},
+		{name: "other platform", userID: "TG:4010000000", want: false},
+		{name: "empty user ID", userID: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isQQBotUserID(tt.userID); got != tt.want {
+				t.Fatalf("isQQBotUserID(%q) = %t, want %t", tt.userID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupInfoIsBotCombinesManualAndVirtualBots(t *testing.T) {
+	group := &GroupInfo{BotList: new(SyncMap[string, bool])}
+	group.BotList.Store("QQ:12345678", true)
+
+	if !group.IsBot("QQ:12345678", false) {
+		t.Fatal("manually configured bot was not recognized")
+	}
+	if !group.IsBot("QQ:4010000000", true) {
+		t.Fatal("adapter-detected QQ bot was not recognized")
+	}
+	if group.IsBot("QQ:12345679", false) {
+		t.Fatal("ordinary QQ user was recognized as a bot")
+	}
+
+	group.BotList.Store("QQ:4010000000", true)
+	group.BotList.Delete("QQ:4010000000")
+	if !group.IsBot("QQ:4010000000", true) {
+		t.Fatal("deleting a manual entry disabled virtual QQ bot recognition")
+	}
+	if group.BotList.Len() != 1 {
+		t.Fatalf("automatic recognition changed the persisted bot list, length = %d", group.BotList.Len())
+	}
+}
+
+func TestQQAdaptersPopulateRobotSenderInfo(t *testing.T) {
+	legacy := (&MessageQQ{MessageQQBase: MessageQQBase{
+		MessageType: "group",
+		Sender:      &Sender{UserID: json.RawMessage("4010000000")},
+	}}).toStdMessage()
+	if !legacy.Sender.IsRobot {
+		t.Fatal("legacy OneBot conversion did not mark a QQ bot UIN")
+	}
+
+	modern := (&MessageOBQQ{MessageQQOBBase: MessageQQOBBase{
+		MessageType: "group",
+		Sender:      &Sender{UserID: json.RawMessage("3889000000")},
+	}}).toStdMessage()
+	if !modern.Sender.IsRobot {
+		t.Fatal("OneBot conversion did not mark a QQ bot UIN")
+	}
+
+	protocolDetected := (&MessageOBQQ{MessageQQOBBase: MessageQQOBBase{
+		MessageType: "group",
+		Sender: &Sender{
+			UserID:  json.RawMessage("12345678"),
+			IsRobot: true,
+		},
+	}}).toStdMessage()
+	if !protocolDetected.Sender.IsRobot {
+		t.Fatal("OneBot conversion discarded the protocol is_robot field")
+	}
+}
+
+func TestOneBotConversionPopulatesRobotMentionInfo(t *testing.T) {
+	raw := []byte(`{
+		"time": 1,
+		"message_id": 2,
+		"message_type": "group",
+		"group_id": 3,
+		"sender": {"user_id": 12345678, "nickname": "user"},
+		"message": [
+			{"type": "text", "data": {"text": ".r 1d6"}},
+			{"type": "at", "data": {"qq": "4010000000"}}
+		]
+	}`)
+
+	msg, err := arrayByte2SealdiceMessage(zap.NewNop().Sugar(), raw)
+	if err != nil {
+		t.Fatalf("arrayByte2SealdiceMessage returned error: %v", err)
+	}
+	if len(msg.Segment) != 2 {
+		t.Fatalf("converted segment count = %d, want 2", len(msg.Segment))
+	}
+	at, ok := msg.Segment[1].(*message.AtElement)
+	if !ok {
+		t.Fatalf("converted segment type = %T, want *message.AtElement", msg.Segment[1])
+	}
+	if !at.IsRobot {
+		t.Fatal("OneBot conversion did not mark a mentioned QQ bot UIN")
+	}
+}
+
+func TestLegacyAtParsePopulatesRobotInfo(t *testing.T) {
+	_, at := AtParse("[CQ:at,qq=3889000000].r 1d6", "QQ")
+	if len(at) != 1 || !at[0].IsRobot {
+		t.Fatalf("legacy QQ mention was not marked as a robot: %#v", at)
+	}
+}
+
+func TestGetCtxProxyAtPosRawSkipsQQBot(t *testing.T) {
+	ctx := &MsgContext{
+		EndPoint:     &EndPointInfo{EndPointInfoBase: EndPointInfoBase{UserID: "QQ:100000"}},
+		Group:        &GroupInfo{BotList: new(SyncMap[string, bool])},
+		DelegateText: "delegated roll",
+	}
+	cmdArgs := &CmdArgs{At: []*AtInfo{{UserID: "QQ:4010000000", IsRobot: true}}}
+
+	got := GetCtxProxyAtPosRaw(ctx, cmdArgs, 0, false)
+	if got != ctx {
+		t.Fatal("QQ bot UIN was selected as a delegated roll target")
+	}
+	if ctx.DelegateText != "" {
+		t.Fatalf("delegate text was not cleared, got %q", ctx.DelegateText)
+	}
+}
+
+func TestExecuteNewFiltersQQBotInteractions(t *testing.T) {
+	d, ep, adapter, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+
+	robotCommand := newGroupMsg("QQ-Group:81101", "QQ:4010000000", ".r 1d6")
+	robotCommand.Sender.IsRobot = true
+	d.ImSession.ExecuteNew(ep, robotCommand)
+	assertNoAdapterMessage(t, adapter, "command sent by a QQ bot")
+
+	mentionMsg := newGroupMsg("QQ-Group:81102", "QQ:12345678", ".r 1d6")
+	mentionMsg.Segment = []message.IMessageElement{
+		&message.TextElement{Content: ".r 1d6"},
+		&message.AtElement{Target: "4010000000", IsRobot: true},
+	}
+	d.ImSession.ExecuteNew(ep, mentionMsg)
+	assertNoAdapterMessage(t, adapter, "command mentioning another QQ bot")
+
+	const hookGroupID = "QQ-Group:81103"
+	setupCtx := &MsgContext{Dice: d, EndPoint: ep, Session: d.ImSession}
+	hookGroup := SetBotOnAtGroup(setupCtx, hookGroupID)
+	hookCalls := make(chan string, 1)
+	hookGroup.SetActivatedExtList([]*ExtInfo{{
+		Name: "qq-bot-filter-test",
+		OnNotCommandReceived: func(_ *MsgContext, msg *Message) {
+			hookCalls <- msg.Sender.UserID
+		},
+	}}, nil)
+
+	robotText := newGroupMsg(hookGroupID, "QQ:3889000000", "plain text")
+	robotText.Sender.IsRobot = true
+	d.ImSession.ExecuteNew(ep, robotText)
+	select {
+	case senderID := <-hookCalls:
+		t.Fatalf("non-command hook ran for QQ bot %q", senderID)
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	d.ImSession.ExecuteNew(ep, newGroupMsg(hookGroupID, "QQ:12345678", "plain text"))
+	select {
+	case senderID := <-hookCalls:
+		if senderID != "QQ:12345678" {
+			t.Fatalf("non-command hook sender = %q, want ordinary QQ user", senderID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("non-command hook did not run for an ordinary QQ user")
+	}
+}
+
+func assertNoAdapterMessage(t *testing.T, adapter *mockPlatformAdapter, context string) {
+	t.Helper()
+	select {
+	case unexpected := <-adapter.msgCh:
+		t.Fatalf("unexpected reply for %s: %q", context, unexpected)
+	case <-time.After(400 * time.Millisecond):
+	}
+}

--- a/dice/utils.go
+++ b/dice/utils.go
@@ -289,6 +289,18 @@ func ReadCardTypeEx(mctx *MsgContext, curType string) string {
 	return extra
 }
 
+// IsBot reports whether a user is manually marked as a bot or reported as one
+// by its platform adapter. Adapter matches are never persisted.
+func (group *GroupInfo) IsBot(userID string, detectedAsRobot bool) bool {
+	if detectedAsRobot {
+		return true
+	}
+	if group != nil && group.BotList != nil && group.BotList.Exists(userID) {
+		return true
+	}
+	return false
+}
+
 // GetCtxProxyFirst 第三个参数是否取消再观察一下
 func GetCtxProxyFirst(ctx *MsgContext, cmdArgs *CmdArgs) *MsgContext {
 	return GetCtxProxyAtPosRaw(ctx, cmdArgs, 0, true)
@@ -313,18 +325,8 @@ func GetCtxProxyAtPosRaw(ctx *MsgContext, cmdArgs *CmdArgs, pos int, setTempVar 
 		}
 
 		// 这个其实无用，因为有@其他bot的指令不会进入到solve阶段
-		if ctx.Group != nil {
-			isBot := false
-			ctx.Group.BotList.Range(func(botUid string, _ bool) bool {
-				if i.UserID == botUid {
-					isBot = true
-					return false
-				}
-				return true
-			})
-			if isBot {
-				continue
-			}
+		if ctx.Group != nil && ctx.Group.IsBot(i.UserID, i.IsRobot) {
+			continue
 		}
 
 		// theChoosen := i.UID

--- a/message/message.go
+++ b/message/message.go
@@ -170,7 +170,8 @@ func (t *TextElement) FromCQData(dMap map[string]string) error {
 }
 
 type AtElement struct {
-	Target string `jsbind:"target"`
+	Target  string `jsbind:"target"`
+	IsRobot bool   `jsbind:"isRobot"`
 }
 
 func (t *AtElement) Type() ElementType {


### PR DESCRIPTION
## 变更
- 在内部 SenderBase、AtElement 和 AtInfo 中归一化 IsRobot 信息。
- Milky 与 OneBot adapter 使用 QQ 机器人 UIN 号段兜底识别；OneBot 同时接受协议返回的 is_robot。
- 将 adapter 识别结果与群内人工 BotList 合并，统一用于发送者、被提及者、自定义回复和代骰判断。
- 自动识别结果不写入持久化 BotList，也不能通过删除人工记录取消。
- OpenQQ 身份不按 UIN 前缀判断，避免将同一官方机器人应用下的普通用户误判。

## 验证
- go test ./dice/... -count=1
- go vet ./...
- golangci-lint run
- go test ./... -count=1：除 logger 包现有的 Windows database.log 文件锁清理失败外均通过；该失败已在未修改的 master 上复现。