### PR TITLE
fix(official-qq): 统一连接启动入口

### DIFF
--- a/dice/platform_adapter_official_qq_helper.go
+++ b/dice/platform_adapter_official_qq_helper.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -33,16 +32,8 @@ func NewOfficialQQConnItem(appID, appSecret, uin string, onlyQQGuild bool) *EndP
 func ServerOfficialQQ(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" && ep.ProtocolType == "official" {
-		conn := ep.Adapter.(*PlatformAdapterOfficialQQ)
 		ep.BindRuntime(d.ImSession)
-		d.Logger.Infof("official qq 尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Infof("official qq 连接失败")
-			ep.State = 3
-			ep.Enable = false
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		ServeQQ(d, ep)
 	}
 }
 

--- a/dice/platform_adapter_official_qq_helper.go
+++ b/dice/platform_adapter_official_qq_helper.go
@@ -33,6 +33,7 @@ func ServerOfficialQQ(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" && ep.ProtocolType == "official" {
 		ep.BindRuntime(d.ImSession)
+		// 连接状态、重试和日志统一由 ServeQQ 及其官方 QQ 分支负责。
 		ServeQQ(d, ep)
 	}
 }

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -26,6 +26,28 @@ func (f officialQQTransportFunc) Transport(ctx context.Context, method, url stri
 	return f(ctx, method, url, body)
 }
 
+func TestServerOfficialQQSkipsRunningSessionBeforeStateChange(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn := &PlatformAdapterOfficialQQ{Ctx: ctx}
+	ep := &EndPointInfo{EndPointInfoBase: EndPointInfoBase{
+		State:  StateConnected,
+		Enable: true,
+	}}
+
+	serverOfficialQQ(&Dice{}, ep, conn)
+
+	if conn.DiceServing {
+		t.Fatal("running session was marked as a new server")
+	}
+	if ep.State != StateConnected || !ep.Enable {
+		t.Fatalf("endpoint state changed for running session: state=%d enable=%t", ep.State, ep.Enable)
+	}
+}
+
 func TestExtractOfficialQQBotUIN(t *testing.T) {
 	t.Parallel()
 

--- a/dice/platform_adapter_qq_helper.go
+++ b/dice/platform_adapter_qq_helper.go
@@ -218,6 +218,7 @@ func serverSatori(d *Dice, ep *EndPointInfo, conn *PlatformAdapterSatori) {
 }
 
 func serverOfficialQQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterOfficialQQ) {
+	// Ctx 非空表示会话已经建立或正在运行，不能重复启动并覆盖端点状态。
 	if conn.Ctx != nil {
 		return
 	}

--- a/dice/platform_adapter_qq_helper.go
+++ b/dice/platform_adapter_qq_helper.go
@@ -218,6 +218,9 @@ func serverSatori(d *Dice, ep *EndPointInfo, conn *PlatformAdapterSatori) {
 }
 
 func serverOfficialQQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterOfficialQQ) {
+	if conn.Ctx != nil {
+		return
+	}
 	if conn.DiceServing {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -550,6 +550,7 @@ func diceServe(d *dice.Dice) {
 					}
 					if conn.ProtocolType == "official" {
 						dice.ServerOfficialQQ(d, conn)
+						// 官方 QQ 已由统一入口启动，避免继续进入通用 QQ 延迟启动流程。
 						return
 					}
 					if conn.ProtocolType == "satori" {

--- a/main.go
+++ b/main.go
@@ -550,6 +550,7 @@ func diceServe(d *dice.Dice) {
 					}
 					if conn.ProtocolType == "official" {
 						dice.ServerOfficialQQ(d, conn)
+						return
 					}
 					if conn.ProtocolType == "satori" {
 						dice.ServeSatori(d, conn)


### PR DESCRIPTION
修复重启后 official-qq 一直显示连接中但是能用的bug

## Summary by Sourcery

保护官方 QQ 连接的启动过程，避免复用已在运行的会话，并通过统一入口委托连接处理逻辑。

Bug Fixes:
- 防止在会话已经运行或上下文已初始化时，官方 QQ 端点被重新连接或其状态被修改。

Enhancements:
- 新增共享的 `ServeQQ` 入口，用于官方 QQ 连接以集中管理启动逻辑。

Tests:
- 添加回归测试，确保 `serverOfficialQQ` 不会将已经在运行的官方 QQ 会话视为新的服务器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard official QQ connection startup to avoid reusing running sessions and delegate connection handling through a unified entry point.

Bug Fixes:
- Prevent official QQ endpoints from being reconnected or having their state modified when a session is already running or has context initialized.

Enhancements:
- Introduce a shared ServeQQ entry for official QQ connections to centralize startup logic.

Tests:
- Add a regression test ensuring serverOfficialQQ does not treat an already running official QQ session as a new server.

</details>