### PR TITLE
fix(config): 修复自定义文案备份与安全写入

### DIFF
--- a/api/custom.go
+++ b/api/custom.go
@@ -32,6 +32,10 @@ func customTextSave(c echo.Context) error {
 	}{}
 	err := c.Bind(&v)
 	if err == nil {
+		previousTextMapRaw := cloneTextTemplateWithWeightDict(myDice.TextMapRaw)
+		previousTextMapHelpInfo := cloneTextTemplateWithHelpDict(myDice.TextMapHelpInfo)
+		previousTextMap := myDice.TextMap
+
 		for _, v1 := range v.Data {
 			for _, v2 := range v1 {
 				v2[0] = strings.TrimSpace(v2[0].(string))
@@ -41,7 +45,12 @@ func customTextSave(c echo.Context) error {
 		myDice.TextMapRaw[v.Category] = v.Data
 		dice.SetupTextHelpInfo(myDice, myDice.TextMapHelpInfo, myDice.TextMapRaw, "configs/text-template.yaml")
 		myDice.GenerateTextMap()
-		myDice.SaveText()
+		if err := myDice.SaveText(); err != nil {
+			myDice.TextMapRaw = previousTextMapRaw
+			myDice.TextMapHelpInfo = previousTextMapHelpInfo
+			myDice.TextMap = previousTextMap
+			return c.String(http.StatusInternalServerError, err.Error())
+		}
 
 		for k, v2 := range myDice.TextMapRaw[v.Category] {
 			dice.TextMapCompatibleCheck(myDice, v.Category, k, v2)

--- a/api/custom_test.go
+++ b/api/custom_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+
+	"sealdice-core/dice"
+)
+
+func TestCustomTextSaveReturnsErrorAndRollsBackWhenSaveTextFails(t *testing.T) {
+	dataDir := t.TempDir()
+	templatePath := filepath.Join(dataDir, "configs", "text-template.yaml")
+	if err := os.MkdirAll(templatePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(templatePath) error = %v", err)
+	}
+
+	token := setupCustomTextSaveTestDice(t, dataDir)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/sd-api/configs/customText/save", strings.NewReader(
+		`{"category":"核心","data":{}}`,
+	))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("Token", token)
+	rec := httptest.NewRecorder()
+
+	if err := customTextSave(e.NewContext(req, rec)); err != nil {
+		t.Fatalf("customTextSave() error = %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body=%q", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if _, exists := myDice.TextMapRaw["核心"]["原文案"]; !exists {
+		t.Fatalf("TextMapRaw was not rolled back: %#v", myDice.TextMapRaw)
+	}
+	if _, exists := myDice.TextMapHelpInfo["核心"]["原文案"]; !exists {
+		t.Fatalf("TextMapHelpInfo was not rolled back: %#v", myDice.TextMapHelpInfo)
+	}
+	if _, exists := myDice.TextMap["核心:原文案"]; !exists {
+		t.Fatalf("TextMap was not rolled back: %#v", myDice.TextMap)
+	}
+}
+
+func setupCustomTextSaveTestDice(t *testing.T, dataDir string) string {
+	t.Helper()
+
+	testDice := &dice.Dice{
+		BaseConfig: dice.BaseConfig{DataDir: dataDir},
+		Logger:     zap.NewNop().Sugar(),
+		TextMapRaw: dice.TextTemplateWithWeightDict{
+			"核心": dice.TextTemplateWithWeight{
+				"原文案": []dice.TextTemplateItem{{"old", 1}},
+			},
+		},
+		TextMapHelpInfo: dice.TextTemplateWithHelpDict{
+			"核心": dice.TextTemplateHelpGroup{
+				"原文案": &dice.TextTemplateHelpItem{
+					Origin: []dice.TextTemplateItem{{"old", 1}},
+				},
+			},
+		},
+	}
+	testDice.GenerateTextMap()
+
+	manager := &dice.DiceManager{Dice: []*dice.Dice{testDice}}
+	token := "test-token"
+	manager.AccessTokens.Store(token, true)
+	testDice.Parent = manager
+
+	previousDice := myDice
+	previousManager := dm
+	myDice = testDice
+	dm = manager
+	t.Cleanup(func() {
+		myDice = previousDice
+		dm = previousManager
+	})
+
+	return token
+}

--- a/api/custom_text_clone.go
+++ b/api/custom_text_clone.go
@@ -1,0 +1,73 @@
+package api
+
+import "sealdice-core/dice"
+
+func cloneTextTemplateWithWeightDict(src dice.TextTemplateWithWeightDict) dice.TextTemplateWithWeightDict {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(dice.TextTemplateWithWeightDict, len(src))
+	for groupName, group := range src {
+		dst[groupName] = cloneTextTemplateWithWeight(group)
+	}
+	return dst
+}
+
+func cloneTextTemplateWithWeight(src dice.TextTemplateWithWeight) dice.TextTemplateWithWeight {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(dice.TextTemplateWithWeight, len(src))
+	for keyName, items := range src {
+		dst[keyName] = cloneTextTemplateItems(items)
+	}
+	return dst
+}
+
+func cloneTextTemplateItems(src []dice.TextTemplateItem) []dice.TextTemplateItem {
+	if src == nil {
+		return nil
+	}
+
+	dst := make([]dice.TextTemplateItem, len(src))
+	for index, item := range src {
+		dst[index] = append(dice.TextTemplateItem(nil), item...)
+	}
+	return dst
+}
+
+func cloneTextTemplateWithHelpDict(src dice.TextTemplateWithHelpDict) dice.TextTemplateWithHelpDict {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(dice.TextTemplateWithHelpDict, len(src))
+	for groupName, group := range src {
+		dst[groupName] = cloneTextTemplateHelpGroup(group)
+	}
+	return dst
+}
+
+func cloneTextTemplateHelpGroup(src dice.TextTemplateHelpGroup) dice.TextTemplateHelpGroup {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(dice.TextTemplateHelpGroup, len(src))
+	for keyName, item := range src {
+		if item == nil {
+			dst[keyName] = nil
+			continue
+		}
+		cloned := *item
+		cloned.Filename = append([]string(nil), item.Filename...)
+		cloned.Origin = cloneTextTemplateItems(item.Origin)
+		cloned.Vars = append([]string(nil), item.Vars...)
+		cloned.Commands = append([]string(nil), item.Commands...)
+		cloned.ExampleCommands = append([]string(nil), item.ExampleCommands...)
+		dst[keyName] = &cloned
+	}
+	return dst
+}

--- a/dice/atomic_write.go
+++ b/dice/atomic_write.go
@@ -1,0 +1,48 @@
+package dice
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func writeFileAtomically(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create parent dir: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tempFile.Chmod(perm); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := replaceFileAtomically(tempPath, path); err != nil {
+		return fmt.Errorf("replace target file: %w", err)
+	}
+	cleanupTemp = false
+	return nil
+}

--- a/dice/atomic_write_other.go
+++ b/dice/atomic_write_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package dice
+
+import "os"
+
+func replaceFileAtomically(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}

--- a/dice/atomic_write_windows.go
+++ b/dice/atomic_write_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package dice
+
+import "golang.org/x/sys/windows"
+
+func replaceFileAtomically(oldPath, newPath string) error {
+	oldPtr, err := windows.UTF16PtrFromString(oldPath)
+	if err != nil {
+		return err
+	}
+	newPtr, err := windows.UTF16PtrFromString(newPath)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(
+		oldPtr,
+		newPtr,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH,
+	)
+}

--- a/dice/config.go
+++ b/dice/config.go
@@ -2056,7 +2056,7 @@ func setupTextTemplate(d *Dice) {
 	// 加载硬盘设置
 	loadTextTemplate(d, "configs/text-template.yaml")
 
-	d.SaveText()
+	_ = d.SaveText()
 	d.GenerateTextMap()
 }
 
@@ -2222,7 +2222,7 @@ func (d *Dice) loads() {
 
 				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
 				d.GenerateTextMap()
-				d.SaveText()
+				_ = d.SaveText()
 			})
 		}
 
@@ -2253,7 +2253,7 @@ func (d *Dice) loads() {
 
 				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
 				d.GenerateTextMap()
-				d.SaveText()
+				_ = d.SaveText()
 			})
 		}
 
