### PR TITLE
feat(milky): 支持制卡结果合并转发

### DIFF
--- a/dice/platform_adapter.go
+++ b/dice/platform_adapter.go
@@ -54,3 +54,5 @@ var (
 
 	// _ PlatformAdapter = (*PlatformAdapterLagrangeGo)(nil)
 )
+
+var _ forwardMsgSender = (*PlatformAdapterMilky)(nil)

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -758,6 +758,120 @@ func ParseMessageToMilky(send []message.IMessageElement) []milky.IMessageElement
 	return elements
 }
 
+func buildMilkyForwardElement(nodes []forwardNode) (*milky.ForwardElement, error) {
+	if len(nodes) == 0 {
+		return nil, errors.New("forward message has no nodes")
+	}
+
+	messages := make([]milky.OutgoingForwardedMessage, 0, len(nodes))
+	for index, node := range nodes {
+		userID, err := strconv.ParseInt(strings.TrimSpace(node.Data.Uin), 10, 64)
+		if err != nil || userID <= 0 {
+			return nil, fmt.Errorf("forward node %d has invalid user ID %q", index, node.Data.Uin)
+		}
+		if strings.TrimSpace(node.Data.Content) == "" {
+			return nil, fmt.Errorf("forward node %d has empty content", index)
+		}
+
+		segments := ParseMessageToMilky(message.ConvertStringMessage(node.Data.Content))
+		if len(segments) == 0 {
+			return nil, fmt.Errorf("forward node %d has no supported message segments", index)
+		}
+		messages = append(messages, milky.OutgoingForwardedMessage{
+			UserID:   userID,
+			Name:     node.Data.Name,
+			Segments: segments,
+		})
+	}
+
+	return &milky.ForwardElement{Messages: messages}, nil
+}
+
+func (pa *PlatformAdapterMilky) recordForwardMessageSent(ctx *MsgContext, messageType string, targetID string, nodes []forwardNode, messageSeq int64) {
+	if ctx == nil || pa == nil || pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return
+	}
+
+	msg := &Message{
+		Platform:    "QQ",
+		MessageType: messageType,
+		Message:     forwardNodesToText(nodes),
+		Sender: SenderBase{
+			UserID:   pa.EndPoint.UserID,
+			Nickname: pa.EndPoint.Nickname,
+		},
+		RawID: messageSeq,
+	}
+	if messageType == "group" {
+		msg.GroupID = targetID
+	}
+	pa.EndPoint.Session.OnMessageSend(ctx, msg, "")
+}
+
+func (pa *PlatformAdapterMilky) SendGroupForwardMsg(ctx *MsgContext, groupID string, nodes []forwardNode) bool {
+	log := zap.S().Named(logger.LogKeyAdapter)
+	if pa == nil || pa.IntentSession == nil {
+		log.Error("Failed to send Milky group forward message: session unavailable")
+		return false
+	}
+
+	id, err := strconv.ParseInt(ExtractQQGroupID(groupID), 10, 64)
+	if err != nil || id <= 0 {
+		log.Errorf("Invalid group ID %s for Milky forward message", groupID)
+		return false
+	}
+	forward, err := buildMilkyForwardElement(nodes)
+	if err != nil {
+		log.Errorf("Failed to build Milky group forward message: %v", err)
+		return false
+	}
+
+	if ctx != nil && ctx.EndPoint != nil && ctx.EndPoint.Platform == "QQ" {
+		doSleepQQ(ctx)
+	}
+	elements := []milky.IMessageElement{forward}
+	ret, err := pa.IntentSession.SendGroupMessage(id, &elements)
+	if err != nil {
+		log.Errorf("Failed to send group forward message to %s: %v", groupID, err)
+		return false
+	}
+
+	pa.recordForwardMessageSent(ctx, "group", groupID, nodes, ret.MessageSeq)
+	return true
+}
+
+func (pa *PlatformAdapterMilky) SendPrivateForwardMsg(ctx *MsgContext, userID string, nodes []forwardNode) bool {
+	log := zap.S().Named(logger.LogKeyAdapter)
+	if pa == nil || pa.IntentSession == nil {
+		log.Error("Failed to send Milky private forward message: session unavailable")
+		return false
+	}
+
+	id, err := strconv.ParseInt(ExtractQQUserID(userID), 10, 64)
+	if err != nil || id <= 0 {
+		log.Errorf("Invalid user ID %s for Milky forward message", userID)
+		return false
+	}
+	forward, err := buildMilkyForwardElement(nodes)
+	if err != nil {
+		log.Errorf("Failed to build Milky private forward message: %v", err)
+		return false
+	}
+
+	if ctx != nil && ctx.EndPoint != nil && ctx.EndPoint.Platform == "QQ" {
+		doSleepQQ(ctx)
+	}
+	elements := []milky.IMessageElement{forward}
+	ret, err := pa.IntentSession.SendPrivateMessage(id, &elements)
+	if err != nil {
+		log.Errorf("Failed to send private forward message to %s: %v", userID, err)
+		return false
+	}
+
+	pa.recordForwardMessageSent(ctx, "private", userID, nodes, ret.MessageSeq)
+	return true
+}
+
 func (pa *PlatformAdapterMilky) SendToPerson(ctx *MsgContext, uid string, text string, flag string) {
 	log := zap.S().Named(logger.LogKeyAdapter)
 	send := message.ConvertStringMessage(text)

--- a/dice/platform_adapter_milky_forward_test.go
+++ b/dice/platform_adapter_milky_forward_test.go
@@ -1,0 +1,240 @@
+//nolint:testpackage
+package dice
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	milky "github.com/Szzrain/Milky-go-sdk"
+)
+
+type milkyForwardRequest struct {
+	GroupID int64 `json:"group_id"`
+	UserID  int64 `json:"user_id"`
+	Message []struct {
+		Type string `json:"type"`
+		Data struct {
+			Messages []struct {
+				UserID   int64  `json:"user_id"`
+				Name     string `json:"name"`
+				Segments []struct {
+					Type string `json:"type"`
+					Data struct {
+						Text string `json:"text"`
+					} `json:"data"`
+				} `json:"segments"`
+			} `json:"messages"`
+		} `json:"data"`
+	} `json:"message"`
+}
+
+type milkyForwardHarness struct {
+	t        *testing.T
+	apiError string
+
+	mu       sync.Mutex
+	endpoint string
+	request  milkyForwardRequest
+}
+
+func newMilkyForwardHarness(t *testing.T, apiError string) (*milky.Session, *milkyForwardHarness, func()) {
+	t.Helper()
+	h := &milkyForwardHarness{t: t, apiError: apiError}
+	server := httptest.NewServer(http.HandlerFunc(h.handle))
+	session, err := milky.New("ws://127.0.0.1", server.URL, "", noopMilkyLogger{})
+	if err != nil {
+		server.Close()
+		t.Fatalf("failed to create Milky session: %v", err)
+	}
+	return session, h, server.Close
+}
+
+func (h *milkyForwardHarness) handle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var request milkyForwardRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		h.t.Errorf("failed to decode Milky forward request: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	h.mu.Lock()
+	h.endpoint = strings.TrimPrefix(r.URL.Path, "/")
+	h.request = request
+	h.mu.Unlock()
+
+	if h.apiError != "" {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  "failed",
+			"retcode": 1,
+			"message": h.apiError,
+		})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"status":  "ok",
+		"retcode": 0,
+		"data": map[string]any{
+			"message_seq": 321,
+			"time":        1,
+		},
+	})
+}
+
+func (h *milkyForwardHarness) snapshot() (string, milkyForwardRequest) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.endpoint, h.request
+}
+
+func newMilkyForwardTestContext(session *milky.Session, onMessageSend func(ctx *MsgContext, msg *Message, flag string)) (*PlatformAdapterMilky, *MsgContext) {
+	d := &Dice{
+		Config: Config{
+			BaseConfig: BaseConfig{
+				MessageDelayRangeStart: 0,
+				MessageDelayRangeEnd:   0,
+			},
+		},
+		ExtList: []*ExtInfo{{OnMessageSend: onMessageSend}},
+	}
+	d.ImSession = &IMSession{Parent: d}
+	ep := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			UserID:       "QQ:10010",
+			Nickname:     "MilkyBot",
+			Platform:     "QQ",
+			ProtocolType: "milky",
+		},
+	}
+	pa := &PlatformAdapterMilky{EndPoint: ep, IntentSession: session}
+	ep.Adapter = pa
+	ep.BindRuntime(d.ImSession)
+	return pa, &MsgContext{Dice: d, EndPoint: ep}
+}
+
+func TestPlatformAdapterMilkySendForwardMessage(t *testing.T) {
+	nodes := buildForwardNodes("MilkyBot", "10010", "COC7制卡结果", []string{"力量:50", "力量:60"})
+	tests := []struct {
+		name            string
+		endpoint        string
+		targetID        int64
+		messageType     string
+		send            func(pa *PlatformAdapterMilky, ctx *MsgContext) bool
+		wantHookGroupID string
+	}{
+		{
+			name:        "group",
+			endpoint:    milky.EndpointSendGroupMessage,
+			targetID:    20020,
+			messageType: "group",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) bool {
+				return pa.SendGroupForwardMsg(ctx, "QQ-Group:20020", nodes)
+			},
+			wantHookGroupID: "QQ-Group:20020",
+		},
+		{
+			name:        "private",
+			endpoint:    milky.EndpointSendPrivateMessage,
+			targetID:    30030,
+			messageType: "private",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) bool {
+				return pa.SendPrivateForwardMsg(ctx, "QQ:30030", nodes)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session, harness, cleanup := newMilkyForwardHarness(t, "")
+			defer cleanup()
+
+			var hookCalls int
+			var hookMessage *Message
+			pa, ctx := newMilkyForwardTestContext(session, func(_ *MsgContext, msg *Message, flag string) {
+				hookCalls++
+				hookMessage = msg
+				if flag != "" {
+					t.Errorf("forward hook flag = %q, want empty", flag)
+				}
+			})
+
+			if !test.send(pa, ctx) {
+				t.Fatal("Milky forward send returned false")
+			}
+
+			endpoint, request := harness.snapshot()
+			if endpoint != test.endpoint {
+				t.Fatalf("endpoint = %q, want %q", endpoint, test.endpoint)
+			}
+			if test.messageType == "group" && request.GroupID != test.targetID {
+				t.Fatalf("group_id = %d, want %d", request.GroupID, test.targetID)
+			}
+			if test.messageType == "private" && request.UserID != test.targetID {
+				t.Fatalf("user_id = %d, want %d", request.UserID, test.targetID)
+			}
+			if len(request.Message) != 1 || request.Message[0].Type != string(milky.Forward) {
+				t.Fatalf("message = %#v, want one forward element", request.Message)
+			}
+
+			messages := request.Message[0].Data.Messages
+			if len(messages) != len(nodes) {
+				t.Fatalf("forward node count = %d, want %d", len(messages), len(nodes))
+			}
+			for i, node := range messages {
+				if node.UserID != 10010 || node.Name != "MilkyBot" {
+					t.Errorf("node %d sender = (%d, %q), want (10010, %q)", i, node.UserID, node.Name, "MilkyBot")
+				}
+				if len(node.Segments) != 1 || node.Segments[0].Type != string(milky.Text) || node.Segments[0].Data.Text != nodes[i].Data.Content {
+					t.Errorf("node %d segments = %#v, want text %q", i, node.Segments, nodes[i].Data.Content)
+				}
+			}
+
+			if hookCalls != 1 || hookMessage == nil {
+				t.Fatalf("OnMessageSend calls = %d, want 1", hookCalls)
+			}
+			if hookMessage.MessageType != test.messageType || hookMessage.GroupID != test.wantHookGroupID {
+				t.Errorf("hook destination = (%q, %q), want (%q, %q)", hookMessage.MessageType, hookMessage.GroupID, test.messageType, test.wantHookGroupID)
+			}
+			if hookMessage.Message != forwardNodesToText(nodes) || hookMessage.RawID != int64(321) {
+				t.Errorf("hook message = (%q, %#v), want (%q, 321)", hookMessage.Message, hookMessage.RawID, forwardNodesToText(nodes))
+			}
+		})
+	}
+}
+
+func TestPlatformAdapterMilkyForwardMessageFailures(t *testing.T) {
+	validNodes := buildForwardNodes("MilkyBot", "10010", "title", []string{"content"})
+	session, _, cleanup := newMilkyForwardHarness(t, "forward rejected")
+	defer cleanup()
+	pa, ctx := newMilkyForwardTestContext(session, func(_ *MsgContext, _ *Message, _ string) {
+		t.Error("failed forward send must not trigger OnMessageSend")
+	})
+
+	tests := []struct {
+		name string
+		send func() bool
+	}{
+		{name: "API error", send: func() bool { return pa.SendGroupForwardMsg(ctx, "QQ-Group:20020", validNodes) }},
+		{name: "empty nodes", send: func() bool { return pa.SendGroupForwardMsg(ctx, "QQ-Group:20020", nil) }},
+		{name: "invalid group ID", send: func() bool { return pa.SendGroupForwardMsg(ctx, "QQ-Group:invalid", validNodes) }},
+		{name: "invalid private ID", send: func() bool { return pa.SendPrivateForwardMsg(ctx, "QQ:invalid", validNodes) }},
+		{name: "invalid node user ID", send: func() bool {
+			return pa.SendGroupForwardMsg(ctx, "QQ-Group:20020", []forwardNode{{Data: forwardNodeData{Uin: "invalid", Name: "MilkyBot", Content: "content"}}})
+		}},
+		{name: "missing session", send: func() bool {
+			return (&PlatformAdapterMilky{}).SendGroupForwardMsg(ctx, "QQ-Group:20020", validNodes)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.send() {
+				t.Fatal("Milky forward send returned true, want false so the caller can use its text fallback")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

优化官方 QQ 身份迁移，并为转发（合并卡片）消息添加 Milky 适配器支持，同时收紧数据库缓存与版本行为。

New Features:
- 为 QQ 群聊和私聊转发消息添加 Milky 适配器支持，支持由多个节点构建的转发消息，并在 OnMessageSend 中记录聚合后的内容日志。

Bug Fixes:
- 确保官方 QQ 身份迁移在处理多批次记录时，能够正确迁移所有数据，不遗漏残留的旧数据或日志项。
- 防止一次性迁移和维护查询结果被写入共享的 GORM 缓存，从而避免产生过期或不必要的缓存条目。

Enhancements:
- 为官方 QQ 身份迁移查询引入基于批次、绕过缓存的辅助工具，以降低内存使用并避免污染共享数据库缓存。
- 优化跨数据库、日志库和审查库的旧身份检测与迁移逻辑，包括更安全的 BanInfo 更新机制，以追踪记录是否实际发生变更。
- 调整 SQLite 默认的 cache_size pragma，使其使用以 KiB 为单位的有界页面缓存，而非绝对字节数。

Tests:
- 扩展官方 QQ 身份迁移测试，覆盖多数据库探测和多批次迁移场景，包括载荷（payload）保留校验。
- 添加 Milky 转发消息测试，用于验证 API 载荷结构、失败处理以及消息钩子行为。
- 添加数据库缓存禁用上下文测试，用于验证在关闭缓存时读写操作是否被正确跳过。

Chores:
- 将核心版本与更新器版本号提升至 1.6.0/0.1.8，并更新 VERSION_CODE 以发布新版本。
- 声明 PlatformAdapterMilky 作为转发消息发送接口的实现，以保持适配器实现的一致性与显式性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize official QQ identity migration and add Milky adapter support for forwarded (merged card) messages, while tightening database caching and versioning behavior.

New Features:
- Add Milky adapter support for sending QQ group and private forward messages built from multiple nodes, including OnMessageSend logging of the aggregated content.

Bug Fixes:
- Ensure official QQ identity migration correctly processes multiple batches of records without missing residual legacy data or log items.
- Prevent one-off migration and maintenance queries from storing results in the shared GORM cache, avoiding stale or unnecessary cached entries.

Enhancements:
- Introduce batch-based, cache-bypassing helpers for official QQ identity migration queries to reduce memory usage and avoid polluting shared DB caches.
- Refine legacy identity detection and migration logic across data, log, and censor databases, including safer BanInfo updates that track whether records actually changed.
- Adjust SQLite default cache_size pragma to use a bounded page cache sized in KiB rather than absolute bytes.

Tests:
- Extend official QQ identity migration tests to cover multi-database probing and multi-batch migrations, including payload preservation.
- Add Milky forward messaging tests that validate API payload shape, failure handling, and message hook behavior.
- Add tests for the database cache disabling context to verify that reads and writes are correctly skipped when caching is disabled.

Chores:
- Bump core version and updater version numbers to 1.6.0/0.1.8 and update VERSION_CODE for the new release.
- Declare PlatformAdapterMilky as an implementation of the forward message sender interface to keep adapter conformance explicit.

</details>