### PR TITLE
fix(official-qq): 迁移阶段占据巨大内存问题

### DIFF
--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -405,6 +405,10 @@ func DiceConfigSet(c echo.Context) error {
 		config.OfficialQQUseMarkdown = val.(bool)
 	}
 
+	if val, ok := jsonMap["officialQQEnableIdentityMigration"]; ok {
+		config.OfficialQQMigrationEnable = val.(bool)
+	}
+
 	if val, ok := jsonMap["playerNameWrapEnable"]; ok {
 		config.PlayerNameWrapEnable = val.(bool)
 	}

--- a/dice/dice_config.go
+++ b/dice/dice_config.go
@@ -175,6 +175,8 @@ type BaseConfig struct {
 	// TODO: 历史遗留问题，由于不输出DICE日志效果过差，已经抹除日志输出选项，剩余两个选项，私以为可以想办法也抹除掉。
 	Name    string `yaml:"name"`    // 名称，默认为default
 	DataDir string `yaml:"dataDir"` // 数据路径，为./data/{name}，例如data/default
+
+	OfficialQQMigrationEnable bool `json:"officialQQEnableIdentityMigration" yaml:"officialQQEnableIdentityMigration"` // 启动 QQ 官方旧身份数据迁移
 }
 
 type RateLimitConfig struct {

--- a/dice/dice_config_default.go
+++ b/dice/dice_config_default.go
@@ -48,6 +48,8 @@ var DefaultConfig = Config{
 		VMVersionForMsg:          "v2",
 		Name:                     "default",
 		DataDir:                  "data/default",
+
+		OfficialQQMigrationEnable: false,
 	},
 	RateLimitConfig{
 		RateLimitEnabled:         false,

--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -93,22 +93,23 @@ func ensureOfficialQQIdentity(d *Dice, pa *PlatformAdapterOfficialQQ, botID, uin
 	if current := pa.EndPoint.UserID; current != "" && current != oldEndpoint && current != expectedEndpoint {
 		return fmt.Errorf("无法识别旧账号 ID %q，期望 %q", current, oldEndpoint)
 	}
-	// Apply the remotely verified identity even if data migration fails. The
-	// adapter can keep running, and the same migration will be retried on the
-	// next connection or after the account is added again.
+	// The verified runtime identity is required even when the optional legacy
+	// data migration is disabled or fails.
 	pa.UIN = uin
 	pa.EndPoint.UserID = expectedEndpoint
 
-	migration := &officialQQIdentityMigration{
-		appID:       pa.AppID,
-		uin:         uin,
-		oldEndpoint: oldEndpoint,
-		newEndpoint: expectedEndpoint,
-		groups:      map[string]string{},
-		users:       map[string]string{},
-	}
-	if err := migration.run(d); err != nil {
-		return &officialQQIdentityMigrationError{cause: err}
+	if d.Config.OfficialQQMigrationEnable {
+		migration := &officialQQIdentityMigration{
+			appID:       pa.AppID,
+			uin:         uin,
+			oldEndpoint: oldEndpoint,
+			newEndpoint: expectedEndpoint,
+			groups:      map[string]string{},
+			users:       map[string]string{},
+		}
+		if err := migration.run(d); err != nil {
+			return &officialQQIdentityMigrationError{cause: err}
+		}
 	}
 
 	d.LastUpdatedTime = time.Now().Unix()

--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm"
 
 	"sealdice-core/model"
+	"sealdice-core/utils/cache"
 	"sealdice-core/utils/constant"
 	"sealdice-core/utils/dboperator/engine"
 )
@@ -25,6 +26,30 @@ type officialQQIdentityMigration struct {
 	groups         map[string]string
 	users          map[string]string
 	characterNames map[string]string
+}
+
+const officialQQIdentityMigrationBatchSize = 200
+
+func officialQQIdentityMigrationFindInBatches[T any](query *gorm.DB, process func([]T) error) error {
+	var rows []T
+	query = officialQQIdentityMigrationWithoutCache(query)
+	return query.FindInBatches(&rows, officialQQIdentityMigrationBatchSize, func(_ *gorm.DB, _ int) error {
+		return process(rows)
+	}).Error
+}
+
+func officialQQIdentityMigrationWithoutCache(db *gorm.DB) *gorm.DB {
+	return db.WithContext(cache.WithDatabaseCacheDisabled(db.Statement.Context))
+}
+
+func officialQQIdentityMigrationForEachChunk[T any](items []T, process func([]T) error) error {
+	for start := 0; start < len(items); start += officialQQIdentityMigrationBatchSize {
+		end := min(start+officialQQIdentityMigrationBatchSize, len(items))
+		if err := process(items[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type officialQQIdentityMigrationError struct {
@@ -93,6 +118,24 @@ func ensureOfficialQQIdentity(d *Dice, pa *PlatformAdapterOfficialQQ, botID, uin
 
 func (m *officialQQIdentityMigration) oldGroupPrefix() string {
 	return "OpenQQ-Group-T:" + m.appID + "-"
+}
+
+func officialQQIdentityMigrationPrefixBounds(prefix string) (string, string) {
+	// All legacy identity prefixes are ASCII and end in '-'. Replacing that
+	// byte with '.' gives the smallest exclusive upper bound for the prefix.
+	return prefix, strings.TrimSuffix(prefix, "-") + "."
+}
+
+func (m *officialQQIdentityMigration) oldGroupBounds() (string, string) {
+	return officialQQIdentityMigrationPrefixBounds(m.oldGroupPrefix())
+}
+
+func (m *officialQQIdentityMigration) oldMemberRootPrefix() string {
+	return "OpenQQ-Member-T:" + m.appID + "-"
+}
+
+func (m *officialQQIdentityMigration) oldMemberBounds() (string, string) {
+	return officialQQIdentityMigrationPrefixBounds(m.oldMemberRootPrefix())
 }
 
 func (m *officialQQIdentityMigration) oldMemberPrefix(groupOpenID string) string {
@@ -285,17 +328,20 @@ func (m *officialQQIdentityMigration) syncCharacterCache(d *Dice, operator engin
 	if !hasTable(db, &model.AttributesItemModel{}) {
 		return nil
 	}
-	var rows []model.AttributesItemModel
-	if err := db.Select("id, name").Where("attrs_type = ? AND id IN ?", "character", ids).Find(&rows).Error; err != nil {
-		return err
-	}
-	for _, row := range rows {
-		if item, ok := d.AttrsManager.m.Load(row.Id); ok && item != nil {
-			item.Name = row.Name
-			item.IsSaved = true
+	db = officialQQIdentityMigrationWithoutCache(db)
+	return officialQQIdentityMigrationForEachChunk(ids, func(batchIDs []string) error {
+		var rows []model.AttributesItemModel
+		if err := db.Select("id, name").Where("attrs_type = ? AND id IN ?", "character", batchIDs).Find(&rows).Error; err != nil {
+			return err
 		}
-	}
-	return nil
+		for _, row := range rows {
+			if item, ok := d.AttrsManager.m.Load(row.Id); ok && item != nil {
+				item.Name = row.Name
+				item.IsSaved = true
+			}
+		}
+		return nil
+	})
 }
 
 func hasTable(db *gorm.DB, value any) bool {
@@ -303,114 +349,196 @@ func hasTable(db *gorm.DB, value any) bool {
 }
 
 func (m *officialQQIdentityMigration) shouldRunIdentityMigration(operator engine.DatabaseOperator) (bool, error) {
-	db := operator.GetDataDB(constant.READ)
-	if !hasTable(db, &model.GroupInfo{}) {
-		// Without group_info the optimized probe is unavailable, so preserve the full fallback.
+	groupPrefix, groupUpperBound := m.oldGroupBounds()
+	memberPrefix, memberUpperBound := m.oldMemberBounds()
+
+	probes := []*gorm.DB{}
+	dataDB := operator.GetDataDB(constant.READ)
+	if !hasTable(dataDB, &model.GroupInfo{}) {
+		// Without group_info the optimized database probe cannot rule out
+		// legacy identities held only in memory, so preserve the full fallback.
 		return true, nil
 	}
+	probes = append(probes, dataDB.Model(&model.GroupInfo{}).Where("id >= ? AND id < ?", groupPrefix, groupUpperBound))
 
-	prefix := m.oldGroupPrefix()
-	// The IDs are ASCII; '.' is the exclusive upper bound for a prefix ending in '-'.
-	upperBound := strings.TrimSuffix(prefix, "-") + "."
-	var row model.GroupInfo
-	result := db.Select("id").Where("id >= ? AND id < ?", prefix, upperBound).Limit(1).Find(&row)
-	if result.Error != nil {
-		return false, result.Error
+	logDB := operator.GetLogDB(constant.READ)
+	if hasTable(logDB, &model.LogInfo{}) {
+		probes = append(probes, logDB.Model(&model.LogInfo{}).Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound))
 	}
-	return result.RowsAffected != 0, nil
+	if hasTable(logDB, &model.LogOneItem{}) {
+		probes = append(probes, logDB.Model(&model.LogOneItem{}).Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound))
+	}
+
+	if hasTable(dataDB, &model.GroupPlayerInfoBase{}) {
+		probes = append(probes, dataDB.Model(&model.GroupPlayerInfoBase{}).Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound))
+	}
+	if hasTable(dataDB, &model.AttributesItemModel{}) {
+		probes = append(probes, m.legacyAttrsQuery(dataDB.Model(&model.AttributesItemModel{})))
+	}
+	if hasTable(dataDB, &model.BanInfo{}) {
+		probes = append(probes, dataDB.Model(&model.BanInfo{}).Where(
+			"(id >= ? AND id < ?) OR (id >= ? AND id < ?)",
+			groupPrefix,
+			groupUpperBound,
+			memberPrefix,
+			memberUpperBound,
+		))
+	}
+	if hasTable(dataDB, &model.EndpointInfo{}) {
+		probes = append(probes, dataDB.Model(&model.EndpointInfo{}).Where("user_id = ?", m.oldEndpoint))
+	}
+
+	censorDB := operator.GetCensorDB(constant.READ)
+	if hasTable(censorDB, &model.CensorLog{}) {
+		probes = append(probes, censorDB.Model(&model.CensorLog{}).Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound))
+	}
+
+	for _, probe := range probes {
+		var found int
+		result := officialQQIdentityMigrationWithoutCache(probe).Select("1").Limit(1).Scan(&found)
+		if result.Error != nil {
+			return false, result.Error
+		}
+		if result.RowsAffected != 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (m *officialQQIdentityMigration) collectDatabase(operator engine.DatabaseOperator) error {
+	groupPrefix, groupUpperBound := m.oldGroupBounds()
+	memberPrefix, memberUpperBound := m.oldMemberBounds()
 	dataDB := operator.GetDataDB(constant.READ)
 	if hasTable(dataDB, &model.GroupInfo{}) {
-		var rows []model.GroupInfo
-		if err := dataDB.Where("id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			dataDB.Select("id").Where("id >= ? AND id < ?", groupPrefix, groupUpperBound),
+			func(rows []model.GroupInfo) error {
+				for _, row := range rows {
+					m.addGroup(row.ID)
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			m.addGroup(row.ID)
 		}
 	}
 	if hasTable(dataDB, &model.GroupPlayerInfoBase{}) {
-		var rows []model.GroupPlayerInfoBase
-		if err := dataDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			dataDB.Select("id, group_id, user_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+			func(rows []model.GroupPlayerInfoBase) error {
+				for _, row := range rows {
+					m.addGroup(row.GroupID)
+					m.addMember(row.GroupID, row.UserID)
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			m.addGroup(row.GroupID)
-			m.addMember(row.GroupID, row.UserID)
 		}
 	}
 
 	logDB := operator.GetLogDB(constant.READ)
 	if hasTable(logDB, &model.LogInfo{}) {
-		var rows []model.LogInfo
-		if err := logDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			logDB.Select("id, group_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+			func(rows []model.LogInfo) error {
+				for _, row := range rows {
+					m.addGroup(row.GroupID)
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			m.addGroup(row.GroupID)
 		}
 	}
 	if hasTable(logDB, &model.LogOneItem{}) {
-		var rows []model.LogOneItem
-		if err := logDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			logDB.Select("id, group_id, im_userid, user_uniform_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+			func(rows []model.LogOneItem) error {
+				for _, row := range rows {
+					m.addGroup(row.GroupID)
+					m.addMember(row.GroupID, row.IMUserID)
+					m.addMember(row.GroupID, row.UniformID)
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			m.addGroup(row.GroupID)
-			m.addMember(row.GroupID, row.IMUserID)
-			m.addMember(row.GroupID, row.UniformID)
 		}
 	}
 
 	censorDB := operator.GetCensorDB(constant.READ)
 	if hasTable(censorDB, &model.CensorLog{}) {
-		var rows []model.CensorLog
-		if err := censorDB.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			censorDB.Select("id, group_id, user_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+			func(rows []model.CensorLog) error {
+				for _, row := range rows {
+					m.addGroup(row.GroupID)
+					m.addMember(row.GroupID, row.UserID)
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			m.addGroup(row.GroupID)
-			m.addMember(row.GroupID, row.UserID)
 		}
 	}
 
 	if hasTable(dataDB, &model.AttributesItemModel{}) {
-		var rows []model.AttributesItemModel
-		query := "id LIKE ? OR id LIKE ? OR owner_id LIKE ?"
-		if err := dataDB.Where(query, m.oldGroupPrefix()+"%", "%"+"OpenQQ-Member-T:"+m.appID+"-%", "OpenQQ-Member-T:"+m.appID+"-%").Find(&rows).Error; err != nil {
-			return err
-		}
 		groupUserMarker := "-OpenQQ-Member-T:" + m.appID + "-"
-		for _, row := range rows {
-			if marker := strings.Index(row.Id, groupUserMarker); marker > 0 {
-				oldGroupID := row.Id[:marker]
-				if m.addGroup(oldGroupID) {
-					m.addMember(oldGroupID, row.Id[marker+1:])
+		err := officialQQIdentityMigrationFindInBatches(
+			m.legacyAttrsQuery(dataDB.Select("id, owner_id")),
+			func(rows []model.AttributesItemModel) error {
+				for _, row := range rows {
+					if marker := strings.Index(row.Id, groupUserMarker); marker > 0 {
+						oldGroupID := row.Id[:marker]
+						if m.addGroup(oldGroupID) {
+							m.addMember(oldGroupID, row.Id[marker+1:])
+						}
+					} else if strings.HasPrefix(row.Id, m.oldGroupPrefix()) {
+						m.addGroup(row.Id)
+					}
+					m.addMemberID(row.Id)
+					m.addMemberID(row.OwnerId)
 				}
-			} else if strings.HasPrefix(row.Id, m.oldGroupPrefix()) {
-				m.addGroup(row.Id)
-			}
-			m.addMemberID(row.Id)
-			m.addMemberID(row.OwnerId)
+				return nil
+			},
+		)
+		if err != nil {
+			return err
 		}
 	}
 
 	if hasTable(dataDB, &model.BanInfo{}) {
-		var rows []model.BanInfo
-		if err := dataDB.Where("id LIKE ? OR id LIKE ?", m.oldGroupPrefix()+"%", "OpenQQ-Member-T:"+m.appID+"-%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			dataDB.Select("id, data").Where(
+				"(id >= ? AND id < ?) OR (id >= ? AND id < ?)",
+				groupPrefix,
+				groupUpperBound,
+				memberPrefix,
+				memberUpperBound,
+			),
+			func(rows []model.BanInfo) error {
+				for _, row := range rows {
+					var item BanListInfoItem
+					if json.Unmarshal(row.Data, &item) != nil {
+						continue
+					}
+					for _, place := range item.Places {
+						m.addGroup(place)
+						m.addMember(place, row.ID)
+					}
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			var item BanListInfoItem
-			if json.Unmarshal(row.Data, &item) != nil {
-				continue
-			}
-			for _, place := range item.Places {
-				m.addGroup(place)
-				m.addMember(place, row.ID)
-			}
 		}
 	}
 	return nil
@@ -458,7 +586,23 @@ func ensureNoTarget(db *gorm.DB, value any, where string, args ...any) error {
 	return nil
 }
 
-func mergeOfficialQQUserAttrs(rows []model.AttributesItemModel) (model.AttributesItemModel, error) {
+func (m *officialQQIdentityMigration) legacyAttrsQuery(db *gorm.DB) *gorm.DB {
+	groupPrefix, groupUpperBound := m.oldGroupBounds()
+	memberPrefix, memberUpperBound := m.oldMemberBounds()
+	return db.Where(
+		"(id >= ? AND id < ?) OR (id >= ? AND id < ?) OR (owner_id >= ? AND owner_id < ?)",
+		groupPrefix,
+		groupUpperBound,
+		memberPrefix,
+		memberUpperBound,
+		memberPrefix,
+		memberUpperBound,
+	)
+}
+
+const officialQQIdentityMigrationAttrsMetadataColumns = "id, attrs_type, binding_sheet_id, name, owner_id, sheet_type, is_hidden, created_at, updated_at"
+
+func mergeOfficialQQUserAttrs(tx *gorm.DB, rows []model.AttributesItemModel) (model.AttributesItemModel, error) {
 	if len(rows) == 0 {
 		return model.AttributesItemModel{}, errors.New("没有可合并的 QQ 官方用户属性")
 	}
@@ -484,26 +628,50 @@ func mergeOfficialQQUserAttrs(rows []model.AttributesItemModel) (model.Attribute
 		if row.BindingSheetId != "" {
 			return model.AttributesItemModel{}, fmt.Errorf("无法合并带角色绑定的 QQ 官方用户属性 %s", row.Id)
 		}
-		value, err := ds.VMValueFromJSON(row.Data)
-		if err != nil {
-			return model.AttributesItemModel{}, fmt.Errorf("解析 QQ 官方用户属性 %s 失败: %w", row.Id, err)
-		}
-		dict, ok := value.ReadDictData()
-		if !ok {
-			return model.AttributesItemModel{}, fmt.Errorf("QQ 官方用户属性 %s 不是字典", row.Id)
-		}
-		if dict.Dict != nil {
-			dict.Dict.Range(func(key string, value *ds.VMValue) bool {
-				merged.Store(key, value)
-				return true
-			})
-		}
 		if row.CreatedAt < createdAt {
 			createdAt = row.CreatedAt
 		}
 		if row.UpdatedAt > updatedAt {
 			updatedAt = row.UpdatedAt
 		}
+	}
+	tx = officialQQIdentityMigrationWithoutCache(tx)
+	if err := officialQQIdentityMigrationForEachChunk(ordered, func(batch []model.AttributesItemModel) error {
+		ids := make([]string, 0, len(batch))
+		for _, row := range batch {
+			ids = append(ids, row.Id)
+		}
+		var dataRows []model.AttributesItemModel
+		if err := tx.Select("id, data").Where("id IN ?", ids).Find(&dataRows).Error; err != nil {
+			return err
+		}
+		dataByID := make(map[string][]byte, len(dataRows))
+		for _, row := range dataRows {
+			dataByID[row.Id] = row.Data
+		}
+		for _, row := range batch {
+			data, exists := dataByID[row.Id]
+			if !exists {
+				return fmt.Errorf("QQ 官方用户属性 %s 在合并期间不存在", row.Id)
+			}
+			value, err := ds.VMValueFromJSON(data)
+			if err != nil {
+				return fmt.Errorf("解析 QQ 官方用户属性 %s 失败: %w", row.Id, err)
+			}
+			dict, ok := value.ReadDictData()
+			if !ok {
+				return fmt.Errorf("QQ 官方用户属性 %s 不是字典", row.Id)
+			}
+			if dict.Dict != nil {
+				dict.Dict.Range(func(key string, value *ds.VMValue) bool {
+					merged.Store(key, value)
+					return true
+				})
+			}
+		}
+		return nil
+	}); err != nil {
+		return model.AttributesItemModel{}, err
 	}
 
 	data, err := ds.NewDictVal(merged).V().ToJSON()
@@ -519,14 +687,24 @@ func mergeOfficialQQUserAttrs(rows []model.AttributesItemModel) (model.Attribute
 	return result, nil
 }
 
-func (m *officialQQIdentityMigration) mergeCollidingUserAttrs(tx *gorm.DB, rows []model.AttributesItemModel) (map[string]struct{}, error) {
+func (m *officialQQIdentityMigration) mergeCollidingUserAttrs(tx *gorm.DB) error {
+	tx = officialQQIdentityMigrationWithoutCache(tx)
 	byTarget := map[string][]model.AttributesItemModel{}
-	for _, row := range rows {
-		newID := m.migrateUserID(row.Id)
-		if newID == row.Id {
-			continue
-		}
-		byTarget[newID] = append(byTarget[newID], row)
+	err := officialQQIdentityMigrationFindInBatches(
+		m.legacyAttrsQuery(tx).Select(officialQQIdentityMigrationAttrsMetadataColumns),
+		func(rows []model.AttributesItemModel) error {
+			for _, row := range rows {
+				newID := m.migrateUserID(row.Id)
+				if newID == row.Id {
+					continue
+				}
+				byTarget[newID] = append(byTarget[newID], row)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return err
 	}
 
 	targets := make([]string, 0, len(byTarget))
@@ -537,21 +715,20 @@ func (m *officialQQIdentityMigration) mergeCollidingUserAttrs(tx *gorm.DB, rows 
 	}
 	sort.Strings(targets)
 
-	mergedSourceIDs := map[string]struct{}{}
 	for _, target := range targets {
 		sources := byTarget[target]
 		var existing model.AttributesItemModel
-		result := tx.Where("id = ?", target).Limit(1).Find(&existing)
+		result := tx.Select(officialQQIdentityMigrationAttrsMetadataColumns).Where("id = ?", target).Limit(1).Find(&existing)
 		if result.Error != nil {
-			return nil, result.Error
+			return result.Error
 		}
 		if result.RowsAffected != 0 {
 			sources = append(sources, existing)
 		}
 
-		merged, err := mergeOfficialQQUserAttrs(sources)
+		merged, err := mergeOfficialQQUserAttrs(tx, sources)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		merged.Id = target
 		merged.OwnerId = m.migrateUserID(merged.OwnerId)
@@ -559,21 +736,21 @@ func (m *officialQQIdentityMigration) mergeCollidingUserAttrs(tx *gorm.DB, rows 
 		ids := make([]string, 0, len(sources))
 		for _, source := range sources {
 			ids = append(ids, source.Id)
-			if source.Id != target {
-				mergedSourceIDs[source.Id] = struct{}{}
-			}
 		}
-		if err := tx.Where("id IN ?", ids).Delete(&model.AttributesItemModel{}).Error; err != nil {
-			return nil, err
+		if err := officialQQIdentityMigrationForEachChunk(ids, func(batchIDs []string) error {
+			return tx.Where("id IN ?", batchIDs).Delete(&model.AttributesItemModel{}).Error
+		}); err != nil {
+			return err
 		}
 		if err := tx.Create(&merged).Error; err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return mergedSourceIDs, nil
+	return nil
 }
 
-func (m *officialQQIdentityMigration) planCharacterNames(tx *gorm.DB, rows []model.AttributesItemModel) (map[string]string, error) {
+func (m *officialQQIdentityMigration) planCharacterNames(tx *gorm.DB) (map[string]string, error) {
+	tx = officialQQIdentityMigrationWithoutCache(tx)
 	type ownerName struct {
 		owner string
 		name  string
@@ -587,19 +764,28 @@ func (m *officialQQIdentityMigration) planCharacterNames(tx *gorm.DB, rows []mod
 
 	owners := map[string]struct{}{}
 	groups := map[ownerName][]candidate{}
-	for _, row := range rows {
-		newOwnerID := m.migrateUserID(row.OwnerId)
-		if row.AttrsType != "character" || newOwnerID == row.OwnerId {
-			continue
-		}
-		owners[newOwnerID] = struct{}{}
-		key := ownerName{owner: newOwnerID, name: row.Name}
-		groups[key] = append(groups[key], candidate{
-			id:        row.Id,
-			owner:     newOwnerID,
-			name:      row.Name,
-			createdAt: row.CreatedAt,
-		})
+	err := officialQQIdentityMigrationFindInBatches(
+		m.legacyAttrsQuery(tx).Select("id, attrs_type, name, owner_id, created_at"),
+		func(rows []model.AttributesItemModel) error {
+			for _, row := range rows {
+				newOwnerID := m.migrateUserID(row.OwnerId)
+				if row.AttrsType != "character" || newOwnerID == row.OwnerId {
+					continue
+				}
+				owners[newOwnerID] = struct{}{}
+				key := ownerName{owner: newOwnerID, name: row.Name}
+				groups[key] = append(groups[key], candidate{
+					id:        row.Id,
+					owner:     newOwnerID,
+					name:      row.Name,
+					createdAt: row.CreatedAt,
+				})
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 	if len(owners) == 0 {
 		return map[string]string{}, nil
@@ -609,17 +795,23 @@ func (m *officialQQIdentityMigration) planCharacterNames(tx *gorm.DB, rows []mod
 	for ownerID := range owners {
 		ownerIDs = append(ownerIDs, ownerID)
 	}
-	var existing []model.AttributesItemModel
-	if err := tx.Where("attrs_type = ? AND owner_id IN ?", "character", ownerIDs).Find(&existing).Error; err != nil {
-		return nil, err
-	}
 
 	usedNames := map[string]map[string]struct{}{}
 	for ownerID := range owners {
 		usedNames[ownerID] = map[string]struct{}{}
 	}
-	for _, row := range existing {
-		usedNames[row.OwnerId][row.Name] = struct{}{}
+	if err := officialQQIdentityMigrationForEachChunk(ownerIDs, func(batchOwnerIDs []string) error {
+		return officialQQIdentityMigrationFindInBatches(
+			tx.Select("id, owner_id, name").Where("attrs_type = ? AND owner_id IN ?", "character", batchOwnerIDs),
+			func(rows []model.AttributesItemModel) error {
+				for _, row := range rows {
+					usedNames[row.OwnerId][row.Name] = struct{}{}
+				}
+				return nil
+			},
+		)
+	}); err != nil {
+		return nil, err
 	}
 
 	keys := make([]ownerName, 0, len(groups))
@@ -680,112 +872,131 @@ func (m *officialQQIdentityMigration) migrateDataDB(operator engine.DatabaseOper
 	if db == nil {
 		return nil
 	}
+	groupPrefix, groupUpperBound := m.oldGroupBounds()
 	return db.Transaction(func(tx *gorm.DB) error {
 		if hasTable(tx, &model.GroupInfo{}) {
-			var rows []model.GroupInfo
-			if err := tx.Where("id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			err := officialQQIdentityMigrationFindInBatches(
+				tx.Select("id, data").Where("id >= ? AND id < ?", groupPrefix, groupUpperBound),
+				func(rows []model.GroupInfo) error {
+					for _, row := range rows {
+						newID := m.migrateGroupID(row.ID)
+						if newID == row.ID {
+							continue
+						}
+						if err := ensureNoTarget(tx, &model.GroupInfo{}, "id = ?", newID); err != nil {
+							return err
+						}
+						var group GroupInfo
+						if err := json.Unmarshal(row.Data, &group); err != nil {
+							return fmt.Errorf("解析群组 %s 失败: %w", row.ID, err)
+						}
+						m.migrateGroup(&group, row.ID)
+						data, err := json.Marshal(&group)
+						if err != nil {
+							return err
+						}
+						if err := tx.Model(&model.GroupInfo{}).Where("id = ?", row.ID).Updates(map[string]any{"id": newID, "data": data}).Error; err != nil {
+							return err
+						}
+					}
+					return nil
+				},
+			)
+			if err != nil {
 				return err
-			}
-			for _, row := range rows {
-				newID := m.migrateGroupID(row.ID)
-				if newID == row.ID {
-					continue
-				}
-				if err := ensureNoTarget(tx, &model.GroupInfo{}, "id = ?", newID); err != nil {
-					return err
-				}
-				var group GroupInfo
-				if err := json.Unmarshal(row.Data, &group); err != nil {
-					return fmt.Errorf("解析群组 %s 失败: %w", row.ID, err)
-				}
-				m.migrateGroup(&group, row.ID)
-				data, err := json.Marshal(&group)
-				if err != nil {
-					return err
-				}
-				if err := tx.Model(&model.GroupInfo{}).Where("id = ?", row.ID).Updates(map[string]any{"id": newID, "data": data}).Error; err != nil {
-					return err
-				}
 			}
 		}
 
 		if hasTable(tx, &model.GroupPlayerInfoBase{}) {
-			var rows []model.GroupPlayerInfoBase
-			if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			err := officialQQIdentityMigrationFindInBatches(
+				tx.Select("id, group_id, user_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+				func(rows []model.GroupPlayerInfoBase) error {
+					for _, row := range rows {
+						newGroupID := m.migrateGroupID(row.GroupID)
+						newUserID := m.migrateContextUserID(row.GroupID, row.UserID)
+						if err := tx.Model(&model.GroupPlayerInfoBase{}).Where("id = ?", row.ID).Updates(map[string]any{"group_id": newGroupID, "user_id": newUserID}).Error; err != nil {
+							return err
+						}
+					}
+					return nil
+				},
+			)
+			if err != nil {
 				return err
-			}
-			for _, row := range rows {
-				newGroupID := m.migrateGroupID(row.GroupID)
-				newUserID := m.migrateContextUserID(row.GroupID, row.UserID)
-				if err := tx.Model(&model.GroupPlayerInfoBase{}).Where("id = ?", row.ID).Updates(map[string]any{"group_id": newGroupID, "user_id": newUserID}).Error; err != nil {
-					return err
-				}
 			}
 		}
 
 		if hasTable(tx, &model.AttributesItemModel{}) {
-			var rows []model.AttributesItemModel
-			query := "id LIKE ? OR id LIKE ? OR owner_id LIKE ?"
-			if err := tx.Where(query, m.oldGroupPrefix()+"%", "%"+"OpenQQ-Member-T:"+m.appID+"-%", "OpenQQ-Member-T:"+m.appID+"-%").Find(&rows).Error; err != nil {
-				return err
-			}
-			characterNames, err := m.planCharacterNames(tx, rows)
+			characterNames, err := m.planCharacterNames(tx)
 			if err != nil {
 				return err
 			}
-			mergedUserAttrs, err := m.mergeCollidingUserAttrs(tx, rows)
-			if err != nil {
+			if err := m.mergeCollidingUserAttrs(tx); err != nil {
 				return err
 			}
-			for _, row := range rows {
-				if _, merged := mergedUserAttrs[row.Id]; merged {
-					continue
-				}
-				newID := m.migrateAttrsID(row.Id, row.AttrsType)
-				newOwnerID := m.migrateUserID(row.OwnerId)
-				newName, rename := characterNames[row.Id]
-				if newID == row.Id && newOwnerID == row.OwnerId && !rename {
-					continue
-				}
-				if newID != row.Id {
-					if err := ensureNoTarget(tx, &model.AttributesItemModel{}, "id = ?", newID); err != nil {
-						return err
+			err = officialQQIdentityMigrationFindInBatches(
+				m.legacyAttrsQuery(tx).Select("id, attrs_type, owner_id"),
+				func(rows []model.AttributesItemModel) error {
+					for _, row := range rows {
+						newID := m.migrateAttrsID(row.Id, row.AttrsType)
+						newOwnerID := m.migrateUserID(row.OwnerId)
+						newName, rename := characterNames[row.Id]
+						if newID == row.Id && newOwnerID == row.OwnerId && !rename {
+							continue
+						}
+						if newID != row.Id {
+							if err := ensureNoTarget(tx, &model.AttributesItemModel{}, "id = ?", newID); err != nil {
+								return err
+							}
+						}
+						updates := map[string]any{"id": newID, "owner_id": newOwnerID}
+						if rename {
+							updates["name"] = newName
+						}
+						if err := tx.Model(&model.AttributesItemModel{}).Where("id = ?", row.Id).Updates(updates).Error; err != nil {
+							return err
+						}
 					}
-				}
-				updates := map[string]any{"id": newID, "owner_id": newOwnerID}
-				if rename {
-					updates["name"] = newName
-				}
-				if err := tx.Model(&model.AttributesItemModel{}).Where("id = ?", row.Id).Updates(updates).Error; err != nil {
-					return err
-				}
+					return nil
+				},
+			)
+			if err != nil {
+				return err
 			}
 		}
 
 		if hasTable(tx, &model.BanInfo{}) {
-			var rows []model.BanInfo
-			if err := tx.Find(&rows).Error; err != nil {
-				return err
-			}
-			for _, row := range rows {
-				newID := m.migrateAnyID(row.ID)
-				var item BanListInfoItem
-				if err := json.Unmarshal(row.Data, &item); err != nil {
-					continue
-				}
-				m.migrateBanItem(&item)
-				data, err := json.Marshal(&item)
-				if err != nil {
-					return err
-				}
-				if newID != row.ID {
-					if err := ensureNoTarget(tx, &model.BanInfo{}, "id = ?", newID); err != nil {
-						return err
+			err := officialQQIdentityMigrationFindInBatches(
+				tx.Select("id, data"),
+				func(rows []model.BanInfo) error {
+					for _, row := range rows {
+						newID := m.migrateAnyID(row.ID)
+						var item BanListInfoItem
+						if err := json.Unmarshal(row.Data, &item); err != nil {
+							continue
+						}
+						changed := m.migrateBanItem(&item) || newID != row.ID
+						if !changed {
+							continue
+						}
+						data, err := json.Marshal(&item)
+						if err != nil {
+							return err
+						}
+						if newID != row.ID {
+							if err := ensureNoTarget(tx, &model.BanInfo{}, "id = ?", newID); err != nil {
+								return err
+							}
+						}
+						if err := tx.Model(&model.BanInfo{}).Where("id = ?", row.ID).Updates(map[string]any{"id": newID, "data": data}).Error; err != nil {
+							return err
+						}
 					}
-				}
-				if err := tx.Model(&model.BanInfo{}).Where("id = ?", row.ID).Updates(map[string]any{"id": newID, "data": data}).Error; err != nil {
-					return err
-				}
+					return nil
+				},
+			)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -830,36 +1041,47 @@ func (m *officialQQIdentityMigration) migrateLogDB(operator engine.DatabaseOpera
 	if db == nil {
 		return nil
 	}
+	groupPrefix, groupUpperBound := m.oldGroupBounds()
 	return db.Transaction(func(tx *gorm.DB) error {
 		if hasTable(tx, &model.LogInfo{}) {
-			var rows []model.LogInfo
-			if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			err := officialQQIdentityMigrationFindInBatches(
+				tx.Select("id, name, group_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+				func(rows []model.LogInfo) error {
+					for _, row := range rows {
+						newGroupID := m.migrateGroupID(row.GroupID)
+						if err := ensureNoTarget(tx, &model.LogInfo{}, "group_id = ? AND name = ?", newGroupID, row.Name); err != nil {
+							return err
+						}
+						if err := tx.Model(&model.LogInfo{}).Where("id = ?", row.ID).Update("group_id", newGroupID).Error; err != nil {
+							return err
+						}
+					}
+					return nil
+				},
+			)
+			if err != nil {
 				return err
-			}
-			for _, row := range rows {
-				newGroupID := m.migrateGroupID(row.GroupID)
-				if err := ensureNoTarget(tx, &model.LogInfo{}, "group_id = ? AND name = ?", newGroupID, row.Name); err != nil {
-					return err
-				}
-				if err := tx.Model(&model.LogInfo{}).Where("id = ?", row.ID).Update("group_id", newGroupID).Error; err != nil {
-					return err
-				}
 			}
 		}
 		if hasTable(tx, &model.LogOneItem{}) {
-			var rows []model.LogOneItem
-			if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+			err := officialQQIdentityMigrationFindInBatches(
+				tx.Select("id, group_id, im_userid, user_uniform_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+				func(rows []model.LogOneItem) error {
+					for _, row := range rows {
+						updates := map[string]any{
+							"group_id":        m.migrateGroupID(row.GroupID),
+							"im_userid":       m.migrateContextUserID(row.GroupID, row.IMUserID),
+							"user_uniform_id": m.migrateContextUserID(row.GroupID, row.UniformID),
+						}
+						if err := tx.Model(&model.LogOneItem{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
+							return err
+						}
+					}
+					return nil
+				},
+			)
+			if err != nil {
 				return err
-			}
-			for _, row := range rows {
-				updates := map[string]any{
-					"group_id":        m.migrateGroupID(row.GroupID),
-					"im_userid":       m.migrateContextUserID(row.GroupID, row.IMUserID),
-					"user_uniform_id": m.migrateContextUserID(row.GroupID, row.UniformID),
-				}
-				if err := tx.Model(&model.LogOneItem{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
-					return err
-				}
 			}
 		}
 		return nil
@@ -871,19 +1093,25 @@ func (m *officialQQIdentityMigration) migrateCensorDB(operator engine.DatabaseOp
 	if db == nil || !hasTable(db, &model.CensorLog{}) {
 		return nil
 	}
+	groupPrefix, groupUpperBound := m.oldGroupBounds()
 	return db.Transaction(func(tx *gorm.DB) error {
-		var rows []model.CensorLog
-		if err := tx.Where("group_id LIKE ?", m.oldGroupPrefix()+"%").Find(&rows).Error; err != nil {
+		err := officialQQIdentityMigrationFindInBatches(
+			tx.Select("id, group_id, user_id").Where("group_id >= ? AND group_id < ?", groupPrefix, groupUpperBound),
+			func(rows []model.CensorLog) error {
+				for _, row := range rows {
+					updates := map[string]any{
+						"group_id": m.migrateGroupID(row.GroupID),
+						"user_id":  m.migrateContextUserID(row.GroupID, row.UserID),
+					}
+					if err := tx.Model(&model.CensorLog{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		)
+		if err != nil {
 			return err
-		}
-		for _, row := range rows {
-			updates := map[string]any{
-				"group_id": m.migrateGroupID(row.GroupID),
-				"user_id":  m.migrateContextUserID(row.GroupID, row.UserID),
-			}
-			if err := tx.Model(&model.CensorLog{}).Where("id = ?", row.ID).Updates(updates).Error; err != nil {
-				return err
-			}
 		}
 		return nil
 	})
@@ -968,14 +1196,24 @@ func (m *officialQQIdentityMigration) migrateGroup(group *GroupInfo, oldGroupID 
 	}
 }
 
-func (m *officialQQIdentityMigration) migrateBanItem(item *BanListInfoItem) {
+func (m *officialQQIdentityMigration) migrateBanItem(item *BanListInfoItem) bool {
 	if item == nil {
-		return
+		return false
 	}
-	item.ID = m.migrateAnyID(item.ID)
+	changed := false
+	newID := m.migrateAnyID(item.ID)
+	if newID != item.ID {
+		item.ID = newID
+		changed = true
+	}
 	for index, place := range item.Places {
-		item.Places[index] = m.migrateAnyID(place)
+		newPlace := m.migrateAnyID(place)
+		if newPlace != place {
+			item.Places[index] = newPlace
+			changed = true
+		}
 	}
+	return changed
 }
 
 func (m *officialQQIdentityMigration) migrateMemory(d *Dice) {

--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -931,8 +931,8 @@ func (m *officialQQIdentityMigration) migrateDataDB(operator engine.DatabaseOper
 			if err != nil {
 				return err
 			}
-			if err := m.mergeCollidingUserAttrs(tx); err != nil {
-				return err
+			if mergeErr := m.mergeCollidingUserAttrs(tx); mergeErr != nil {
+				return mergeErr
 			}
 			err = officialQQIdentityMigrationFindInBatches(
 				m.legacyAttrsQuery(tx).Select("id, attrs_type, owner_id"),
@@ -945,16 +945,16 @@ func (m *officialQQIdentityMigration) migrateDataDB(operator engine.DatabaseOper
 							continue
 						}
 						if newID != row.Id {
-							if err := ensureNoTarget(tx, &model.AttributesItemModel{}, "id = ?", newID); err != nil {
-								return err
+							if targetErr := ensureNoTarget(tx, &model.AttributesItemModel{}, "id = ?", newID); targetErr != nil {
+								return targetErr
 							}
 						}
 						updates := map[string]any{"id": newID, "owner_id": newOwnerID}
 						if rename {
 							updates["name"] = newName
 						}
-						if err := tx.Model(&model.AttributesItemModel{}).Where("id = ?", row.Id).Updates(updates).Error; err != nil {
-							return err
+						if updateErr := tx.Model(&model.AttributesItemModel{}).Where("id = ?", row.Id).Updates(updates).Error; updateErr != nil {
+							return updateErr
 						}
 					}
 					return nil

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -417,7 +417,7 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 	pa.botID = botInfo.BotID
 	ep.Nickname = botInfo.Nickname
 
-	// 身份校验和迁移完成后再开始接收事件。
+	// 身份校验和可选的数据迁移完成后再开始接收事件。
 	event.RegisterHandlersByAppID(
 		pa.AppID,
 		pa.makeHandlers()...,

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -315,7 +316,7 @@ func TestPublicDiceEndpointAppID(t *testing.T) {
 	}
 }
 
-func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
+func TestOfficialQQIdentityMigrationLegacyDataProbe(t *testing.T) {
 	const appID = "123456789"
 
 	dbOperator, openErr := newMockDatabaseOperator(filepath.Join(t.TempDir(), "official-qq-probe.db"))
@@ -323,13 +324,13 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 		t.Fatal(openErr)
 	}
 	t.Cleanup(dbOperator.Close)
-	if err := dbOperator.db.AutoMigrate(&model.GroupInfo{}); err != nil {
+	if err := dbOperator.db.AutoMigrate(&model.GroupInfo{}, &model.LogInfo{}, &model.LogOneItem{}); err != nil {
 		t.Fatal(err)
 	}
 
 	migration := &officialQQIdentityMigration{appID: appID}
 	prefix := migration.oldGroupPrefix()
-	upperBound := strings.TrimSuffix(prefix, "-") + "."
+	_, upperBound := migration.oldGroupBounds()
 	timestamp := int64(1)
 	for _, id := range []string{
 		"OpenQQ-Group:1-new-group",
@@ -359,6 +360,19 @@ func TestOfficialQQIdentityMigrationLegacyGroupProbe(t *testing.T) {
 	}
 	if !shouldMigrate {
 		t.Fatal("legacy group probe missed an old official QQ group")
+	}
+	if err := dbOperator.db.Delete(&model.GroupInfo{}, "id = ?", legacyID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := dbOperator.db.Create(&model.LogOneItem{GroupID: legacyID, Time: 1}).Error; err != nil {
+		t.Fatal(err)
+	}
+	shouldMigrate, probeErr = migration.shouldRunIdentityMigration(dbOperator)
+	if probeErr != nil {
+		t.Fatal(probeErr)
+	}
+	if !shouldMigrate {
+		t.Fatal("legacy data probe missed residual official QQ log items")
 	}
 
 	type queryPlanRow struct {
@@ -632,6 +646,108 @@ func TestOfficialQQIdentityMigration(t *testing.T) {
 	}
 	if cached, ok := d.AttrsManager.m.Load("character-b"); !ok || cached.Name != "调查员 (3)" {
 		t.Fatalf("cached character name was not migrated: %#v", cached)
+	}
+}
+
+func TestOfficialQQIdentityMigrationProcessesMultipleBatches(t *testing.T) {
+	const (
+		appID = "123456789"
+		uin   = "1"
+	)
+	rowCount := officialQQIdentityMigrationBatchSize*2 + 17
+
+	dbOperator, openErr := newMockDatabaseOperator(filepath.Join(t.TempDir(), "official-qq-batches.db"))
+	if openErr != nil {
+		t.Fatal(openErr)
+	}
+	t.Cleanup(dbOperator.Close)
+	db := dbOperator.db
+	if err := db.AutoMigrate(&model.GroupInfo{}, &model.LogOneItem{}); err != nil {
+		t.Fatal(err)
+	}
+
+	groups := make([]model.GroupInfo, 0, rowCount)
+	logItems := make([]model.LogOneItem, 0, rowCount)
+	for index := range rowCount {
+		groupOpenID := fmt.Sprintf("group-%04d", index)
+		memberOpenID := fmt.Sprintf("member-%04d", index)
+		oldGroupID := "OpenQQ-Group-T:" + appID + "-" + groupOpenID
+		oldUserID := "OpenQQ-Member-T:" + appID + "-" + groupOpenID + "-" + memberOpenID
+		groupData, err := json.Marshal(&GroupInfo{GroupID: oldGroupID, InviteUserID: oldUserID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		timestamp := int64(index + 1)
+		groups = append(groups, model.GroupInfo{ID: oldGroupID, CreatedAt: timestamp, UpdatedAt: &timestamp, Data: groupData})
+		logItems = append(logItems, model.LogOneItem{
+			GroupID:   oldGroupID,
+			IMUserID:  oldUserID,
+			UniformID: oldUserID,
+			Time:      timestamp,
+			Message:   "batch migration payload",
+		})
+	}
+	if err := db.CreateInBatches(&groups, officialQQIdentityMigrationBatchSize).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateInBatches(&logItems, officialQQIdentityMigrationBatchSize).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	migration := &officialQQIdentityMigration{
+		appID:       appID,
+		uin:         uin,
+		oldEndpoint: "OpenQQ:legacy-bot",
+		newEndpoint: formatDiceIDOfficialQQ(uin),
+		groups:      map[string]string{},
+		users:       map[string]string{},
+	}
+	if err := migration.collectDatabase(dbOperator); err != nil {
+		t.Fatalf("collecting migration identities failed: %v", err)
+	}
+	if len(migration.groups) != rowCount || len(migration.users) != rowCount {
+		t.Fatalf("collected groups/users = %d/%d, want %d/%d", len(migration.groups), len(migration.users), rowCount, rowCount)
+	}
+	if err := migration.migrateLogDB(dbOperator); err != nil {
+		t.Fatalf("batched log migration failed: %v", err)
+	}
+	if err := migration.migrateDataDB(dbOperator); err != nil {
+		t.Fatalf("batched data migration failed: %v", err)
+	}
+
+	var oldGroupCount int64
+	if err := db.Model(&model.GroupInfo{}).Where("id LIKE ?", migration.oldGroupPrefix()+"%").Count(&oldGroupCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	var oldLogCount int64
+	if err := db.Model(&model.LogOneItem{}).Where("group_id LIKE ?", migration.oldGroupPrefix()+"%").Count(&oldLogCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	var newGroupCount int64
+	if err := db.Model(&model.GroupInfo{}).Where("id LIKE ?", "OpenQQ-Group:"+uin+"-%").Count(&newGroupCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	var newLogCount int64
+	if err := db.Model(&model.LogOneItem{}).Where("group_id LIKE ?", "OpenQQ-Group:"+uin+"-%").Count(&newLogCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if oldGroupCount != 0 || oldLogCount != 0 || newGroupCount != int64(rowCount) || newLogCount != int64(rowCount) {
+		t.Fatalf(
+			"migration counts old groups/logs=%d/%d new groups/logs=%d/%d, want 0/0/%d/%d",
+			oldGroupCount,
+			oldLogCount,
+			newGroupCount,
+			newLogCount,
+			rowCount,
+			rowCount,
+		)
+	}
+	var migratedLogItem model.LogOneItem
+	if err := db.Where("group_id LIKE ?", "OpenQQ-Group:"+uin+"-%").First(&migratedLogItem).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migratedLogItem.Message != "batch migration payload" {
+		t.Fatalf("migrated log message = %q", migratedLogItem.Message)
 	}
 }
 

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -316,6 +316,19 @@ func TestPublicDiceEndpointAppID(t *testing.T) {
 	}
 }
 
+func TestOfficialQQIdentityMigrationConfigRequiresOptIn(t *testing.T) {
+	config := DefaultConfig
+	if config.OfficialQQMigrationEnable {
+		t.Fatal("official QQ identity migration is enabled by default")
+	}
+	if err := yaml.Unmarshal([]byte("officialQQEnableIdentityMigration: true\n"), &config); err != nil {
+		t.Fatal(err)
+	}
+	if !config.OfficialQQMigrationEnable {
+		t.Fatal("serve.yaml did not enable official QQ identity migration")
+	}
+}
+
 func TestOfficialQQIdentityMigrationLegacyDataProbe(t *testing.T) {
 	const appID = "123456789"
 
@@ -575,6 +588,13 @@ func TestOfficialQQIdentityMigration(t *testing.T) {
 	d.ImSession.EndPoints = []*EndPointInfo{endpoint}
 
 	if err := ensureOfficialQQIdentity(d, adapter, botID, uin); err != nil {
+		t.Fatalf("identity initialization with migration disabled failed: %v", err)
+	}
+	assertOfficialQQMigrationRow(t, db, &model.GroupInfo{}, "id = ?", oldGroupID)
+	assertOfficialQQMigrationMissing(t, db, &model.GroupInfo{}, "id = ?", newGroupID)
+
+	d.Config.OfficialQQMigrationEnable = true
+	if err := ensureOfficialQQIdentity(d, adapter, botID, uin); err != nil {
 		t.Fatalf("first migration failed: %v", err)
 	}
 	// Simulate stale memory after the data phase succeeded but a later phase failed.
@@ -803,6 +823,7 @@ func TestOfficialQQIdentityMigrationRetriesAfterFailure(t *testing.T) {
 	}
 	d.ImSession.Parent = d
 	d.Config = NewConfig(d)
+	d.Config.OfficialQQMigrationEnable = true
 	d.AttrsManager = &AttrsManager{db: dbOperator}
 	endpoint.BindRuntime(d.ImSession)
 

--- a/dice/version.go
+++ b/dice/version.go
@@ -12,7 +12,7 @@ var (
 	VERSION = semver.MustParse(VERSION_MAIN + VERSION_PRERELEASE + VERSION_BUILD_METADATA)
 
 	// VERSION_MAIN 主版本号
-	VERSION_MAIN = "1.5.1"
+	VERSION_MAIN = "1.6.0"
 	// VERSION_PRERELEASE 先行版本号
 	VERSION_PRERELEASE = "-dev"
 	// VERSION_BUILD_METADATA 版本编译信息
@@ -21,7 +21,7 @@ var (
 	// APP_CHANNEL 更新频道，stable/dev，在 action 构建时自动注入
 	APP_CHANNEL = "dev" //nolint:revive
 
-	VERSION_CODE = int64(1005001) //nolint:revive
+	VERSION_CODE = int64(1006000) //nolint:revive
 
 	VERSION_JSAPI_COMPATIBLE = []*semver.Version{
 		VERSION,

--- a/update_updater.go
+++ b/update_updater.go
@@ -18,7 +18,7 @@ import (
 	"sealdice-core/utils"
 )
 
-const updaterVersion = "0.1.7"
+const updaterVersion = "0.1.8"
 
 func checkURLOne(url string, wg *sync.WaitGroup, resultChan chan string) {
 	defer wg.Done()

--- a/utils/cache/gormcache.go
+++ b/utils/cache/gormcache.go
@@ -24,7 +24,19 @@ const (
 	LogsDBCacheKey    cacheKey = "logs-db::"
 	DataDBCacheKey    cacheKey = "data-db::"
 	CensorsDBCacheKey cacheKey = "censor-db::"
+	cacheDisabledKey  cacheKey = "gorm_cache_disabled"
 )
+
+// WithDatabaseCacheDisabled prevents one-off queries from filling the shared
+// result cache. Mutations still invalidate existing cached results.
+func WithDatabaseCacheDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, cacheDisabledKey, true)
+}
+
+func isDatabaseCacheDisabled(ctx context.Context) bool {
+	disabled, _ := ctx.Value(cacheDisabledKey).(bool)
+	return disabled
+}
 
 func (c *OtterDBCacher) getKeyWithCtx(ctx context.Context, key string) string {
 	// 获取ctx中的key字段
@@ -44,6 +56,9 @@ func (c *OtterDBCacher) getKeyWithCtx(ctx context.Context, key string) string {
 // 如果成功获取数据，将返回填充了数据的查询对象。
 // TODO: 有点奇怪的逻辑，或许我应该直接存储Byte？
 func (c *OtterDBCacher) Get(ctx context.Context, key string, q *caches.Query[any]) (*caches.Query[any], error) {
+	if isDatabaseCacheDisabled(ctx) {
+		return nil, nil //nolint:nilnil
+	}
 	result, ok := c.otter.Get(c.getKeyWithCtx(ctx, key))
 	if !ok {
 		// 设计如此
@@ -69,6 +84,9 @@ func (c *OtterDBCacher) Get(ctx context.Context, key string, q *caches.Query[any
 //
 //	error: 在序列化或存储过程中遇到的错误，如果没有错误则返回nil。
 func (c *OtterDBCacher) Store(ctx context.Context, key string, val *caches.Query[any]) error {
+	if isDatabaseCacheDisabled(ctx) {
+		return nil
+	}
 	storeBytes, err := val.Marshal()
 	if err != nil {
 		return err

--- a/utils/cache/gormcache_test.go
+++ b/utils/cache/gormcache_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage // This test verifies the unexported cacher implementation directly.
 package cache
 
 import (
@@ -18,8 +19,8 @@ func TestDatabaseCacheDisabledContext(t *testing.T) {
 	disabledCtx := WithDatabaseCacheDisabled(normalCtx)
 	query := &caches.Query[any]{Dest: map[string]int{"value": 1}, RowsAffected: 1}
 
-	if err := cacher.Store(disabledCtx, "disabled-store", query); err != nil {
-		t.Fatal(err)
+	if storeErr := cacher.Store(disabledCtx, "disabled-store", query); storeErr != nil {
+		t.Fatal(storeErr)
 	}
 	got, err := cacher.Get(normalCtx, "disabled-store", &caches.Query[any]{})
 	if err != nil {
@@ -29,8 +30,8 @@ func TestDatabaseCacheDisabledContext(t *testing.T) {
 		t.Fatal("cache-disabled query was stored")
 	}
 
-	if err := cacher.Store(normalCtx, "normal-store", query); err != nil {
-		t.Fatal(err)
+	if storeErr := cacher.Store(normalCtx, "normal-store", query); storeErr != nil {
+		t.Fatal(storeErr)
 	}
 	got, err = cacher.Get(disabledCtx, "normal-store", &caches.Query[any]{})
 	if err != nil {

--- a/utils/cache/gormcache_test.go
+++ b/utils/cache/gormcache_test.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-gorm/caches/v4"
+	"github.com/maypok86/otter"
+)
+
+func TestDatabaseCacheDisabledContext(t *testing.T) {
+	cacheInstance, err := otter.MustBuilder[string, []byte](10).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacher := &OtterDBCacher{otter: &cacheInstance}
+	normalCtx := context.WithValue(context.Background(), CacheKey, DataDBCacheKey)
+	disabledCtx := WithDatabaseCacheDisabled(normalCtx)
+	query := &caches.Query[any]{Dest: map[string]int{"value": 1}, RowsAffected: 1}
+
+	if err := cacher.Store(disabledCtx, "disabled-store", query); err != nil {
+		t.Fatal(err)
+	}
+	got, err := cacher.Get(normalCtx, "disabled-store", &caches.Query[any]{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatal("cache-disabled query was stored")
+	}
+
+	if err := cacher.Store(normalCtx, "normal-store", query); err != nil {
+		t.Fatal(err)
+	}
+	got, err = cacher.Get(disabledCtx, "normal-store", &caches.Query[any]{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatal("cache-disabled query read a cached result")
+	}
+	got, err = cacher.Get(normalCtx, "normal-store", &caches.Query[any]{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.RowsAffected != 1 {
+		t.Fatalf("normal cached query = %#v", got)
+	}
+}

--- a/utils/dboperator/engine/sqlite/sqlite.go
+++ b/utils/dboperator/engine/sqlite/sqlite.go
@@ -128,8 +128,8 @@ func SetDefaultPragmas(db *sql.DB) error {
 		// 在 WAL 模式下使用 synchronous=NORMAL 提交的事务可能会在断电或系统崩溃后回滚。
 		// 无论同步设置或日志模式如何，事务在应用程序崩溃时都是持久的。
 		// 对于在 WAL 模式下运行的大多数应用程序来说，synchronous=NORMAL 设置是一个不错的选择。
-		"synchronous": "1",         // NORMAL --> https://www.sqlite.org/pragma.html#pragma_synchronous
-		"cache_size":  "536870912", // 536870912 = 512MB --> https://www.sqlite.org/pragma.html#pragma_cache_size
+		"synchronous": "1",       // NORMAL --> https://www.sqlite.org/pragma.html#pragma_synchronous
+		"cache_size":  "-524288", // Negative values are KiB, so this caps the page cache at 512 MiB.
 	}
 
 	// set the pragmas

--- a/utils/dboperator/engine/sqlite/sqlite_cgo.go
+++ b/utils/dboperator/engine/sqlite/sqlite_cgo.go
@@ -126,8 +126,8 @@ func SetDefaultPragmas(db *sql.DB) error {
 		// 在 WAL 模式下使用 synchronous=NORMAL 提交的事务可能会在断电或系统崩溃后回滚。
 		// 无论同步设置或日志模式如何，事务在应用程序崩溃时都是持久的。
 		// 对于在 WAL 模式下运行的大多数应用程序来说，synchronous=NORMAL 设置是一个不错的选择。
-		"synchronous": "1",         // NORMAL --> https://www.sqlite.org/pragma.html#pragma_synchronous
-		"cache_size":  "536870912", // 536870912 = 512MB --> https://www.sqlite.org/pragma.html#pragma_cache_size
+		"synchronous": "1",       // NORMAL --> https://www.sqlite.org/pragma.html#pragma_synchronous
+		"cache_size":  "-524288", // Negative values are KiB, so this caps the page cache at 512 MiB.
 	}
 
 	// set the pragmas


### PR DESCRIPTION
## Summary by Sourcery

在进行 QQ 官方身份迁移及数据库操作时，减少内存与缓存使用。

New Features:
- 为 QQ 官方身份迁移新增批处理辅助工具与基于前缀的查询能力，以限制内存中数据规模。
- 引入上下文标记，用于在一次性数据库操作中禁用 GORM 查询结果缓存。

Bug Fixes:
- 修复旧版 QQ 官方身份迁移查询，避免扫描非旧版行，并避免遗漏仅存在于内存中的身份记录。
- 确保封禁列表和属性迁移仅在 ID 或负载发生实际变更时才重写记录。
- 更正 SQLite `cache_size` pragma 配置，通过负值 KiB 限制页面缓存，而非使用绝对页面数量。

Enhancements:
- 重构 QQ 官方身份迁移逻辑，使用批量查询、前缀范围和绕过缓存的上下文，以降低峰值内存占用。
- 扩展身份迁移探测范围，覆盖更多数据表，确保在仍存在残留旧版数据时迁移仍能执行。
- 更新测试，覆盖跨群组、日志和属性表的多批次迁移与数据探测场景。
- 使用带有“禁用缓存”标记的上下文保护 GORM 缓存读写操作，防止污染共享缓存。

Build:
- 将应用版本提升至 1.6.0，并将更新器版本提升至 0.1.8。

Tests:
- 增加测试，验证在禁用缓存的上下文中可绕过 GORM 查询缓存。
- 增加测试，确保 QQ 官方身份迁移可在多个数据表中探测旧版数据，并正确处理多批次迁移。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reduce memory and cache usage during official QQ identity migration and database operations.

New Features:
- Add batch processing helpers and prefix-bound querying for official QQ identity migration to limit in-memory data size.
- Introduce a context flag to disable GORM query result caching for one-off database operations.

Bug Fixes:
- Fix legacy official QQ identity migration queries to avoid scanning non-legacy rows and missing in-memory-only identities.
- Ensure ban list and attribute migrations only rewrite records when IDs or payloads actually change.
- Correct SQLite cache_size pragma to cap page cache via negative KiB value instead of an absolute page count.

Enhancements:
- Refactor official QQ identity migration to use batched queries, prefix ranges, and cache-bypassing contexts to reduce peak memory usage.
- Extend identity migration probes to cover additional tables, ensuring migrations still run when residual legacy data exists.
- Update tests to cover multi-batch migrations and data probes across group, log, and attribute tables.
- Guard GORM cache get/store operations with a cache-disabled context flag to prevent polluting shared caches.

Build:
- Bump application version to 1.6.0 and updater version to 0.1.8.

Tests:
- Add tests verifying cache-disabled contexts bypass GORM query caching.
- Add tests ensuring official QQ identity migration probes legacy data across multiple tables and handles multi-batch migrations correctly.

</details>