@@ -2269,7 +2269,7 @@ func (d *Dice) loads() {
 
 				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
 				d.GenerateTextMap()
-				d.SaveText()
+				_ = d.SaveText()
 			})
 		}
 
@@ -2288,7 +2288,7 @@ func (d *Dice) loads() {
 
 				SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
 				d.GenerateTextMap()
-				d.SaveText()
+				_ = d.SaveText()
 			})
 		}
 
@@ -2303,7 +2303,7 @@ func (d *Dice) loads() {
 			}
 			SetupTextHelpInfo(d, d.TextMapHelpInfo, d.TextMapRaw, "configs/text-template.yaml")
 			d.GenerateTextMap()
-			d.SaveText()
+			_ = d.SaveText()
 		})
 
 		d.Config = config
@@ -2415,21 +2415,52 @@ func (d *Dice) loadAdvanced() {
 	d.AdvancedConfig = advancedConfig
 }
 
-func (d *Dice) SaveText() {
-	buf, err := yaml.Marshal(d.TextMapRaw)
+func (d *Dice) SaveText() error {
+	buf, err := marshalTextTemplateYAML(d.TextMapRaw)
 	if err != nil {
-		d.Logger.Error("Dice.SaveText", err)
-	} else {
-		newFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml")
-		bakFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml.bak")
-		// ioutil.WriteFile(filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml"), buf, 0644)
-		current, err := os.ReadFile(newFn)
-		if err != nil {
-			_ = os.WriteFile(bakFn, current, 0o644) //nolint:gosec
-		}
-
-		_ = os.WriteFile(newFn, buf, 0o644)
+		return d.saveTextError(fmt.Errorf("生成自定义文案 YAML 失败: %w", err))
 	}
+
+	var verified TextTemplateWithWeightDict
+	if err := yaml.Unmarshal(buf, &verified); err != nil {
+		return d.saveTextError(fmt.Errorf("校验自定义文案 YAML 失败: %w", err))
+	}
+
+	newFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml")
+	bakFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml.bak")
+	if err := os.MkdirAll(filepath.Dir(newFn), 0o755); err != nil {
+		return d.saveTextError(fmt.Errorf("创建自定义文案目录失败: %w", err))
+	}
+
+	current, err := os.ReadFile(newFn)
+	if err == nil {
+		if err := writeFileAtomically(bakFn, current, 0o644); err != nil {
+			return d.saveTextError(fmt.Errorf("备份自定义文案文件失败: %w", err))
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return d.saveTextError(fmt.Errorf("读取旧自定义文案文件失败，已取消保存: %w", err))
+	}
+
+	if err := writeFileAtomically(newFn, buf, 0o644); err != nil {
+		return d.saveTextError(fmt.Errorf("保存自定义文案文件失败: %w", err))
+	}
+	return nil
+}
+
+func marshalTextTemplateYAML(texts TextTemplateWithWeightDict) (buf []byte, err error) {
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("marshal panic: %v", v)
+		}
+	}()
+	return yaml.Marshal(texts)
+}
+
+func (d *Dice) saveTextError(err error) error {
+	if d.Logger != nil {
+		d.Logger.Error("Dice.SaveText", err)
+	}
+	return err
 }
 
 // ApplyExtDefaultSettings 应用扩展默认配置，同时处理插件的启用和禁用

