### PR TITLE
fix(milky): 升级 SDK 修正合并转发字段

### DIFF
--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -778,9 +778,9 @@ func buildMilkyForwardElement(nodes []forwardNode) (*milky.ForwardElement, error
 			return nil, fmt.Errorf("forward node %d has no supported message segments", index)
 		}
 		messages = append(messages, milky.OutgoingForwardedMessage{
-			UserID:   userID,
-			Name:     node.Data.Name,
-			Segments: segments,
+			UserID:     userID,
+			SenderName: node.Data.Name,
+			Segments:   segments,
 		})
 	}
 

--- a/dice/platform_adapter_milky_forward_test.go
+++ b/dice/platform_adapter_milky_forward_test.go
@@ -19,9 +19,10 @@ type milkyForwardRequest struct {
 		Type string `json:"type"`
 		Data struct {
 			Messages []struct {
-				UserID   int64  `json:"user_id"`
-				Name     string `json:"name"`
-				Segments []struct {
+				UserID     int64  `json:"user_id"`
+				SenderName string `json:"sender_name"`
+				LegacyName string `json:"name"`
+				Segments   []struct {
 					Type string `json:"type"`
 					Data struct {
 						Text string `json:"text"`
@@ -185,8 +186,11 @@ func TestPlatformAdapterMilkySendForwardMessage(t *testing.T) {
 				t.Fatalf("forward node count = %d, want %d", len(messages), len(nodes))
 			}
 			for i, node := range messages {
-				if node.UserID != 10010 || node.Name != "MilkyBot" {
-					t.Errorf("node %d sender = (%d, %q), want (10010, %q)", i, node.UserID, node.Name, "MilkyBot")
+				if node.UserID != 10010 || node.SenderName != "MilkyBot" {
+					t.Errorf("node %d sender = (%d, %q), want (10010, %q)", i, node.UserID, node.SenderName, "MilkyBot")
+				}
+				if node.LegacyName != "" {
+					t.Errorf("node %d contains deprecated name field %q", i, node.LegacyName)
 				}
 				if len(node.Segments) != 1 || node.Segments[0].Type != string(milky.Text) || node.Segments[0].Data.Text != nodes[i].Data.Content {
 					t.Errorf("node %d segments = %#v, want text %q", i, node.Segments, nodes[i].Data.Content)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/PaienNate/pineutil v1.1.1
 	github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a
 	github.com/Szzrain/DingTalk-go v0.0.8-alpha
-	github.com/Szzrain/Milky-go-sdk v1.0.2
+	github.com/Szzrain/Milky-go-sdk v1.1.0
 	github.com/Szzrain/dodo-open-go v0.2.8
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a h1:NPnGVq
 github.com/ShiraazMoollatjie/goluhn v0.0.0-20211017190329-0d86158c056a/go.mod h1:5LI6VqIHoGmWsR0EJLbct5bBrtM/0pTonaAyGKmFk9U=
 github.com/Szzrain/DingTalk-go v0.0.8-alpha h1:mSR/ORDDjtndoR12WrEdd3hdxxXXm9VMQ/r75NJkkkE=
 github.com/Szzrain/DingTalk-go v0.0.8-alpha/go.mod h1:j2+BnL67DfiCu6E1rhJDHy4up2drtGXJOrRohIHg5uo=
-github.com/Szzrain/Milky-go-sdk v1.0.2 h1:Vee6yAeWsZWkTv4mX1YBR3AvEaOrQ1FeJfjziORuBIs=
-github.com/Szzrain/Milky-go-sdk v1.0.2/go.mod h1:vyl5G/6TQha+Ygf9ZWkDN//7dJFq2V0ezdk3Rm2kDKQ=
+github.com/Szzrain/Milky-go-sdk v1.1.0 h1:NijhEpPgwzDlu6QOUyE1JGTCfwZovMLRaAsItLeWqM0=
+github.com/Szzrain/Milky-go-sdk v1.1.0/go.mod h1:vyl5G/6TQha+Ygf9ZWkDN//7dJFq2V0ezdk3Rm2kDKQ=
 github.com/Szzrain/dodo-open-go v0.2.8 h1:a5p2/XOOyKZNFfowEdD7VsFaOClwIX6JziBpNIyzkvo=
 github.com/Szzrain/dodo-open-go v0.2.8/go.mod h1:Nk7ozwqQVvuQW2KubsVVXLM8fFqDo0TwN5UX7F4AR2w=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=


### PR DESCRIPTION
## Summary by Sourcery

升级 Milky SDK，并在转发消息的构造和测试中对齐新的发送者姓名字段，同时确保不再使用已弃用的姓名字段。

Bug 修复：
- 修正转发消息中发送者字段的映射，改为使用 SDK 的发送者姓名字段，而不是旧的姓名字段。

构建：
- 将 Milky-go-sdk 依赖从 v1.0.2 升级到 v1.1.0。

测试：
- 更新 Milky 转发消息测试，用于验证 `sender_name` 的使用，并确保不再填充已弃用的姓名字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the Milky SDK and align forwarded message construction and tests with the new sender name fields while ensuring deprecated name usage is cleared.

Bug Fixes:
- Correct forwarded message sender field mapping to use the SDK's sender name field instead of the legacy name field.

Build:
- Bump Milky-go-sdk dependency from v1.0.2 to v1.1.0.

Tests:
- Update Milky forward message tests to validate sender_name usage and ensure the deprecated name field is no longer populated.

</details>