### PR TITLE
fix(official-qq): 加速官方bot的迁移

### DIFF
--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -228,6 +228,17 @@ func (m *officialQQIdentityMigration) migrateAttrsID(id, attrsType string) strin
 
 func (m *officialQQIdentityMigration) run(d *Dice) error {
 	if d.DBOperator != nil {
+		hasLegacyGroups, err := m.hasLegacyGroups(d.DBOperator)
+		if err != nil {
+			return fmt.Errorf("检查 QQ 官方旧群组数据失败: %w", err)
+		}
+		if !hasLegacyGroups {
+			if err := m.syncCharacterCache(d, d.DBOperator); err != nil {
+				return fmt.Errorf("同步角色卡缓存失败: %w", err)
+			}
+			m.migrateMemory(d)
+			return nil
+		}
 		if err := m.collectDatabase(d.DBOperator); err != nil {
 			return err
 		}
@@ -240,14 +251,14 @@ func (m *officialQQIdentityMigration) run(d *Dice) error {
 		}
 	}
 	if d.DBOperator != nil {
-		if err := m.migrateDataDB(d.DBOperator); err != nil {
-			return fmt.Errorf("迁移主数据库失败: %w", err)
-		}
 		if err := m.migrateLogDB(d.DBOperator); err != nil {
 			return fmt.Errorf("迁移日志数据库失败: %w", err)
 		}
 		if err := m.migrateCensorDB(d.DBOperator); err != nil {
 			return fmt.Errorf("迁移敏感词数据库失败: %w", err)
+		}
+		if err := m.migrateDataDB(d.DBOperator); err != nil {
+			return fmt.Errorf("迁移主数据库失败: %w", err)
 		}
 		if err := m.syncCharacterCache(d, d.DBOperator); err != nil {
 			return fmt.Errorf("同步角色卡缓存失败: %w", err)
@@ -289,6 +300,24 @@ func (m *officialQQIdentityMigration) syncCharacterCache(d *Dice, operator engin
 
 func hasTable(db *gorm.DB, value any) bool {
 	return db != nil && db.Migrator().HasTable(value)
+}
+
+func (m *officialQQIdentityMigration) hasLegacyGroups(operator engine.DatabaseOperator) (bool, error) {
+	db := operator.GetDataDB(constant.READ)
+	if !hasTable(db, &model.GroupInfo{}) {
+		// Keep the full fallback for incomplete and test databases that do not have group_info.
+		return true, nil
+	}
+
+	prefix := m.oldGroupPrefix()
+	// The IDs are ASCII; '.' is the exclusive upper bound for a prefix ending in '-'.
+	upperBound := strings.TrimSuffix(prefix, "-") + "."
+	var row model.GroupInfo
+	result := db.Select("id").Where("id >= ? AND id < ?", prefix, upperBound).Limit(1).Find(&row)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected != 0, nil
 }
 
 func (m *officialQQIdentityMigration) collectDatabase(operator engine.DatabaseOperator) error {

--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -228,11 +228,11 @@ func (m *officialQQIdentityMigration) migrateAttrsID(id, attrsType string) strin
 
 func (m *officialQQIdentityMigration) run(d *Dice) error {
 	if d.DBOperator != nil {
-		hasLegacyGroups, err := m.hasLegacyGroups(d.DBOperator)
+		shouldMigrate, err := m.shouldRunIdentityMigration(d.DBOperator)
 		if err != nil {
 			return fmt.Errorf("检查 QQ 官方旧群组数据失败: %w", err)
 		}
-		if !hasLegacyGroups {
+		if !shouldMigrate {
 			if err := m.syncCharacterCache(d, d.DBOperator); err != nil {
 				return fmt.Errorf("同步角色卡缓存失败: %w", err)
 			}
@@ -302,10 +302,10 @@ func hasTable(db *gorm.DB, value any) bool {
 	return db != nil && db.Migrator().HasTable(value)
 }
 
-func (m *officialQQIdentityMigration) hasLegacyGroups(operator engine.DatabaseOperator) (bool, error) {
+func (m *officialQQIdentityMigration) shouldRunIdentityMigration(operator engine.DatabaseOperator) (bool, error) {
 	db := operator.GetDataDB(constant.READ)
 	if !hasTable(db, &model.GroupInfo{}) {
-		// Keep the full fallback for incomplete and test databases that do not have group_info.
+		// Without group_info the optimized probe is unavailable, so preserve the full fallback.
 		return true, nil
 	}
 

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -315,6 +315,68 @@ func TestPublicDiceEndpointAppID(t *testing.T) {
 	}
 }
 
+func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
+	const appID = "123456789"
+
+	dbOperator, err := newMockDatabaseOperator(filepath.Join(t.TempDir(), "official-qq-probe.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(dbOperator.Close)
+	if err := dbOperator.db.AutoMigrate(&model.GroupInfo{}); err != nil {
+		t.Fatal(err)
+	}
+
+	migration := &officialQQIdentityMigration{appID: appID}
+	prefix := migration.oldGroupPrefix()
+	upperBound := strings.TrimSuffix(prefix, "-") + "."
+	timestamp := int64(1)
+	for _, id := range []string{
+		"OpenQQ-Group:1-new-group",
+		"OpenQQ-Group-T:123456788-other-app",
+		upperBound,
+	} {
+		if err := dbOperator.db.Create(&model.GroupInfo{ID: id, CreatedAt: timestamp, UpdatedAt: &timestamp}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	hasLegacyGroups, err := migration.hasLegacyGroups(dbOperator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasLegacyGroups {
+		t.Fatal("legacy group probe matched an unrelated group")
+	}
+
+	legacyID := prefix + "group-open-id"
+	if err := dbOperator.db.Create(&model.GroupInfo{ID: legacyID, CreatedAt: timestamp, UpdatedAt: &timestamp}).Error; err != nil {
+		t.Fatal(err)
+	}
+	hasLegacyGroups, err = migration.hasLegacyGroups(dbOperator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasLegacyGroups {
+		t.Fatal("legacy group probe missed an old official QQ group")
+	}
+
+	type queryPlanRow struct {
+		Detail string `gorm:"column:detail"`
+	}
+	var plan []queryPlanRow
+	if err := dbOperator.db.Raw(
+		"EXPLAIN QUERY PLAN SELECT id FROM group_info WHERE id >= ? AND id < ? LIMIT 1",
+		prefix,
+		upperBound,
+	).Scan(&plan).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(plan) == 0 || !strings.Contains(plan[0].Detail, "SEARCH") || strings.Contains(plan[0].Detail, "SCAN") {
+		t.Fatalf("legacy group probe does not use an indexed search: %#v", plan)
+	}
+}
+
 func TestOfficialQQIdentityMigration(t *testing.T) {
 	const (
 		appID        = "123456789"

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -341,11 +341,11 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 		}
 	}
 
-	hasLegacyGroups, probeErr := migration.hasLegacyGroups(dbOperator)
+	shouldMigrate, probeErr := migration.shouldRunIdentityMigration(dbOperator)
 	if probeErr != nil {
 		t.Fatal(probeErr)
 	}
-	if hasLegacyGroups {
+	if shouldMigrate {
 		t.Fatal("legacy group probe matched an unrelated group")
 	}
 
@@ -353,11 +353,11 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 	if err := dbOperator.db.Create(&model.GroupInfo{ID: legacyID, CreatedAt: timestamp, UpdatedAt: &timestamp}).Error; err != nil {
 		t.Fatal(err)
 	}
-	hasLegacyGroups, probeErr = migration.hasLegacyGroups(dbOperator)
+	shouldMigrate, probeErr = migration.shouldRunIdentityMigration(dbOperator)
 	if probeErr != nil {
 		t.Fatal(probeErr)
 	}
-	if !hasLegacyGroups {
+	if !shouldMigrate {
 		t.Fatal("legacy group probe missed an old official QQ group")
 	}
 
@@ -372,7 +372,18 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 	).Scan(&plan).Error; err != nil {
 		t.Fatal(err)
 	}
-	if len(plan) == 0 || !strings.Contains(plan[0].Detail, "SEARCH") || strings.Contains(plan[0].Detail, "SCAN") {
+	usesIndexedSearch := false
+	for _, row := range plan {
+		detail := strings.ToUpper(row.Detail)
+		if !strings.Contains(detail, "GROUP_INFO") {
+			continue
+		}
+		if strings.Contains(detail, "SCAN") {
+			t.Fatalf("legacy group probe uses a table scan: %#v", plan)
+		}
+		usesIndexedSearch = usesIndexedSearch || strings.Contains(detail, "SEARCH")
+	}
+	if !usesIndexedSearch {
 		t.Fatalf("legacy group probe does not use an indexed search: %#v", plan)
 	}
 }

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -318,9 +318,9 @@ func TestPublicDiceEndpointAppID(t *testing.T) {
 func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 	const appID = "123456789"
 
-	dbOperator, err := newMockDatabaseOperator(filepath.Join(t.TempDir(), "official-qq-probe.db"))
-	if err != nil {
-		t.Fatal(err)
+	dbOperator, openErr := newMockDatabaseOperator(filepath.Join(t.TempDir(), "official-qq-probe.db"))
+	if openErr != nil {
+		t.Fatal(openErr)
 	}
 	t.Cleanup(dbOperator.Close)
 	if err := dbOperator.db.AutoMigrate(&model.GroupInfo{}); err != nil {
@@ -341,9 +341,9 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 		}
 	}
 
-	hasLegacyGroups, err := migration.hasLegacyGroups(dbOperator)
-	if err != nil {
-		t.Fatal(err)
+	hasLegacyGroups, probeErr := migration.hasLegacyGroups(dbOperator)
+	if probeErr != nil {
+		t.Fatal(probeErr)
 	}
 	if hasLegacyGroups {
 		t.Fatal("legacy group probe matched an unrelated group")
@@ -353,9 +353,9 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 	if err := dbOperator.db.Create(&model.GroupInfo{ID: legacyID, CreatedAt: timestamp, UpdatedAt: &timestamp}).Error; err != nil {
 		t.Fatal(err)
 	}
-	hasLegacyGroups, err = migration.hasLegacyGroups(dbOperator)
-	if err != nil {
-		t.Fatal(err)
+	hasLegacyGroups, probeErr = migration.hasLegacyGroups(dbOperator)
+	if probeErr != nil {
+		t.Fatal(probeErr)
 	}
 	if !hasLegacyGroups {
 		t.Fatal("legacy group probe missed an old official QQ group")


### PR DESCRIPTION
## Summary by Sourcery

通过使用对索引友好的查询来探测旧版官方 QQ 群组，并在不存在任何旧版数据时短路多余的迁移步骤，同时调整数据库迁移顺序，从而优化官方 QQ 身份迁移流程。

Bug Fixes:
- 当主数据库中不存在任何旧版官方 QQ 群组记录时，跳过旧版官方 QQ 群组迁移。

Enhancements:
- 在 `group_info` 上新增带索引的旧版群组检测查询，以避免不必要的迁移工作。
- 重新排序数据库迁移流程，使日志库和审查库优先于主数据仓库进行迁移。
- 当未检测到任何旧版群组时，跳过内存迁移和字符缓存同步，以加速新部署环境中的迁移过程。

Tests:
- 新增测试，用于验证旧版群组探测行为，并确保底层的 `group_info` 查询使用基于索引的搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the official QQ identity migration flow by probing for legacy groups using an index-friendly query and short-circuiting unnecessary migration steps when no legacy data is present, while adjusting the order of database migrations.

Bug Fixes:
- Skip legacy official QQ group migration when no legacy group records exist in the main database.

Enhancements:
- Add an indexed legacy group detection query on group_info to avoid unnecessary migration work.
- Reorder database migration so log and censor databases are migrated before the main data database.
- Bypass in-memory migration and character cache sync when no legacy groups are detected to speed up migrations on new deployments.

Tests:
- Add a test verifying the legacy group probe behavior and that the underlying group_info query uses an index-based search.

</details>

Bug Fixes（错误修复）:
- 在不存在旧版 QQ 群组数据时，避免执行旧版官方 QQ 群组迁移逻辑，从而防止不必要的工作和潜在问题。

Enhancements（增强与改进）:
- 在主数据库中引入一个有针对性、对索引友好的探测流程，用于检测旧版官方 QQ 群组记录。
- 重新排序数据库迁移步骤，使日志数据库和审查数据库在主数据数据库之前完成迁移。
- 在不存在旧版群组时，跳过内存迁移和角色缓存同步，以加速新部署环境中的迁移过程。

Tests（测试）:
- 添加一个针对性的测试，用于验证旧版群组探测行为，并确保底层查询在 `group_info` 上使用索引检索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过使用对索引友好的查询来探测旧版官方 QQ 群组，并在不存在任何旧版数据时短路多余的迁移步骤，同时调整数据库迁移顺序，从而优化官方 QQ 身份迁移流程。

Bug Fixes:
- 当主数据库中不存在任何旧版官方 QQ 群组记录时，跳过旧版官方 QQ 群组迁移。

Enhancements:
- 在 `group_info` 上新增带索引的旧版群组检测查询，以避免不必要的迁移工作。
- 重新排序数据库迁移流程，使日志库和审查库优先于主数据仓库进行迁移。
- 当未检测到任何旧版群组时，跳过内存迁移和字符缓存同步，以加速新部署环境中的迁移过程。

Tests:
- 新增测试，用于验证旧版群组探测行为，并确保底层的 `group_info` 查询使用基于索引的搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the official QQ identity migration flow by probing for legacy groups using an index-friendly query and short-circuiting unnecessary migration steps when no legacy data is present, while adjusting the order of database migrations.

Bug Fixes:
- Skip legacy official QQ group migration when no legacy group records exist in the main database.

Enhancements:
- Add an indexed legacy group detection query on group_info to avoid unnecessary migration work.
- Reorder database migration so log and censor databases are migrated before the main data database.
- Bypass in-memory migration and character cache sync when no legacy groups are detected to speed up migrations on new deployments.

Tests:
- Add a test verifying the legacy group probe behavior and that the underlying group_info query uses an index-based search.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过使用对索引友好的查询来探测旧版官方 QQ 群组，并在不存在任何旧版数据时短路多余的迁移步骤，同时调整数据库迁移顺序，从而优化官方 QQ 身份迁移流程。

Bug Fixes:
- 当主数据库中不存在任何旧版官方 QQ 群组记录时，跳过旧版官方 QQ 群组迁移。

Enhancements:
- 在 `group_info` 上新增带索引的旧版群组检测查询，以避免不必要的迁移工作。
- 重新排序数据库迁移流程，使日志库和审查库优先于主数据仓库进行迁移。
- 当未检测到任何旧版群组时，跳过内存迁移和字符缓存同步，以加速新部署环境中的迁移过程。

Tests:
- 新增测试，用于验证旧版群组探测行为，并确保底层的 `group_info` 查询使用基于索引的搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the official QQ identity migration flow by probing for legacy groups using an index-friendly query and short-circuiting unnecessary migration steps when no legacy data is present, while adjusting the order of database migrations.

Bug Fixes:
- Skip legacy official QQ group migration when no legacy group records exist in the main database.

Enhancements:
- Add an indexed legacy group detection query on group_info to avoid unnecessary migration work.
- Reorder database migration so log and censor databases are migrated before the main data database.
- Bypass in-memory migration and character cache sync when no legacy groups are detected to speed up migrations on new deployments.

Tests:
- Add a test verifying the legacy group probe behavior and that the underlying group_info query uses an index-based search.

</details>

Bug Fixes（错误修复）:
- 在不存在旧版 QQ 群组数据时，避免执行旧版官方 QQ 群组迁移逻辑，从而防止不必要的工作和潜在问题。

Enhancements（增强与改进）:
- 在主数据库中引入一个有针对性、对索引友好的探测流程，用于检测旧版官方 QQ 群组记录。
- 重新排序数据库迁移步骤，使日志数据库和审查数据库在主数据数据库之前完成迁移。
- 在不存在旧版群组时，跳过内存迁移和角色缓存同步，以加速新部署环境中的迁移过程。

Tests（测试）:
- 添加一个针对性的测试，用于验证旧版群组探测行为，并确保底层查询在 `group_info` 上使用索引检索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过使用对索引友好的查询来探测旧版官方 QQ 群组，并在不存在任何旧版数据时短路多余的迁移步骤，同时调整数据库迁移顺序，从而优化官方 QQ 身份迁移流程。

Bug Fixes:
- 当主数据库中不存在任何旧版官方 QQ 群组记录时，跳过旧版官方 QQ 群组迁移。

Enhancements:
- 在 `group_info` 上新增带索引的旧版群组检测查询，以避免不必要的迁移工作。
- 重新排序数据库迁移流程，使日志库和审查库优先于主数据仓库进行迁移。
- 当未检测到任何旧版群组时，跳过内存迁移和字符缓存同步，以加速新部署环境中的迁移过程。

Tests:
- 新增测试，用于验证旧版群组探测行为，并确保底层的 `group_info` 查询使用基于索引的搜索。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the official QQ identity migration flow by probing for legacy groups using an index-friendly query and short-circuiting unnecessary migration steps when no legacy data is present, while adjusting the order of database migrations.

Bug Fixes:
- Skip legacy official QQ group migration when no legacy group records exist in the main database.

Enhancements:
- Add an indexed legacy group detection query on group_info to avoid unnecessary migration work.
- Reorder database migration so log and censor databases are migrated before the main data database.
- Bypass in-memory migration and character cache sync when no legacy groups are detected to speed up migrations on new deployments.

Tests:
- Add a test verifying the legacy group probe behavior and that the underlying group_info query uses an index-based search.

</details>

</details>

</details>