--- a/dice/config_save_text_test.go
+++ b/dice/config_save_text_test.go
@@ -1,0 +1,164 @@
+package dice
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSaveTextBacksUpExistingTemplateBeforeReplace(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := filepath.Join(dataDir, "configs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(configDir) error = %v", err)
+	}
+
+	templatePath := filepath.Join(configDir, "text-template.yaml")
+	backupPath := filepath.Join(configDir, "text-template.yaml.bak")
+	oldContent := []byte("核心:\n  旧文案:\n    - - old\n      - 1\n")
+	if err := os.WriteFile(templatePath, oldContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(templatePath) error = %v", err)
+	}
+
+	d := newSaveTextTestDice(dataDir, "new")
+	if err := d.SaveText(); err != nil {
+		t.Fatalf("SaveText() error = %v", err)
+	}
+
+	backupContent, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("ReadFile(backupPath) error = %v", err)
+	}
+	if string(backupContent) != string(oldContent) {
+		t.Fatalf("backup content = %q, want %q", string(backupContent), string(oldContent))
+	}
+
+	saved := readSavedTextTemplate(t, templatePath)
+	if got := saved["核心"]["测试文案"][0][0]; got != "new" {
+		t.Fatalf("saved text = %v, want new", got)
+	}
+}
+
+func TestSaveTextCreatesTemplateWithoutEmptyBackup(t *testing.T) {
+	dataDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dataDir, "configs"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(configs) error = %v", err)
+	}
+
+	templatePath := filepath.Join(dataDir, "configs", "text-template.yaml")
+	backupPath := filepath.Join(dataDir, "configs", "text-template.yaml.bak")
+	d := newSaveTextTestDice(dataDir, "new")
+	if err := d.SaveText(); err != nil {
+		t.Fatalf("SaveText() error = %v", err)
+	}
+
+	saved := readSavedTextTemplate(t, templatePath)
+	if got := saved["核心"]["测试文案"][0][0]; got != "new" {
+		t.Fatalf("saved text = %v, want new", got)
+	}
+	if _, err := os.Stat(backupPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("backup stat error = %v, want not exist", err)
+	}
+}
+
+func TestSaveTextStopsWhenExistingTemplateCannotBeRead(t *testing.T) {
+	dataDir := t.TempDir()
+	templatePath := filepath.Join(dataDir, "configs", "text-template.yaml")
+	backupPath := filepath.Join(dataDir, "configs", "text-template.yaml.bak")
+	if err := os.MkdirAll(templatePath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(templatePath) error = %v", err)
+	}
+
+	d := newSaveTextTestDice(dataDir, "new")
+	if err := d.SaveText(); err == nil {
+		t.Fatal("SaveText() error = nil, want error")
+	}
+	if _, err := os.Stat(backupPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("backup stat error = %v, want not exist", err)
+	}
+}
+
+func TestSaveTextDoesNotReplaceTemplateWhenMarshalFails(t *testing.T) {
+	dataDir := t.TempDir()
+	configDir := filepath.Join(dataDir, "configs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(configDir) error = %v", err)
+	}
+
+	templatePath := filepath.Join(configDir, "text-template.yaml")
+	oldContent := []byte("核心:\n  旧文案:\n    - - old\n      - 1\n")
+	if err := os.WriteFile(templatePath, oldContent, 0o644); err != nil {
+		t.Fatalf("WriteFile(templatePath) error = %v", err)
+	}
+
+	d := &Dice{
+		BaseConfig: BaseConfig{DataDir: dataDir},
+		Logger:     zap.NewNop().Sugar(),
+		TextMapRaw: TextTemplateWithWeightDict{
+			"核心": TextTemplateWithWeight{
+				"测试文案": []TextTemplateItem{{func() {}, 1}},
+			},
+		},
+	}
+	if err := d.SaveText(); err == nil {
+		t.Fatal("SaveText() error = nil, want error")
+	}
+
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("ReadFile(templatePath) error = %v", err)
+	}
+	if string(content) != string(oldContent) {
+		t.Fatalf("template content = %q, want %q", string(content), string(oldContent))
+	}
+}
+
+func TestWriteFileAtomicallyRemovesTempFileOnReplaceFailure(t *testing.T) {
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.yaml")
+	if err := os.MkdirAll(targetPath, 0o755); err != nil {
+		t.Fatalf("MkdirAll(targetPath) error = %v", err)
+	}
+
+	if err := writeFileAtomically(targetPath, []byte("new"), 0o644); err == nil {
+		t.Fatal("writeFileAtomically() error = nil, want error")
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, ".target.yaml.tmp-*"))
+	if err != nil {
+		t.Fatalf("Glob(temp files) error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files left behind: %v", matches)
+	}
+}
+
+func newSaveTextTestDice(dataDir, text string) *Dice {
+	return &Dice{
+		BaseConfig: BaseConfig{DataDir: dataDir},
+		Logger:     zap.NewNop().Sugar(),
+		TextMapRaw: TextTemplateWithWeightDict{
+			"核心": TextTemplateWithWeight{
+				"测试文案": []TextTemplateItem{{text, 1}},
+			},
+		},
+	}
+}
+
+func readSavedTextTemplate(t *testing.T, path string) TextTemplateWithWeightDict {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	texts := TextTemplateWithWeightDict{}
+	if err := yaml.Unmarshal(data, &texts); err != nil {
+		t.Fatalf("Unmarshal(%s) error = %v", path, err)
+	}
+	return texts
+}


### PR DESCRIPTION
## Summary by Sourcery

通过让 `SaveText` 感知错误、引入原子化文件写入，并在保存失败时确保 API 级别的回滚，提高自定义文本模板持久化的可靠性。

New Features:
- 引入原子化文件写入工具，使用平台特定的文件替换机制安全更新配置文件。

Bug Fixes:
- 让 `SaveText` 验证 YAML、备份现有模板并暴露错误，以防止在保存自定义文本模板时出现数据丢失。
- 确保自定义文本 API 在持久化更改失败时回滚内存中的文本状态，并返回 HTTP 500。

Enhancements:
- 修改 `SaveText` 以返回错误而不仅仅是日志记录，使调用方能够显式处理失败情况。

Tests:
- 添加单元测试，覆盖 `SaveText` 备份行为、编组和读取失败场景以及原子写入的清理逻辑。
- 添加 API 测试，在通过 HTTP 保存自定义文本失败时验证回滚行为和错误响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reliability of custom text template persistence by making SaveText error-aware, adding atomic file writing, and ensuring API-level rollback on save failures.

New Features:
- Introduce atomic file writing utility with platform-specific file replacement to safely update configuration files.

Bug Fixes:
- Make SaveText validate YAML, back up existing templates, and surface errors to prevent data loss when saving custom text templates.
- Ensure custom text API rolls back in-memory text state and returns HTTP 500 when persistence of changes fails.

Enhancements:
- Change SaveText to return errors instead of only logging, enabling callers to handle failures explicitly.

Tests:
- Add unit tests covering SaveText backup behavior, marshal and read failure scenarios, and atomic write cleanup.
- Add API tests verifying rollback behavior and error responses when saving custom text via HTTP fails.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过让 `SaveText` 感知错误、引入原子化文件写入，并在保存失败时确保 API 级别的回滚，提高自定义文本模板持久化的可靠性。

New Features:
- 引入原子化文件写入工具，使用平台特定的文件替换机制安全更新配置文件。

Bug Fixes:
- 让 `SaveText` 验证 YAML、备份现有模板并暴露错误，以防止在保存自定义文本模板时出现数据丢失。
- 确保自定义文本 API 在持久化更改失败时回滚内存中的文本状态，并返回 HTTP 500。

Enhancements:
- 修改 `SaveText` 以返回错误而不仅仅是日志记录，使调用方能够显式处理失败情况。

Tests:
- 添加单元测试，覆盖 `SaveText` 备份行为、编组和读取失败场景以及原子写入的清理逻辑。
- 添加 API 测试，在通过 HTTP 保存自定义文本失败时验证回滚行为和错误响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reliability of custom text template persistence by making SaveText error-aware, adding atomic file writing, and ensuring API-level rollback on save failures.

New Features:
- Introduce atomic file writing utility with platform-specific file replacement to safely update configuration files.

Bug Fixes:
- Make SaveText validate YAML, back up existing templates, and surface errors to prevent data loss when saving custom text templates.
- Ensure custom text API rolls back in-memory text state and returns HTTP 500 when persistence of changes fails.

Enhancements:
- Change SaveText to return errors instead of only logging, enabling callers to handle failures explicitly.

Tests:
- Add unit tests covering SaveText backup behavior, marshal and read failure scenarios, and atomic write cleanup.
- Add API tests verifying rollback behavior and error responses when saving custom text via HTTP fails.

</details>

</details>

Bug 修复：
- 通过验证 YAML、备份现有文件以及在读/写错误时安全失败，防止在保存自定义文本模板时发生数据丢失和损坏。
- 确保当持久化更改失败时，API 的自定义文本更新会回滚内存状态并返回错误响应。

增强功能：
- 添加原子文件写入工具和平台相关的文件替换机制，以保证配置文件的安全更新。
- 优化 SaveText，使其返回错误而不是仅进行日志记录的副作用，使调用方能够显式处理失败情况。

测试：
- 添加单元测试，覆盖 SaveText 的备份行为、错误场景以及原子写入的清理逻辑。
- 添加 API 测试，在自定义文本保存失败时验证回滚行为和 HTTP 错误响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过让 `SaveText` 感知错误、引入原子化文件写入，并在保存失败时确保 API 级别的回滚，提高自定义文本模板持久化的可靠性。

New Features:
- 引入原子化文件写入工具，使用平台特定的文件替换机制安全更新配置文件。

Bug Fixes:
- 让 `SaveText` 验证 YAML、备份现有模板并暴露错误，以防止在保存自定义文本模板时出现数据丢失。
- 确保自定义文本 API 在持久化更改失败时回滚内存中的文本状态，并返回 HTTP 500。

Enhancements:
- 修改 `SaveText` 以返回错误而不仅仅是日志记录，使调用方能够显式处理失败情况。

Tests:
- 添加单元测试，覆盖 `SaveText` 备份行为、编组和读取失败场景以及原子写入的清理逻辑。
- 添加 API 测试，在通过 HTTP 保存自定义文本失败时验证回滚行为和错误响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reliability of custom text template persistence by making SaveText error-aware, adding atomic file writing, and ensuring API-level rollback on save failures.

New Features:
- Introduce atomic file writing utility with platform-specific file replacement to safely update configuration files.

Bug Fixes:
- Make SaveText validate YAML, back up existing templates, and surface errors to prevent data loss when saving custom text templates.
- Ensure custom text API rolls back in-memory text state and returns HTTP 500 when persistence of changes fails.

Enhancements:
- Change SaveText to return errors instead of only logging, enabling callers to handle failures explicitly.

Tests:
- Add unit tests covering SaveText backup behavior, marshal and read failure scenarios, and atomic write cleanup.
- Add API tests verifying rollback behavior and error responses when saving custom text via HTTP fails.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过让 `SaveText` 感知错误、引入原子化文件写入，并在保存失败时确保 API 级别的回滚，提高自定义文本模板持久化的可靠性。

New Features:
- 引入原子化文件写入工具，使用平台特定的文件替换机制安全更新配置文件。

Bug Fixes:
- 让 `SaveText` 验证 YAML、备份现有模板并暴露错误，以防止在保存自定义文本模板时出现数据丢失。
- 确保自定义文本 API 在持久化更改失败时回滚内存中的文本状态，并返回 HTTP 500。

Enhancements:
- 修改 `SaveText` 以返回错误而不仅仅是日志记录，使调用方能够显式处理失败情况。

Tests:
- 添加单元测试，覆盖 `SaveText` 备份行为、编组和读取失败场景以及原子写入的清理逻辑。
- 添加 API 测试，在通过 HTTP 保存自定义文本失败时验证回滚行为和错误响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve reliability of custom text template persistence by making SaveText error-aware, adding atomic file writing, and ensuring API-level rollback on save failures.

New Features:
- Introduce atomic file writing utility with platform-specific file replacement to safely update configuration files.

Bug Fixes:
- Make SaveText validate YAML, back up existing templates, and surface errors to prevent data loss when saving custom text templates.
- Ensure custom text API rolls back in-memory text state and returns HTTP 500 when persistence of changes fails.

Enhancements:
- Change SaveText to return errors instead of only logging, enabling callers to handle failures explicitly.

Tests:
- Add unit tests covering SaveText backup behavior, marshal and read failure scenarios, and atomic write cleanup.
- Add API tests verifying rollback behavior and error responses when saving custom text via HTTP fails.

</details>

</details>

</details>