### PR TITLE
feat(notice): 通知列表与骰主列表分离，支持分条自定义通知项目

### DIFF
--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -134,7 +134,13 @@ func DiceConfigSet(c echo.Context) error {
 
 	config := &myDice.Config
 	if val, ok := jsonMap["noticeIds"]; ok {
-		config.NoticeIDs = stringConvert(val)
+		rawTargets := stringConvert(val)
+		config.NoticeIDs = make([]string, 0, len(rawTargets))
+		for _, rawTarget := range rawTargets {
+			if target := dice.ParseNoticeTarget(rawTarget); target.ID != "" {
+				config.NoticeIDs = append(config.NoticeIDs, target.String())
+			}
+		}
 	}
 
 	if val, ok := jsonMap["defaultCocRuleIndex"]; ok { //nolint:nestif
@@ -484,7 +490,7 @@ func DiceMailTest(c echo.Context) error {
 		return Error(&c, "展示模式不支持该操作", Response{"testMode": true})
 	}
 
-	err := myDice.SendMail("", dice.MailTest)
+	err := myDice.SendMail("", dice.MailTest, dice.NoticeTypeSystem)
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}

--- a/api/group.go
+++ b/api/group.go
@@ -114,7 +114,7 @@ func groupQuit(c echo.Context) error {
 		myDice.Logger.Info(_txt)
 
 		ctx := &dice.MsgContext{Dice: myDice, EndPoint: ep, Session: myDice.ImSession}
-		ctx.Notice(_txt)
+		ctx.Notice(_txt, dice.NoticeTypeGroup)
 		// dice.SetBotOffAtGroup(ctx, group.GroupId)
 
 		if !v.Silence {

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -240,7 +240,7 @@ func (d *Dice) executeDismissOperation(ctx *MsgContext, msg *Message, targetGrou
 	txt := fmt.Sprintf("指令退群: 于群组<%s>(%s)中告别，操作者:<%s>(%s)",
 		groupName, targetGroupID, userName, msg.Sender.UserID)
 	d.Logger.Info(txt)
-	ctx.Notice(txt)
+	ctx.Notice(txt, NoticeTypeGroup)
 
 	time.Sleep(3 * time.Second)
 	if targetGroup != nil {

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -869,7 +869,7 @@ func (d *Dice) ApplyAliveNotice() {
 	}
 	if d.Config.AliveNoticeEnable {
 		entry, err := d.Cron.AddFunc((&d.Config).AliveNoticeValue, func() {
-			d.NoticeForEveryEndpoint(fmt.Sprintf("存活, D100=%d", DiceRoll64(100)), false)
+			d.NoticeForEveryEndpoint(fmt.Sprintf("存活, D100=%d", DiceRoll64(100)), false, NoticeTypeSystem)
 		})
 		if err == nil {
 			d.AliveNoticeEntry = entry

--- a/dice/dice_ban.go
+++ b/dice/dice_ban.go
@@ -371,7 +371,7 @@ func (i *BanListInfo) NoticeCheck(uid string, place string, oldRank BanRankType,
 
 	if ctx != nil {
 		// 做出通知
-		ctx.Notice(txt)
+		ctx.Notice(txt, NoticeTypeBan)
 
 		if ctx.Player == nil {
 			ctx.Player = &GroupPlayerInfo{} // 为了能存 $t 变量，God bless this design

--- a/dice/dice_censor.go
+++ b/dice/dice_censor.go
@@ -281,7 +281,7 @@ func (d *Dice) CensorMsg(mctx *MsgContext, msg *Message, checkContent string, se
 						levelText,
 					)
 				}
-				mctx.Notice(text)
+				mctx.Notice(text, NoticeTypeCensor)
 			}
 			if handler&(1<<BanUser) != 0 {
 				// 拉黑用户

--- a/dice/dice_config_default.go
+++ b/dice/dice_config_default.go
@@ -14,7 +14,7 @@ var DefaultConfig = Config{
 	BaseConfig{
 		CommandCompatibleMode:    true, // 一直为true即可
 		LastSavedTime:            nil,
-		NoticeIDs:                []string{},
+		NoticeIDs:                []string{"UI:1001"},
 		OnlyLogCommandInGroup:    false,
 		OnlyLogCommandInPrivate:  false,
 		VersionCode:              ConfigVersionCode,

--- a/dice/dice_config_default_test.go
+++ b/dice/dice_config_default_test.go
@@ -1,0 +1,16 @@
+package dice
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDefaultNoticeIDsIncludeDefaultDiceMasters(t *testing.T) {
+	if !reflect.DeepEqual(DefaultConfig.NoticeIDs, DefaultConfig.DiceMasters) {
+		t.Fatalf(
+			"新安装的通知列表应与默认骰主列表一致，diceMasters=%v noticeIds=%v",
+			DefaultConfig.DiceMasters,
+			DefaultConfig.NoticeIDs,
+		)
+	}
+}

--- a/dice/dice_config_default_test.go
+++ b/dice/dice_config_default_test.go
@@ -1,16 +1,18 @@
-package dice
+package dice_test
 
 import (
 	"reflect"
 	"testing"
+
+	"sealdice-core/dice"
 )
 
 func TestDefaultNoticeIDsIncludeDefaultDiceMasters(t *testing.T) {
-	if !reflect.DeepEqual(DefaultConfig.NoticeIDs, DefaultConfig.DiceMasters) {
+	if !reflect.DeepEqual(dice.DefaultConfig.NoticeIDs, dice.DefaultConfig.DiceMasters) {
 		t.Fatalf(
 			"新安装的通知列表应与默认骰主列表一致，diceMasters=%v noticeIds=%v",
-			DefaultConfig.DiceMasters,
-			DefaultConfig.NoticeIDs,
+			dice.DefaultConfig.DiceMasters,
+			dice.DefaultConfig.NoticeIDs,
 		)
 	}
 }

--- a/dice/ext_core.go
+++ b/dice/ext_core.go
@@ -29,7 +29,7 @@ func RegisterBuiltinExtCore(dice *Dice) {
 				if opUID == "" {
 					txt := fmt.Sprintf("退出群组<%s>(%s)，但操作者ID为空，停止继续处理", groupName, event.GroupID)
 					dice.Logger.Info(txt)
-					ctx.Notice(txt)
+					ctx.Notice(txt, NoticeTypeGroup)
 					return
 				}
 
@@ -56,7 +56,7 @@ func RegisterBuiltinExtCore(dice *Dice) {
 
 				txt := fmt.Sprintf("被踢出群: 在群组<%s>(%s)中被踢出，操作者:<%s>(%s)%s", groupName, event.GroupID, userName, event.OperatorID, extra)
 				dice.Logger.Info(txt)
-				ctx.Notice(txt)
+				ctx.Notice(txt, NoticeTypeGroup)
 			}
 		},
 	}

--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -447,11 +447,14 @@ func RegisterBuiltinExtFun(self *Dice) {
 				return CmdExecuteResult{Matched: true, Solved: true, ShowHelp: true}
 			default:
 				if self.Config.MailEnable {
-					_ = ctx.Dice.SendMail(cmdArgs.CleanArgs, MailTypeSendNote)
+					if err := ctx.Dice.SendMail(cmdArgs.CleanArgs, MailTypeSendNote, NoticeTypeSend); err != nil {
+						ctx.Dice.Logger.Errorf("留言邮件发送失败: %v", err)
+					}
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:留言_已记录"))
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
-				for _, uid := range ctx.Dice.DiceMasters {
+				for _, target := range filterNoticeTargets(ctx.Dice.Config.NoticeIDs, NoticeTypeSend) {
+					uid := target.ID
 					text := ""
 
 					if ctx.IsCurGroupBotOn {
@@ -461,7 +464,7 @@ func RegisterBuiltinExtFun(self *Dice) {
 					}
 
 					text += cmdArgs.CleanArgs
-					if strings.Contains(uid, "Group") || strings.Contains(uid, "Channel") || strings.Contains(uid, "Guild") {
+					if target.IsGroup() {
 						ctx.EndPoint.Adapter.SendToGroup(ctx, uid, text, "")
 					} else {
 						ctx.EndPoint.Adapter.SendToPerson(ctx, uid, text, "")

--- a/dice/ext_fun.go
+++ b/dice/ext_fun.go
@@ -453,21 +453,17 @@ func RegisterBuiltinExtFun(self *Dice) {
 					ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:留言_已记录"))
 					return CmdExecuteResult{Matched: true, Solved: true}
 				}
+				text := ""
+				if ctx.IsCurGroupBotOn {
+					text += fmt.Sprintf("一条来自群组<%s>(%s)，作者<%s>(%s)的留言:\n", ctx.Group.GroupName, ctx.Group.GroupID, ctx.Player.Name, ctx.Player.UserID)
+				} else {
+					text += fmt.Sprintf("一条来自私聊，作者<%s>(%s)的留言:\n", ctx.Player.Name, ctx.Player.UserID)
+				}
+				text += cmdArgs.CleanArgs
+
 				for _, target := range filterNoticeTargets(ctx.Dice.Config.NoticeIDs, NoticeTypeSend) {
-					uid := target.ID
-					text := ""
-
-					if ctx.IsCurGroupBotOn {
-						text += fmt.Sprintf("一条来自群组<%s>(%s)，作者<%s>(%s)的留言:\n", ctx.Group.GroupName, ctx.Group.GroupID, ctx.Player.Name, ctx.Player.UserID)
-					} else {
-						text += fmt.Sprintf("一条来自私聊，作者<%s>(%s)的留言:\n", ctx.Player.Name, ctx.Player.UserID)
-					}
-
-					text += cmdArgs.CleanArgs
-					if target.IsGroup() {
-						ctx.EndPoint.Adapter.SendToGroup(ctx, uid, text, "")
-					} else {
-						ctx.EndPoint.Adapter.SendToPerson(ctx, uid, text, "")
+					if !sendNoticeTargetCrossPlatform(ctx, target, text) {
+						ctx.Dice.Logger.Errorf("未能向通知目标 %s 发送留言", target.ID)
 					}
 				}
 				ReplyToSender(ctx, msg, DiceFormatTmpl(ctx, "核心:留言_已记录"))

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -870,7 +870,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 				ep.Adapter.GetGroupInfoAsync(msg.GroupID)
 			}
 			log.Info(txt)
-			mctx.Notice(txt)
+			mctx.Notice(txt, NoticeTypeGroup)
 
 			if msg.Platform == "QQ" || msg.Platform == "TG" {
 				// ServiceAtNew changed
@@ -1252,7 +1252,7 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 		// 疑似是为了获取群信息然后塞到奇怪的地方
 		// ep.Adapter.GetGroupInfoAsync(msg.GroupID)
 		log.Info(txt)
-		mctx.Notice(txt)
+		mctx.Notice(txt, NoticeTypeGroup)
 
 		if msg.Platform == "QQ" || msg.Platform == "TG" {
 			groupInfo, ok = mctx.Session.ServiceAtNew.Load(msg.GroupID)
@@ -1638,7 +1638,7 @@ func (s *IMSession) OnGroupJoined(ctx *MsgContext, msg *Message) {
 	}()
 	txt := fmt.Sprintf("加入群组: <%s>(%s)", groupName, msg.GroupID)
 	log.Info(txt)
-	ctx.Notice(txt)
+	ctx.Notice(txt, NoticeTypeGroup)
 	for _, wrapper := range group.GetActivatedExtList(ctx.Dice) {
 		ext := wrapper.GetRealExt()
 		if ext == nil {
@@ -1815,7 +1815,7 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 	var noticeCtx *MsgContext
 	if summaryMode {
 		noticeCtx = &MsgContext{EndPoint: selectedGroupEndpoints[0].Endpoint, Session: s, Dice: s.Parent}
-		noticeCtx.Notice(fmt.Sprintf("自动退群任务开始：本轮预计处理 %d 个群。", len(selectedGroupEndpoints)))
+		noticeCtx.Notice(fmt.Sprintf("自动退群任务开始：本轮预计处理 %d 个群。", len(selectedGroupEndpoints)), NoticeTypeInactive)
 	}
 
 	go func() {
@@ -1865,7 +1865,7 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 			ep.Adapter.QuitGroup(msgCtx, grp.GroupID)
 			quitStarted++
 			if !summaryMode {
-				msgCtx.Notice(hint)
+				msgCtx.Notice(hint, NoticeTypeInactive)
 			}
 			// 生成一个随机值（8~11秒随机）
 			randomSleep := time.Duration(rand.Intn(3000)+8000) * time.Millisecond
@@ -1873,7 +1873,7 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 			time.Sleep(randomSleep)
 		}
 		if summaryMode && noticeCtx != nil {
-			noticeCtx.Notice(fmt.Sprintf("自动退群任务结束：候选 %d 个，开始处理 %d 个，已发起退群 %d 个，跳过 %d 个，取消 %d 个。", len(selectedGroupEndpoints), processed, quitStarted, skipped, cancelled))
+			noticeCtx.Notice(fmt.Sprintf("自动退群任务结束：候选 %d 个，开始处理 %d 个，已发起退群 %d 个，跳过 %d 个，取消 %d 个。", len(selectedGroupEndpoints), processed, quitStarted, skipped, cancelled), NoticeTypeInactive)
 		}
 	}()
 }
@@ -1943,7 +1943,7 @@ func handleBlacklistedUserQuitIfAdmin(ctx *MsgContext, msg *Message, isWhiteGrou
 
 		noticeMsg := fmt.Sprintf("检测到群(%s)内黑名单用户<%s>(%s)，因是管理以上权限，执行通告后自动退群\n%s", groupID, msg.Sender.Nickname, msg.Sender.UserID, reasontext)
 		log.Info(noticeMsg)
-		ctx.Notice(noticeMsg)
+		ctx.Notice(noticeMsg, NoticeTypeBan)
 		banQuitGroup()
 		return true
 	}
@@ -1964,7 +1964,7 @@ func handleBlacklistedUserQuitIfAdmin(ctx *MsgContext, msg *Message, isWhiteGrou
 		text := fmt.Sprintf("警告: <%s>(%s)是黑名单用户，将对骰主进行通知。\n%s", msg.Sender.Nickname, msg.Sender.UserID, reasontext)
 		ReplyGroupRaw(ctx, &Message{GroupID: groupID}, text, "")
 
-		ctx.Notice(noticeMsg)
+		ctx.Notice(noticeMsg, NoticeTypeBan)
 		return true
 	}
 
@@ -2031,7 +2031,7 @@ func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 		text := fmt.Sprintf("因<%s>(%s)是黑名单用户，将自动退群。", msg.Sender.Nickname, msg.Sender.UserID)
 		ReplyGroupRaw(ctx, &Message{GroupID: groupID}, text, "")
 
-		ctx.Notice(noticeMsg)
+		ctx.Notice(noticeMsg, NoticeTypeBan)
 
 		time.Sleep(1 * time.Second)
 		ctx.EndPoint.Adapter.QuitGroup(ctx, groupID)
@@ -2055,7 +2055,7 @@ func checkBan(ctx *MsgContext, msg *Message) (notReply bool) {
 
 				ReplyGroupRaw(ctx, &Message{GroupID: groupID}, "因本群处于黑名单中，将自动退群。", "")
 
-				ctx.Notice(noticeMsg)
+				ctx.Notice(noticeMsg, NoticeTypeBan)
 
 				time.Sleep(1 * time.Second)
 				ctx.EndPoint.Adapter.QuitGroup(ctx, groupID)
@@ -2470,11 +2470,21 @@ func (ep *EndPointInfo) RefreshGroupNum() {
 	}
 }
 
-func (d *Dice) NoticeForEveryEndpoint(txt string, allowCrossPlatform bool) {
+func sendNoticeToTarget(ctx *MsgContext, target NoticeTarget, txt string) {
+	if target.IsGroup() {
+		ReplyGroup(ctx, &Message{GroupID: target.ID}, txt)
+	} else {
+		ReplyPerson(ctx, &Message{Sender: SenderBase{UserID: target.ID}}, txt)
+	}
+}
+
+// NoticeForEveryEndpoint 向每个平台的在线账号发送一遍指定分类的通知。
+func (d *Dice) NoticeForEveryEndpoint(txt string, allowCrossPlatform bool, noticeTypes ...NoticeType) {
 	_ = allowCrossPlatform
-	// 通知种类之一：每个noticeId  *  每个平台匹配的ep：存活
-	// TODO: 先复制几次实现，后面重构
-	// Pinenutn: 啥时候重构啊.jpg
+	noticeType := NoticeTypeSystem
+	if len(noticeTypes) > 0 {
+		noticeType = noticeTypes[0]
+	}
 	foo := func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -2483,41 +2493,45 @@ func (d *Dice) NoticeForEveryEndpoint(txt string, allowCrossPlatform bool) {
 		}()
 
 		if d.Config.MailEnable {
-			_ = d.SendMail(txt, MailTypeNotice)
+			if err := d.SendMail(txt, MailTypeNotice, noticeType); err != nil {
+				d.Logger.Errorf("邮件通知发送失败: %v", err)
+			}
 			return
 		}
 
 		for _, ep := range d.ImSession.EndPoints {
-			for _, i := range d.Config.NoticeIDs {
-				n := strings.Split(i, ":")
-				// 如果文本中没有-，则会取到整个字符串
-				// 但好像不严谨，比如QQ-CH-Group
-				prefix := strings.Split(n[0], "-")[0]
-
-				if len(n) >= 2 && prefix == ep.Platform && ep.Enable && ep.State == 1 {
-					if ep.Session == nil {
-						ep.Session = d.ImSession
-					}
-					if strings.HasSuffix(n[0], "-Group") {
-						msg := &Message{GroupID: i, MessageType: "private", Sender: SenderBase{UserID: i}}
-						ctx := CreateTempCtx(ep, msg)
-						ReplyGroup(ctx, msg, txt)
-					} else {
-						msg := &Message{GroupID: i, MessageType: "group", Sender: SenderBase{UserID: i}}
-						ctx := CreateTempCtx(ep, msg)
-						ReplyPerson(ctx, &Message{Sender: SenderBase{UserID: i}}, txt)
-					}
+			if ep == nil || !ep.Enable || ep.State != StateConnected {
+				continue
+			}
+			for _, target := range filterNoticeTargets(d.Config.NoticeIDs, noticeType) {
+				platform, ok := target.Platform()
+				if !ok || platform == "Mail" || platform != ep.Platform {
+					continue
 				}
-				time.Sleep(1 * time.Second)
+				if ep.Session == nil {
+					ep.BindRuntime(d.ImSession)
+				}
+				messageType := "private"
+				msg := &Message{Sender: SenderBase{UserID: target.ID}, MessageType: messageType}
+				if target.IsGroup() {
+					msg.MessageType = "group"
+					msg.GroupID = target.ID
+				}
+				ctx := CreateTempCtx(ep, msg)
+				sendNoticeToTarget(ctx, target, txt)
+				time.Sleep(time.Second)
 			}
 		}
 	}
 	go foo()
 }
 
-func (ctx *MsgContext) NoticeCrossPlatform(txt string) {
-	// 通知种类之二：每个noticeID  *  第一个平台匹配的ep：跨平台通知
-	// TODO: 先复制几次实现，后面重构
+// NoticeCrossPlatform 优先用当前账号发送，并为其他平台寻找第一个启用账号。
+func (ctx *MsgContext) NoticeCrossPlatform(txt string, noticeTypes ...NoticeType) {
+	noticeType := NoticeTypeSystem
+	if len(noticeTypes) > 0 {
+		noticeType = noticeTypes[0]
+	}
 	foo := func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -2526,42 +2540,30 @@ func (ctx *MsgContext) NoticeCrossPlatform(txt string) {
 		}()
 
 		if ctx.Dice.Config.MailEnable {
-			_ = ctx.Dice.SendMail(txt, MailTypeNotice)
+			if err := ctx.Dice.SendMail(txt, MailTypeNotice, noticeType); err != nil {
+				ctx.Dice.Logger.Errorf("邮件通知发送失败: %v", err)
+			}
 			return
 		}
 
 		sent := false
-
-		for _, i := range ctx.Dice.Config.NoticeIDs {
-			n := strings.Split(i, ":")
-			if len(n) < 2 {
+		for _, target := range filterNoticeTargets(ctx.Dice.Config.NoticeIDs, noticeType) {
+			platform, ok := target.Platform()
+			if !ok || platform == "Mail" {
+				continue
+			}
+			if ctx.EndPoint != nil && ctx.EndPoint.Enable && ctx.EndPoint.Platform == platform {
+				sendNoticeToTarget(ctx, target, txt)
+				sent = true
+				time.Sleep(time.Second)
 				continue
 			}
 
-			seg := strings.Split(n[0], "-")[0]
-
-			messageType := "private"
-			if strings.HasSuffix(n[0], "-Group") {
-				messageType = "group"
-			}
-
-			if ctx.EndPoint.Platform == seg {
-				if messageType == "group" {
-					ReplyGroup(ctx, &Message{GroupID: i}, txt)
-				} else {
-					ReplyPerson(ctx, &Message{Sender: SenderBase{UserID: i}}, txt)
-				}
-				time.Sleep(1 * time.Second)
-				sent = true
-				continue // 找到对应平台、调用了发送的在此即切出循环
-			}
-
-			// 如果走到这里，说明当前ep不是noticeID对应的平台
-			if done := CrossMsgBySearch(ctx.Session, seg, i, txt, messageType == "private"); !done {
-				ctx.Dice.Logger.Errorf("尝试跨平台后仍未能向 %s 发送通知：%s", i, txt)
+			if done := CrossMsgBySearch(ctx.Session, platform, target.ID, txt, !target.IsGroup()); !done {
+				ctx.Dice.Logger.Errorf("尝试跨平台后仍未能向 %s 发送通知：%s", target.ID, txt)
 			} else {
 				sent = true
-				time.Sleep(1 * time.Second)
+				time.Sleep(time.Second)
 			}
 		}
 
@@ -2572,10 +2574,12 @@ func (ctx *MsgContext) NoticeCrossPlatform(txt string) {
 	go foo()
 }
 
-func (ctx *MsgContext) Notice(txt string) {
-	// Notice
-	// 通知种类之三：每个noticeID  * 当前mctx的ep：不跨平台通知
-	// TODO: 先复制几次实现，后面重构
+// Notice 使用当前消息上下文的账号发送指定分类通知。
+func (ctx *MsgContext) Notice(txt string, noticeTypes ...NoticeType) {
+	noticeType := NoticeTypeSystem
+	if len(noticeTypes) > 0 {
+		noticeType = noticeTypes[0]
+	}
 	foo := func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -2584,31 +2588,30 @@ func (ctx *MsgContext) Notice(txt string) {
 		}()
 
 		if ctx.Dice.Config.MailEnable {
-			_ = ctx.Dice.SendMail(txt, MailTypeNotice)
+			if err := ctx.Dice.SendMail(txt, MailTypeNotice, noticeType); err != nil {
+				ctx.Dice.Logger.Errorf("邮件通知发送失败: %v", err)
+			}
 			return
 		}
 
 		sent := false
-		if ctx.EndPoint.Enable {
-			for _, i := range ctx.Dice.Config.NoticeIDs {
-				n := strings.Split(i, ":")
-				if len(n) >= 2 {
-					if strings.HasSuffix(n[0], "-Group") {
-						ReplyGroup(ctx, &Message{GroupID: i}, txt)
-					} else {
-						ReplyPerson(ctx, &Message{Sender: SenderBase{UserID: i}}, txt)
-					}
-					sent = true
+		if ctx.EndPoint != nil && ctx.EndPoint.Enable {
+			for _, target := range filterNoticeTargets(ctx.Dice.Config.NoticeIDs, noticeType) {
+				platform, ok := target.Platform()
+				if !ok || platform == "Mail" || platform != ctx.EndPoint.Platform {
+					continue
 				}
-				time.Sleep(1 * time.Second)
+				sendNoticeToTarget(ctx, target, txt)
+				sent = true
+				time.Sleep(time.Second)
 			}
 		}
 
 		if !sent {
-			if len(ctx.Dice.Config.NoticeIDs) != 0 {
+			if len(filterNoticeTargets(ctx.Dice.Config.NoticeIDs, noticeType)) != 0 {
 				ctx.Dice.Logger.Errorf("未能发送来自%s的通知：%s", ctx.EndPoint.Platform, txt)
 			} else {
-				ctx.Dice.Logger.Warnf("因为没有配置通知列表，无法发送来自%s的通知：%s", ctx.EndPoint.Platform, txt)
+				ctx.Dice.Logger.Warnf("因为没有启用接收 %s 分类的通知目标，无法发送来自%s的通知：%s", noticeType, ctx.EndPoint.Platform, txt)
 			}
 		}
 	}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -2613,7 +2613,11 @@ func (ctx *MsgContext) NoticeCrossPlatform(txt string, noticeTypes ...NoticeType
 		}
 
 		if !sent {
-			ctx.Dice.Logger.Errorf("未能发送来自%s的通知：%s", ctx.EndPoint.Platform, txt)
+			platform := "<未知平台>"
+			if ctx.EndPoint != nil {
+				platform = ctx.EndPoint.Platform
+			}
+			ctx.Dice.Logger.Errorf("未能发送来自%s的通知：%s", platform, txt)
 		}
 	}
 	go foo()
@@ -2652,10 +2656,14 @@ func (ctx *MsgContext) Notice(txt string, noticeTypes ...NoticeType) {
 		}
 
 		if !sent {
+			platform := "<未知平台>"
+			if ctx.EndPoint != nil {
+				platform = ctx.EndPoint.Platform
+			}
 			if len(filterNoticeTargets(ctx.Dice.Config.NoticeIDs, noticeType)) != 0 {
-				ctx.Dice.Logger.Errorf("未能发送来自%s的通知：%s", ctx.EndPoint.Platform, txt)
+				ctx.Dice.Logger.Errorf("未能发送来自%s的通知：%s", platform, txt)
 			} else {
-				ctx.Dice.Logger.Warnf("因为没有启用接收 %s 分类的通知目标，无法发送来自%s的通知：%s", noticeType, ctx.EndPoint.Platform, txt)
+				ctx.Dice.Logger.Warnf("因为没有启用接收 %s 分类的通知目标，无法发送来自%s的通知：%s", noticeType, platform, txt)
 			}
 		}
 	}

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -2478,6 +2478,72 @@ func sendNoticeToTarget(ctx *MsgContext, target NoticeTarget, txt string) {
 	}
 }
 
+func noticeTargetMatchesEndpoint(target NoticeTarget, ep *EndPointInfo) bool {
+	if ep == nil || !target.MatchesEndpoint(ep.Platform, ep.ProtocolType) {
+		return false
+	}
+
+	targetPlatform, _ := target.Platform()
+	if targetPlatform != "OpenQQ" {
+		return true
+	}
+
+	// 多个官方 QQ 账号共存时，只让 ID 中 UIN 对应的账号发送。
+	pa, ok := ep.Adapter.(*PlatformAdapterOfficialQQ)
+	if !ok || pa.UIN == "" {
+		return false
+	}
+	_, rawID, ok := strings.Cut(target.ID, ":")
+	return ok && (rawID == pa.UIN || strings.HasPrefix(rawID, pa.UIN+"-"))
+}
+
+func noticeTargetContext(session *IMSession, ep *EndPointInfo, target NoticeTarget) *MsgContext {
+	if ep.Session == nil {
+		ep.BindRuntime(session)
+	}
+
+	msg := &Message{Sender: SenderBase{UserID: target.ID}, MessageType: "private"}
+	if target.IsGroup() {
+		msg.MessageType = "group"
+		msg.GroupID = target.ID
+	}
+	return CreateTempCtx(ep, msg)
+}
+
+func findNoticeEndpoint(session *IMSession, target NoticeTarget) *EndPointInfo {
+	if session == nil {
+		return nil
+	}
+	for _, ep := range session.EndPoints {
+		if ep != nil && ep.Enable && ep.State == StateConnected && noticeTargetMatchesEndpoint(target, ep) {
+			return ep
+		}
+	}
+	return nil
+}
+
+// sendNoticeTargetCrossPlatform 优先使用当前 Endpoint，否则寻找兼容且在线的 Endpoint。
+func sendNoticeTargetCrossPlatform(ctx *MsgContext, target NoticeTarget, txt string) bool {
+	if ctx == nil {
+		return false
+	}
+	if ctx.EndPoint != nil && ctx.EndPoint.Enable && noticeTargetMatchesEndpoint(target, ctx.EndPoint) {
+		sendNoticeToTarget(ctx, target, txt)
+		return true
+	}
+
+	session := ctx.Session
+	if session == nil && ctx.Dice != nil {
+		session = ctx.Dice.ImSession
+	}
+	ep := findNoticeEndpoint(session, target)
+	if ep == nil {
+		return false
+	}
+	sendNoticeToTarget(noticeTargetContext(session, ep, target), target, txt)
+	return true
+}
+
 // NoticeForEveryEndpoint 向每个平台的在线账号发送一遍指定分类的通知。
 func (d *Dice) NoticeForEveryEndpoint(txt string, allowCrossPlatform bool, noticeTypes ...NoticeType) {
 	_ = allowCrossPlatform
@@ -2504,20 +2570,10 @@ func (d *Dice) NoticeForEveryEndpoint(txt string, allowCrossPlatform bool, notic
 				continue
 			}
 			for _, target := range filterNoticeTargets(d.Config.NoticeIDs, noticeType) {
-				platform, ok := target.Platform()
-				if !ok || platform == "Mail" || platform != ep.Platform {
+				if !noticeTargetMatchesEndpoint(target, ep) {
 					continue
 				}
-				if ep.Session == nil {
-					ep.BindRuntime(d.ImSession)
-				}
-				messageType := "private"
-				msg := &Message{Sender: SenderBase{UserID: target.ID}, MessageType: messageType}
-				if target.IsGroup() {
-					msg.MessageType = "group"
-					msg.GroupID = target.ID
-				}
-				ctx := CreateTempCtx(ep, msg)
+				ctx := noticeTargetContext(d.ImSession, ep, target)
 				sendNoticeToTarget(ctx, target, txt)
 				time.Sleep(time.Second)
 			}
@@ -2548,18 +2604,7 @@ func (ctx *MsgContext) NoticeCrossPlatform(txt string, noticeTypes ...NoticeType
 
 		sent := false
 		for _, target := range filterNoticeTargets(ctx.Dice.Config.NoticeIDs, noticeType) {
-			platform, ok := target.Platform()
-			if !ok || platform == "Mail" {
-				continue
-			}
-			if ctx.EndPoint != nil && ctx.EndPoint.Enable && ctx.EndPoint.Platform == platform {
-				sendNoticeToTarget(ctx, target, txt)
-				sent = true
-				time.Sleep(time.Second)
-				continue
-			}
-
-			if done := CrossMsgBySearch(ctx.Session, platform, target.ID, txt, !target.IsGroup()); !done {
+			if !sendNoticeTargetCrossPlatform(ctx, target, txt) {
 				ctx.Dice.Logger.Errorf("尝试跨平台后仍未能向 %s 发送通知：%s", target.ID, txt)
 			} else {
 				sent = true
@@ -2597,8 +2642,7 @@ func (ctx *MsgContext) Notice(txt string, noticeTypes ...NoticeType) {
 		sent := false
 		if ctx.EndPoint != nil && ctx.EndPoint.Enable {
 			for _, target := range filterNoticeTargets(ctx.Dice.Config.NoticeIDs, noticeType) {
-				platform, ok := target.Platform()
-				if !ok || platform == "Mail" || platform != ctx.EndPoint.Platform {
+				if !noticeTargetMatchesEndpoint(target, ctx.EndPoint) {
 					continue
 				}
 				sendNoticeToTarget(ctx, target, txt)

--- a/dice/notice.go
+++ b/dice/notice.go
@@ -1,0 +1,179 @@
+package dice
+
+import "strings"
+
+// NoticeType 表示通知内容分类，用于按通知目标进行颗粒化过滤。
+type NoticeType string
+
+const (
+	NoticeTypeGroup    NoticeType = "group"
+	NoticeTypeInvite   NoticeType = "invite"
+	NoticeTypeBan      NoticeType = "ban"
+	NoticeTypeCensor   NoticeType = "censor"
+	NoticeTypeInactive NoticeType = "inactive"
+	NoticeTypeSend     NoticeType = "send"
+	NoticeTypeSystem   NoticeType = "system"
+)
+
+// AllNoticeTypes 是配置和 UI 使用的稳定分类顺序。
+var AllNoticeTypes = []NoticeType{
+	NoticeTypeGroup,
+	NoticeTypeInvite,
+	NoticeTypeBan,
+	NoticeTypeCensor,
+	NoticeTypeInactive,
+	NoticeTypeSend,
+	NoticeTypeSystem,
+}
+
+var validNoticeTypes = func() map[NoticeType]struct{} {
+	result := make(map[NoticeType]struct{}, len(AllNoticeTypes))
+	for _, noticeType := range AllNoticeTypes {
+		result[noticeType] = struct{}{}
+	}
+	return result
+}()
+
+// NoticeTarget 是 NoticeIDs 中单项的运行时表示。
+//
+// 持久化格式保持为字符串，以兼容旧配置：
+//   - QQ:12345                             启用全部分类
+//   - QQ:12345:disable                     禁用
+//   - QQ:12345:only=group,ban              仅启用指定分类
+//   - QQ:12345:disable:only=group,ban      禁用并保留分类选择
+//
+// 元数据仅从末尾识别，因此 OpenQQ 等内部包含多个冒号的统一 ID 仍可正常解析。
+type NoticeTarget struct {
+	ID                  string
+	Disabled            bool
+	NoticeTypes         []NoticeType
+	HasNoticeTypeFilter bool
+}
+
+// ParseNoticeTarget 解析一条兼容旧格式的通知目标配置。
+func ParseNoticeTarget(raw string) NoticeTarget {
+	parts := strings.Split(strings.TrimSpace(raw), ":")
+	target := NoticeTarget{}
+	end := len(parts)
+
+	for end > 1 {
+		suffix := strings.TrimSpace(parts[end-1])
+		switch {
+		case suffix == "disable":
+			target.Disabled = true
+			end--
+		case strings.HasPrefix(suffix, "only="):
+			// 多个 only 后缀出现时，以最右侧（最后配置）的值为准。
+			if !target.HasNoticeTypeFilter {
+				target.HasNoticeTypeFilter = true
+				values := strings.Split(strings.TrimPrefix(suffix, "only="), ",")
+				for _, value := range values {
+					noticeType := NoticeType(strings.TrimSpace(value))
+					if _, ok := validNoticeTypes[noticeType]; ok {
+						target.NoticeTypes = append(target.NoticeTypes, noticeType)
+					}
+				}
+			}
+			end--
+		default:
+			target.ID = strings.TrimSpace(strings.Join(parts[:end], ":"))
+			target.NoticeTypes = normalizeNoticeTypes(target.NoticeTypes)
+			return target
+		}
+	}
+
+	target.ID = strings.TrimSpace(strings.Join(parts[:end], ":"))
+	target.NoticeTypes = normalizeNoticeTypes(target.NoticeTypes)
+	return target
+}
+
+// Allows 判断目标是否允许接收指定分类。
+func (target NoticeTarget) Allows(noticeType NoticeType) bool {
+	if target.Disabled || target.ID == "" {
+		return false
+	}
+	if !target.HasNoticeTypeFilter {
+		return true
+	}
+	for _, allowed := range target.NoticeTypes {
+		if allowed == noticeType {
+			return true
+		}
+	}
+	return false
+}
+
+// String 返回通知目标的规范持久化格式。
+func (target NoticeTarget) String() string {
+	id := strings.TrimSpace(target.ID)
+	if id == "" {
+		return ""
+	}
+
+	var result strings.Builder
+	result.WriteString(id)
+	if target.Disabled {
+		result.WriteString(":disable")
+	}
+
+	types := normalizeNoticeTypes(target.NoticeTypes)
+	if target.HasNoticeTypeFilter && len(types) != len(AllNoticeTypes) {
+		result.WriteString(":only=")
+		for index, noticeType := range types {
+			if index > 0 {
+				result.WriteByte(',')
+			}
+			result.WriteString(string(noticeType))
+		}
+	}
+	return result.String()
+}
+
+// Platform 返回通知 ID 对应的平台。Mail 目标也会返回 Mail，由调用方决定是否跳过。
+func (target NoticeTarget) Platform() (string, bool) {
+	prefix, _, ok := strings.Cut(target.ID, ":")
+	if !ok || prefix == "" {
+		return "", false
+	}
+	platform, _, _ := strings.Cut(prefix, "-")
+	return platform, platform != ""
+}
+
+// IsGroup 判断目标是否为群、频道或服务器消息目标。
+func (target NoticeTarget) IsGroup() bool {
+	prefix, _, ok := strings.Cut(target.ID, ":")
+	if !ok {
+		return false
+	}
+	return strings.HasSuffix(prefix, "-Group") ||
+		strings.HasSuffix(prefix, "-Channel") ||
+		strings.HasSuffix(prefix, "-Guild")
+}
+
+func normalizeNoticeTypes(types []NoticeType) []NoticeType {
+	selected := make(map[NoticeType]struct{}, len(types))
+	for _, noticeType := range types {
+		if _, ok := validNoticeTypes[noticeType]; ok {
+			selected[noticeType] = struct{}{}
+		}
+	}
+
+	result := make([]NoticeType, 0, len(selected))
+	for _, noticeType := range AllNoticeTypes {
+		if _, ok := selected[noticeType]; ok {
+			result = append(result, noticeType)
+		}
+	}
+	return result
+}
+
+func filterNoticeTargets(rawTargets []string, noticeType NoticeType) []NoticeTarget {
+	targets := make([]NoticeTarget, 0, len(rawTargets))
+	for _, raw := range rawTargets {
+		target := ParseNoticeTarget(raw)
+		if target.Allows(noticeType) {
+			targets = append(targets, target)
+		}
+	}
+	return targets
+}

--- a/dice/notice.go
+++ b/dice/notice.go
@@ -139,6 +139,26 @@ func (target NoticeTarget) Platform() (string, bool) {
 	return platform, platform != ""
 }
 
+// MatchesEndpoint 判断通知目标是否可由指定平台和协议的 Endpoint 发送。
+//
+// 官方 QQ 的统一 ID 使用 OpenQQ/OpenQQCH 前缀，但 Endpoint 平台仍是 QQ，
+// 因此还必须结合 protocolType 区分它与普通 QQ 连接。
+func (target NoticeTarget) MatchesEndpoint(platform, protocolType string) bool {
+	targetPlatform, ok := target.Platform()
+	if !ok || targetPlatform == "Mail" {
+		return false
+	}
+
+	switch targetPlatform {
+	case "OpenQQ", "OpenQQCH":
+		return platform == "QQ" && protocolType == "official"
+	case "QQ":
+		return platform == "QQ" && protocolType != "official"
+	default:
+		return targetPlatform == platform
+	}
+}
+
 // IsGroup 判断目标是否为群、频道或服务器消息目标。
 func (target NoticeTarget) IsGroup() bool {
 	prefix, _, ok := strings.Cut(target.ID, ":")

--- a/dice/notice_test.go
+++ b/dice/notice_test.go
@@ -1,0 +1,141 @@
+//nolint:testpackage
+package dice
+
+import (
+	"reflect"
+	"testing"
+)
+
+func normalizeForCompare(target NoticeTarget) NoticeTarget {
+	if target.NoticeTypes == nil {
+		target.NoticeTypes = []NoticeType{}
+	}
+	return target
+}
+
+func TestParseNoticeTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want NoticeTarget
+	}{
+		{
+			name: "legacy target allows all",
+			raw:  "QQ:12345",
+			want: NoticeTarget{ID: "QQ:12345"},
+		},
+		{
+			name: "disabled target",
+			raw:  "QQ-Group:67890:disable",
+			want: NoticeTarget{ID: "QQ-Group:67890", Disabled: true},
+		},
+		{
+			name: "filtered target uses stable order",
+			raw:  "QQ:12345:only=ban,group,ban",
+			want: NoticeTarget{
+				ID:                  "QQ:12345",
+				NoticeTypes:         []NoticeType{NoticeTypeGroup, NoticeTypeBan},
+				HasNoticeTypeFilter: true,
+			},
+		},
+		{
+			name: "metadata can be reversed",
+			raw:  "QQ:12345:only=send:disable",
+			want: NoticeTarget{
+				ID:                  "QQ:12345",
+				Disabled:            true,
+				NoticeTypes:         []NoticeType{NoticeTypeSend},
+				HasNoticeTypeFilter: true,
+			},
+		},
+		{
+			name: "embedded colon is retained",
+			raw:  "OpenQQ-Group:100-abc-OpenQQ:100-user:disable:only=group",
+			want: NoticeTarget{
+				ID:                  "OpenQQ-Group:100-abc-OpenQQ:100-user",
+				Disabled:            true,
+				NoticeTypes:         []NoticeType{NoticeTypeGroup},
+				HasNoticeTypeFilter: true,
+			},
+		},
+		{
+			name: "empty filter allows no categories",
+			raw:  "Mail:user@example.com:only=",
+			want: NoticeTarget{
+				ID:                  "Mail:user@example.com",
+				NoticeTypes:         []NoticeType{},
+				HasNoticeTypeFilter: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := normalizeForCompare(ParseNoticeTarget(test.raw))
+			want := normalizeForCompare(test.want)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("ParseNoticeTarget(%q) = %#v, want %#v", test.raw, got, want)
+			}
+		})
+	}
+}
+
+func TestNoticeTargetAllows(t *testing.T) {
+	legacy := ParseNoticeTarget("QQ:1")
+	if !legacy.Allows(NoticeTypeGroup) || !legacy.Allows(NoticeTypeSend) {
+		t.Fatal("legacy target should allow every category")
+	}
+
+	filtered := ParseNoticeTarget("QQ:1:only=group,ban")
+	if !filtered.Allows(NoticeTypeGroup) || !filtered.Allows(NoticeTypeBan) {
+		t.Fatal("filtered target should allow selected categories")
+	}
+	if filtered.Allows(NoticeTypeSend) {
+		t.Fatal("filtered target should reject unselected categories")
+	}
+
+	disabled := ParseNoticeTarget("QQ:1:disable:only=group")
+	if disabled.Allows(NoticeTypeGroup) {
+		t.Fatal("disabled target should reject every category")
+	}
+}
+
+func TestNoticeTargetString(t *testing.T) {
+	tests := map[string]string{
+		"QQ:1":                "QQ:1",
+		"QQ:1:disable":        "QQ:1:disable",
+		"QQ:1:only=ban,group": "QQ:1:only=group,ban",
+		"QQ:1:only=system,send,inactive,censor,ban,invite,group": "QQ:1",
+		"QQ:1:disable:only=": "QQ:1:disable:only=",
+	}
+
+	for raw, want := range tests {
+		if got := ParseNoticeTarget(raw).String(); got != want {
+			t.Errorf("ParseNoticeTarget(%q).String() = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestNoticeTargetAddressing(t *testing.T) {
+	tests := []struct {
+		raw      string
+		platform string
+		group    bool
+	}{
+		{raw: "QQ:1:disable", platform: "QQ", group: false},
+		{raw: "QQ-Group:1:only=group", platform: "QQ", group: true},
+		{raw: "DISCORD-CH-Channel:1", platform: "DISCORD", group: true},
+		{raw: "Mail:user@example.com", platform: "Mail", group: false},
+	}
+
+	for _, test := range tests {
+		target := ParseNoticeTarget(test.raw)
+		platform, ok := target.Platform()
+		if !ok || platform != test.platform {
+			t.Errorf("%q platform = %q, %t; want %q, true", test.raw, platform, ok, test.platform)
+		}
+		if got := target.IsGroup(); got != test.group {
+			t.Errorf("%q IsGroup() = %t, want %t", test.raw, got, test.group)
+		}
+	}
+}

--- a/dice/notice_test.go
+++ b/dice/notice_test.go
@@ -139,3 +139,30 @@ func TestNoticeTargetAddressing(t *testing.T) {
 		}
 	}
 }
+
+func TestNoticeTargetMatchesEndpoint(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		platform     string
+		protocolType string
+		want         bool
+	}{
+		{name: "ordinary QQ target matches onebot", raw: "QQ:1", platform: "QQ", protocolType: "onebot", want: true},
+		{name: "ordinary QQ target rejects official", raw: "QQ:1", platform: "QQ", protocolType: "official", want: false},
+		{name: "OpenQQ target matches official", raw: "OpenQQ:100-user", platform: "QQ", protocolType: "official", want: true},
+		{name: "OpenQQ group rejects onebot", raw: "OpenQQ-Group:100-group", platform: "QQ", protocolType: "onebot", want: false},
+		{name: "OpenQQ channel matches official", raw: "OpenQQCH-Channel:guild-channel", platform: "QQ", protocolType: "official", want: true},
+		{name: "Discord target matches Discord", raw: "DISCORD:1", platform: "DISCORD", protocolType: "", want: true},
+		{name: "Discord target rejects QQ", raw: "DISCORD:1", platform: "QQ", protocolType: "onebot", want: false},
+		{name: "mail is not an instant-message endpoint", raw: "Mail:user@example.com", platform: "Mail", protocolType: "", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ParseNoticeTarget(test.raw).MatchesEndpoint(test.platform, test.protocolType); got != test.want {
+				t.Fatalf("MatchesEndpoint(%q, %q) = %t, want %t", test.platform, test.protocolType, got, test.want)
+			}
+		})
+	}
+}

--- a/dice/official_qq_identity_migration.go
+++ b/dice/official_qq_identity_migration.go
@@ -1328,8 +1328,10 @@ func (m *officialQQIdentityMigration) migrateMemory(d *Dice) {
 	for index, id := range d.DiceMasters {
 		d.DiceMasters[index] = m.migrateAnyID(id)
 	}
-	for index, id := range d.Config.NoticeIDs {
-		d.Config.NoticeIDs[index] = m.migrateAnyID(id)
+	for index, rawTarget := range d.Config.NoticeIDs {
+		target := ParseNoticeTarget(rawTarget)
+		target.ID = m.migrateAnyID(target.ID)
+		d.Config.NoticeIDs[index] = target.String()
 	}
 	d.Config.UpgradeWindowID = m.migrateAnyID(d.Config.UpgradeWindowID)
 

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -642,7 +642,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			userName := dm.TryGetUserName(uid)
 			txt := fmt.Sprintf("收到QQ加群邀请: 群组<%s>(%s) 邀请人:<%s>(%s)", groupName, msgQQ.GroupID, userName, msgQQ.UserID)
 			log.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeInvite)
 			tempInviteMap[msg.GroupID] = time.Now().Unix()
 			tempInviteMap2[msg.GroupID] = uid
 
@@ -757,7 +757,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 			txt := fmt.Sprintf("收到QQ好友邀请: 邀请人:%s, 验证信息: %s, 是否自动同意: %t%s", msgQQ.UserID, comment, willAccept, extra)
 			log.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeInvite)
 
 			// 忽略邀请
 			if pa.IgnoreFriendRequest {
@@ -892,7 +892,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			}()
 			txt := fmt.Sprintf("加入QQ群组: <%s>(%s)", groupName, msgQQ.GroupID)
 			log.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeGroup)
 			if groupInfo, ok := ctx.Session.ServiceAtNew.Load(msg.GroupID); ok {
 				groupInfo.TriggerExtHook(ctx.Dice, func(ext *ExtInfo) func() {
 					if ext.OnGroupJoined == nil {
@@ -995,7 +995,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, msgQQ.GroupID)
 				log.Error(txtErr)
 				if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
-					ctx.Notice(txtErr)
+					ctx.Notice(txtErr, NoticeTypeGroup)
 				}
 				return
 			}
@@ -1004,7 +1004,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			group.MarkDirty(ctx.Dice)
 			log.Info(txt)
 			if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
-				ctx.Notice(txt)
+				ctx.Notice(txt, NoticeTypeGroup)
 			}
 			return
 		}
@@ -1020,7 +1020,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				ctx.Dice.Config.BanList.AddScoreByGroupMuted(opUID, msg.GroupID, ctx)
 				txt := fmt.Sprintf("被禁言: 在群组<%s>(%s)中被禁言，时长%d秒，操作者:<%s>(%s)", groupName, msgQQ.GroupID, msgQQ.Duration, userName, msgQQ.OperatorID)
 				log.Info(txt)
-				ctx.Notice(txt)
+				ctx.Notice(txt, NoticeTypeGroup)
 			}
 			return
 		}
@@ -1039,7 +1039,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				pa.riskAlertShieldCount--
 			} else {
 				log.Warn("群消息发送失败: 账号可能被风控")
-				_ = ctx.Dice.SendMail("群消息发送失败: 账号可能被风控", MailTypeCIAMLock)
+				_ = ctx.Dice.SendMail("群消息发送失败: 账号可能被风控", MailTypeCIAMLock, NoticeTypeSystem)
 			}
 		}
 
@@ -1104,7 +1104,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		lastDisconnect = now
 
 		log.Info("onebot 服务的连接被对方关闭")
-		_ = pa.EndPoint.Session.Parent.SendMail("", MailTypeConnectClose)
+		_ = pa.EndPoint.Session.Parent.SendMail("", MailTypeConnectClose, NoticeTypeSystem)
 		pa.InPackGoCqhttpDisconnectedCH <- 1
 	}
 

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -332,7 +332,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 			ctx.Dice.Config.BanList.AddScoreByGroupMuted(opUID, groupId, ctx)
 			txt := fmt.Sprintf("被禁言: 在群组<%s>(%s)中被禁言，时长%d秒，操作者:<%s>(%d)", groupName, groupId, m.Duration, userName, m.OperatorID)
 			log.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeGroup)
 		}
 	})
 	session.AddHandler(func(session2 *milky.Session, m *milky.FriendRequest) {
@@ -353,7 +353,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		userName := dm.TryGetUserName(uid)
 		txt := fmt.Sprintf("收到QQ加群邀请: 群组<%s>(%s) 邀请人:<%s>(%d)", groupName, groupId, userName, m.InitiatorID)
 		log.Info(txt)
-		ctx.Notice(txt)
+		ctx.Notice(txt, NoticeTypeInvite)
 
 		// 邀请人在黑名单上
 		banInfo, ok := ctx.Dice.Config.BanList.GetByID(uid)
@@ -507,7 +507,7 @@ func (pa *PlatformAdapterMilky) handelFriendRequest(ctx *MsgContext, event *milk
 
 	txt := fmt.Sprintf("收到QQ好友邀请: 邀请人:%s, 验证信息: %s, 是否自动同意: %t%s", strconv.FormatInt(event.InitiatorID, 10), comment, willAccept, extra)
 	log.Info(txt)
-	ctx.Notice(txt)
+	ctx.Notice(txt, NoticeTypeInvite)
 
 	// 忽略邀请
 	if pa.IgnoreFriendRequest {

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -159,7 +159,7 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 			txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, groupId)
 			p.logger.Error(txtErr)
 			if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
-				ctx.Notice(txtErr)
+				ctx.Notice(txtErr, NoticeTypeGroup)
 			}
 			return nil
 		}
@@ -167,7 +167,7 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 		group.MarkDirty(session.Parent)
 		p.logger.Info(txt)
 		if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeGroup)
 		}
 	}
 
@@ -223,7 +223,7 @@ func (p *PlatformAdapterOnebot) handleGroupBanAction(req gjson.Result, _ *evsock
 			ctx.Dice.Config.BanList.AddScoreByGroupMuted(operatorID, groupId, ctx)
 			txt := fmt.Sprintf("被禁言: 在群组<%s>(%s)中被禁言，时长%d秒，操作者:<%s>(%s)", groupName, groupId, duration, userName, operatorID)
 			p.logger.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeGroup)
 		}
 	}
 	return nil
@@ -377,7 +377,7 @@ func (p *PlatformAdapterOnebot) handleReqGroupAction(req gjson.Result, _ *evsock
 		_ = p.submitAsync(func() {
 			txt := fmt.Sprintf("收到QQ加群邀请: 群组<%s>(%s) 邀请人:<%s>(%s)", res.GroupName, res.GroupId, userName, diceUserId)
 			p.logger.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeInvite)
 			err := p.sendEmitter.SetGroupAddRequest(p.ctx, req.Get("flag").String(), true, "")
 			if err != nil {
 				p.logger.Errorf("处理加群请求时发送消息失败 %s", err)
@@ -439,7 +439,7 @@ func (p *PlatformAdapterOnebot) handleReqFriendAction(req gjson.Result, _ *evsoc
 	}
 	txt := fmt.Sprintf("收到QQ好友邀请: 邀请人:%s, 验证信息: %s, 是否自动同意: %t%s", req.Get("user_id").String(), comment, passQuestion && result.Passed, extra)
 	p.logger.Info(txt)
-	ctx.Notice(txt)
+	ctx.Notice(txt, NoticeTypeInvite)
 	// 若忽略邀请，对操作不通过也不拒绝，哪怕他是黑名单里的
 	if !p.IgnoreFriendRequest {
 		err := p.sendEmitter.SetFriendAddRequest(p.ctx, req.Get("flag").String(), result.Passed && passQuestion, "")

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -274,7 +274,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 			}()
 			txt := fmt.Sprintf("加入QQ群组: <%s>(%s)", groupName, event.GroupID)
 			log.Info(txt)
-			ctx.Notice(txt)
+			ctx.Notice(txt, NoticeTypeGroup)
 		}
 
 		// 入群的另一种情况: 管理员审核
@@ -426,14 +426,14 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 
 					txt := fmt.Sprintf("被踢出群: 在QQ群组<%s>(%s)中被踢出，操作者:<%s>(%s)%s", groupName, event.GroupID, userName, n.OperatorID, extra)
 					log.Info(txt)
-					ctx.Notice(txt)
+					ctx.Notice(txt, NoticeTypeGroup)
 				}
 			case "group_member_ban": // 被禁言
 				if event.UserID == event.Self.UserID {
 					ctx.Dice.Config.BanList.AddScoreByGroupMuted(opUID, msg.GroupID, ctx)
 					txt := fmt.Sprintf("被禁言: 在群组<%s>(%s)中被禁言，时长%d秒，操作者:<%s>(%s)", groupName, msg.GroupID, n.Duration, userName, n.OperatorID)
 					log.Info(txt)
-					ctx.Notice(txt)
+					ctx.Notice(txt, NoticeTypeGroup)
 				}
 				return
 			case "group_message_delete": // 消息撤回
@@ -529,7 +529,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 
 				txt := fmt.Sprintf("收到QQ好友邀请: 邀请人:%s, 验证信息: %s, 是否自动同意: %t%s", event.UserID, comment, willAccept, extra)
 				log.Info(txt)
-				ctx.Notice(txt)
+				ctx.Notice(txt, NoticeTypeInvite)
 
 				// 忽略邀请
 				if pa.IgnoreFriendRequest {
@@ -560,7 +560,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 				userName := dm.TryGetUserName(uid)
 				txt := fmt.Sprintf("收到QQ加群邀请: 群组<%s>(%s) 邀请人:<%s>(%s)", groupName, event.GroupID, userName, event.UserID)
 				log.Info(txt)
-				ctx.Notice(txt)
+				ctx.Notice(txt, NoticeTypeInvite)
 				// tempInviteMap[msg.GroupId] = time.Now().Unix()
 				// tempInviteMap2[msg.GroupId] = uid
 

--- a/dice/utils_email.go
+++ b/dice/utils_email.go
@@ -30,9 +30,14 @@ func (d *Dice) CanSendMail() bool {
 	return true
 }
 
-func (d *Dice) SendMail(body string, m MailCode) error {
+// SendMail 向允许接收该分类的通知目标发送邮件。
+func (d *Dice) SendMail(body string, m MailCode, noticeTypes ...NoticeType) error {
 	if !d.CanSendMail() {
 		return errors.New("邮件配置不完整")
+	}
+	noticeType := NoticeTypeSystem
+	if len(noticeTypes) > 0 {
+		noticeType = noticeTypes[0]
 	}
 	sub := "Seal News: "
 	switch m {
@@ -48,13 +53,16 @@ func (d *Dice) SendMail(body string, m MailCode) error {
 		sub += "Test 测试邮件"
 	}
 	var to []string
-	for _, id := range d.Config.NoticeIDs {
-		if strings.HasPrefix(id, "QQ:") {
-			to = append(to, id[3:]+"@qq.com")
+	for _, target := range filterNoticeTargets(d.Config.NoticeIDs, noticeType) {
+		if strings.HasPrefix(target.ID, "QQ:") {
+			to = append(to, target.ID[3:]+"@qq.com")
 		}
-		if strings.HasPrefix(id, "Mail:") {
-			to = append(to, id[5:])
+		if strings.HasPrefix(target.ID, "Mail:") {
+			to = append(to, target.ID[5:])
 		}
+	}
+	if len(to) == 0 {
+		return errors.New("没有启用且允许接收此类通知的邮件目标")
 	}
 
 	d.SendMailRow(sub, to, body, nil)

--- a/migrate/v2/MIGRATIONS.md
+++ b/migrate/v2/MIGRATIONS.md
@@ -28,6 +28,7 @@
 | `008_V160LogIDZeroCleanMigration` | v1.6.0 | log_id=0 清理 | 删除 log_items.log_id=0 与 logs.id=0 的残留并重算 size |
 | `009_V160LogRawMsgIDIndexMigration` | v1.6.0 | 日志复合索引 | 为 log_items 建 `(group_id, raw_msg_id, id)` 复合索引 |
 | `010_V160LogSizeRepairMigration` | v1.6.0 | logs.size 兜底修复 | 补建缺失的 size 列并全量重算（兜底 V150 失误） |
+| `011_V161NoticeIDsMigration` | v1.6.1 | 骰主通知目标初始化 | 将骰主 ID 一次性补入通知列表，仅开启 send 通知 |
 
 > ⚠️ ID 冲突提醒：`007_` 前缀同时被 `V150FixGroupInfoMigration` 与 `V151GORMCleanMigration` 使用，靠后缀字典序保证 V150 先于 V151 执行。代码内多处 `TODO` 标注“需要合理的生成逻辑”，建议后续改为更稳健的编号方案。
 
@@ -134,6 +135,14 @@
 - **失败**：返回错误 → 中断升级。
 - **设计说明**：用裸 `db.Exec` 而非 `db.Model().Update()`，以绕开 GORM “无 WHERE 的批量更新”保护——这里确实需要更新全部行；相关子查询与 008 重算口径完全一致，三种数据库均支持。
 
+### 011 — V161NoticeIDsMigration（骰主通知目标初始化）
+
+- **触发条件**：存在 `data/default/serve.yaml`；新安装尚未生成配置文件时跳过，由默认配置初始化。
+- **行为**：按实际 ID（忽略既有 `disable` / `only=` 后缀）保留已有通知目标；将尚未出现的骰主 ID 以 `ID:only=send` 形式追加到 `noticeIds`，仅允许接收 send 分类通知。
+- **仅执行一次**：升级框架记录迁移完成状态；用户之后手动清空通知列表，不会在后续启动时被重新填充。
+- **新安装**：默认骰主 `UI:1001` 同时也是默认通知目标，无需等待配置迁移。
+- **失败**：配置读取、解析或写入失败时返回错误并中断升级，以免迁移被错误标记为完成。
+
 ---
 
 ## size 语义（请重点审阅）
@@ -158,6 +167,7 @@
 - `v120_test.go`：V120 自检守卫（`attrs` 存在 → 跳过迁移 + 重命名 `data.bdb`）。
 - `v160_log_size_test.go`：010 的“补建缺失列+重算”、“已有列重算”、“无 logs 表无操作”。
 - `v160_logid0_test.go`：008 的“清理+重算”、“size 列缺失时不报错”、“无数据无操作”。
+- `v161/v161_test.go`、`v161_notice_ids_test.go`：011 的“合并且去重”、“缺少配置时跳过”，以及迁移完成后用户手动清空不会再次填充。
 - `full_flow_test.go`：用 `testdata/full_setup_logs.sql` + `testdata/full_setup_data.sql` 造假库，跑完整 V120→V010 链路并断言结果，再跑第二次验证幂等。
 
 测试仅覆盖 SQLite（本仓库无 MySQL/PG 的 CI 实例）；迁移代码本身对三种数据库都做了分支处理。

--- a/migrate/v2/enter.go
+++ b/migrate/v2/enter.go
@@ -10,6 +10,7 @@ import (
 	v150 "sealdice-core/migrate/v2/v150"
 	v151 "sealdice-core/migrate/v2/v151"
 	v160 "sealdice-core/migrate/v2/v160"
+	v161 "sealdice-core/migrate/v2/v161"
 	"sealdice-core/utils/constant"
 	operator "sealdice-core/utils/dboperator/engine"
 	upgrade "sealdice-core/utils/upgrader"
@@ -40,6 +41,8 @@ func InitUpgrader(operator operator.DatabaseOperator) error {
 	mgr.Register(v160.V160LogIDZeroCleanMigration)
 	mgr.Register(v160.V160LogRawMsgIDIndexMigration)
 	mgr.Register(v160.V160LogSizeRepairMigration)
+	// v161注册
+	mgr.Register(v161.V161NoticeIDsMigration)
 	err := mgr.ApplyAll()
 	if err != nil {
 		return err

--- a/migrate/v2/v161/v161.go
+++ b/migrate/v2/v161/v161.go
@@ -1,0 +1,111 @@
+package v161
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	operator "sealdice-core/utils/dboperator/engine"
+	upgrade "sealdice-core/utils/upgrader"
+)
+
+const defaultServeConfigPath = "data/default/serve.yaml"
+
+// V161CopyDiceMastersToNoticeIDs 将骰主 ID 一次性补入通知列表。
+//
+// 已有通知目标会被保留；完全相同的 ID 不会重复添加。此函数本身保持可重复执行，
+// “仅执行一次”由升级框架的迁移记录保证。
+func V161CopyDiceMastersToNoticeIDs(configPath string) (int, error) {
+	content, err := os.ReadFile(filepath.Clean(configPath))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// 新安装此时还没有 serve.yaml，由运行期默认配置负责初始化通知列表。
+			return 0, nil
+		}
+		return 0, err
+	}
+
+	var config struct {
+		DiceMasters []string `yaml:"diceMasters"`
+		NoticeIDs   []string `yaml:"noticeIds"`
+	}
+	if err = yaml.Unmarshal(content, &config); err != nil {
+		return 0, err
+	}
+
+	existing := make(map[string]struct{}, len(config.NoticeIDs))
+	for _, target := range config.NoticeIDs {
+		if id := noticeTargetID(target); id != "" {
+			existing[id] = struct{}{}
+		}
+	}
+
+	added := 0
+	for _, rawID := range config.DiceMasters {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			continue
+		}
+		if _, ok := existing[id]; ok {
+			continue
+		}
+		config.NoticeIDs = append(config.NoticeIDs, id+":only=send")
+		existing[id] = struct{}{}
+		added++
+	}
+	if added == 0 {
+		return 0, nil
+	}
+
+	var data map[string]any
+	if err = yaml.Unmarshal(content, &data); err != nil {
+		return 0, err
+	}
+	data["noticeIds"] = config.NoticeIDs
+
+	modified, err := yaml.Marshal(data)
+	if err != nil {
+		return 0, err
+	}
+	if err = os.WriteFile(filepath.Clean(configPath), modified, 0o644); err != nil {
+		return 0, err
+	}
+	return added, nil
+}
+
+// noticeTargetID 提取兼容旧格式通知目标中的实际 ID。
+// 元数据只从末尾识别，避免截断 OpenQQ 等本身含有多个冒号的 ID。
+func noticeTargetID(raw string) string {
+	parts := strings.Split(strings.TrimSpace(raw), ":")
+	end := len(parts)
+	for end > 1 {
+		suffix := strings.TrimSpace(parts[end-1])
+		if suffix == "disable" || strings.HasPrefix(suffix, "only=") {
+			end--
+			continue
+		}
+		break
+	}
+	return strings.TrimSpace(strings.Join(parts[:end], ":"))
+}
+
+var V161NoticeIDsMigration = upgrade.Upgrade{
+	ID: "011_V161NoticeIDsMigration",
+	Description: `
+# 升级说明
+将骰主 ID 一次性补入通知列表，并仅开启 send 分类，避免升级后骰主收不到代发通知。
+`,
+	Apply: func(logf func(string), _ operator.DatabaseOperator) error {
+		logf("[INFO] V161 通知列表迁移开始")
+		added, err := V161CopyDiceMastersToNoticeIDs(defaultServeConfigPath)
+		if err != nil {
+			return fmt.Errorf("迁移骰主 ID 到通知列表失败: %w", err)
+		}
+		logf(fmt.Sprintf("[INFO] V161 通知列表迁移完成，新增 %d 个通知目标", added))
+		return nil
+	},
+}

--- a/migrate/v2/v161/v161_test.go
+++ b/migrate/v2/v161/v161_test.go
@@ -1,10 +1,12 @@
-package v161
+package v161_test
 
 import (
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	v161 "sealdice-core/migrate/v2/v161"
 
 	"gopkg.in/yaml.v3"
 )
@@ -28,7 +30,7 @@ commandPrefix:
 		t.Fatal(err)
 	}
 
-	added, err := V161CopyDiceMastersToNoticeIDs(configPath)
+	added, err := v161.V161CopyDiceMastersToNoticeIDs(configPath)
 	if err != nil {
 		t.Fatalf("迁移失败: %v", err)
 	}
@@ -57,7 +59,7 @@ commandPrefix:
 }
 
 func TestV161CopyDiceMastersToNoticeIDsMissingConfigIsNoOp(t *testing.T) {
-	added, err := V161CopyDiceMastersToNoticeIDs(filepath.Join(t.TempDir(), "serve.yaml"))
+	added, err := v161.V161CopyDiceMastersToNoticeIDs(filepath.Join(t.TempDir(), "serve.yaml"))
 	if err != nil {
 		t.Fatalf("新安装缺少 serve.yaml 时应直接跳过: %v", err)
 	}

--- a/migrate/v2/v161/v161_test.go
+++ b/migrate/v2/v161/v161_test.go
@@ -1,0 +1,67 @@
+package v161
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestV161CopyDiceMastersToNoticeIDs(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "serve.yaml")
+	content := []byte(`
+diceMasters:
+  - QQ:10001
+  - UI:1001
+  - QQ:10001
+  - QQ:30003
+noticeIds:
+  - QQ:20002
+  - UI:1001
+  - QQ:30003:disable
+commandPrefix:
+  - .
+`)
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := V161CopyDiceMastersToNoticeIDs(configPath)
+	if err != nil {
+		t.Fatalf("迁移失败: %v", err)
+	}
+	if added != 1 {
+		t.Fatalf("期望新增 1 个通知目标，实际新增 %d 个", added)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		NoticeIDs     []string `yaml:"noticeIds"`
+		CommandPrefix []string `yaml:"commandPrefix"`
+	}
+	if err = yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"QQ:20002", "UI:1001", "QQ:30003:disable", "QQ:10001:only=send"}
+	if !reflect.DeepEqual(got.NoticeIDs, want) {
+		t.Fatalf("通知列表不符，期望 %v，实际 %v", want, got.NoticeIDs)
+	}
+	if !reflect.DeepEqual(got.CommandPrefix, []string{"."}) {
+		t.Fatalf("无关配置不应丢失，实际 commandPrefix=%v", got.CommandPrefix)
+	}
+}
+
+func TestV161CopyDiceMastersToNoticeIDsMissingConfigIsNoOp(t *testing.T) {
+	added, err := V161CopyDiceMastersToNoticeIDs(filepath.Join(t.TempDir(), "serve.yaml"))
+	if err != nil {
+		t.Fatalf("新安装缺少 serve.yaml 时应直接跳过: %v", err)
+	}
+	if added != 0 {
+		t.Fatalf("缺少配置文件时新增数量应为 0，实际 %d", added)
+	}
+}

--- a/migrate/v2/v161_notice_ids_test.go
+++ b/migrate/v2/v161_notice_ids_test.go
@@ -1,0 +1,68 @@
+package v2_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	v161 "sealdice-core/migrate/v2/v161"
+	"sealdice-core/migrate/v2/v2test"
+	"sealdice-core/utils/constant"
+	upgrade "sealdice-core/utils/upgrader"
+	"sealdice-core/utils/upgrader/store"
+)
+
+func TestV161NoticeIDsMigrationRunsOnlyOnce(t *testing.T) {
+	op, _ := v2test.NewTestSQLiteEngine(t)
+	workDir := t.TempDir()
+	configDir := filepath.Join(workDir, "data", "default")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(configDir, "serve.yaml")
+	if err := os.WriteFile(configPath, []byte("diceMasters: [QQ:10001]\nnoticeIds: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWorkDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = os.Chdir(workDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWorkDir) })
+
+	mgr := &upgrade.Manager{
+		Store:    store.NewGormStore(op.GetDataDB(constant.WRITE)),
+		Database: op,
+	}
+	mgr.Register(v161.V161NoticeIDsMigration)
+	if err = mgr.ApplyAll(); err != nil {
+		t.Fatalf("首次迁移失败: %v", err)
+	}
+
+	// 模拟用户在迁移完成后手动清空通知列表。
+	if err = os.WriteFile(configPath, []byte("diceMasters: [QQ:10001]\nnoticeIds: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err = mgr.ApplyAll(); err != nil {
+		t.Fatalf("第二次启动失败: %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		NoticeIDs []string `yaml:"noticeIds"`
+	}
+	if err = yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.NoticeIDs) != 0 {
+		t.Fatalf("迁移完成后用户手动清空的通知列表不应再次填充，实际 %v", got.NoticeIDs)
+	}
+}

--- a/migrate/v2/v161_notice_ids_test.go
+++ b/migrate/v2/v161_notice_ids_test.go
@@ -30,10 +30,8 @@ func TestV161NoticeIDsMigrationRunsOnlyOnce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = os.Chdir(workDir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWorkDir) })
+	t.Chdir(workDir)
+	t.Cleanup(func() { t.Chdir(oldWorkDir) })
 
 	mgr := &upgrade.Manager{
 		Store:    store.NewGormStore(op.GetDataDB(constant.WRITE)),

--- a/migrate/v2/v2test/helpers.go
+++ b/migrate/v2/v2test/helpers.go
@@ -15,6 +15,7 @@ import (
 	v150 "sealdice-core/migrate/v2/v150"
 	v151 "sealdice-core/migrate/v2/v151"
 	v160 "sealdice-core/migrate/v2/v160"
+	v161 "sealdice-core/migrate/v2/v161"
 	"sealdice-core/utils/constant"
 	engine "sealdice-core/utils/dboperator/engine"
 	"sealdice-core/utils/dboperator/engine/sqlite"
@@ -86,6 +87,7 @@ func NewTestManager(t *testing.T, op engine.DatabaseOperator) *upgrade.Manager {
 	mgr.Register(v160.V160LogIDZeroCleanMigration)
 	mgr.Register(v160.V160LogRawMsgIDIndexMigration)
 	mgr.Register(v160.V160LogSizeRepairMigration)
+	mgr.Register(v161.V161NoticeIDsMigration)
 	return mgr
 }
 


### PR DESCRIPTION
重构：

- 扩展 Config.NoticeID，新增通知项目分类
- 重构 (*MsgContext).Notice 一类函数，接受通知分类
- 重构大部分通知流程，尽量使用上述函数
- 通知时统一使用 NoticeID 而非 masters

新增：

- 通知项可自定义启用/禁用，对哪些事件发送通知

值得商榷的点：`send` 命令名义上是“发给骰主”，那么使用 NoticeID 合理吗？

在本地测试了 send 和群事件通知，但限于本地开发环境，无法测试其他平台。

UI PR：https://github.com/sealdice/sealdice-ui/pull/311

closes #1741, closes #1285

## Summary by Sourcery

引入带类型的通知类别，并重构通知路由，以支持针对不同目标和通知类别的配置，同时保持对现有 NoticeID 格式的向后兼容性。

增强点：
- 重构消息和邮件通知辅助方法，使其接受通知类别，并基于解析后的 `NoticeTarget` 定义来路由消息。
- 新增 `NoticeTarget` 抽象以及解析/序列化逻辑，以支持禁用目标和有选择地启用通知类别，包括对现有 ID 和 OpenQQ 格式的兼容。
- 改进端点匹配逻辑，使通知从合适的平台/协议账号发出，包括对官方 QQ 的处理以及跨平台回退逻辑。
- 调整群组事件、封禁、邀请、审查、不活跃任务以及系统健康检查等各处的通知调用点，为消息标记合适的通知类别。

测试：
- 新增单元测试，覆盖 `NoticeTarget` 解析、类别过滤、字符串规范化、可寻址性以及端点匹配语义等内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce typed notice categories and refactor notification routing to support per-target, per-category configuration while preserving backward compatibility with existing NoticeID formats.

Enhancements:
- Refactor message and email notification helpers to accept notice categories and route messages based on parsed NoticeTarget definitions.
- Add a NoticeTarget abstraction and parsing/serialization logic to support disabling targets and selectively enabling notice categories, including compatibility with existing IDs and OpenQQ formats.
- Improve endpoint matching logic so notifications are sent from appropriate platform/protocol accounts, including official QQ handling and cross-platform fallbacks.
- Adjust notification call sites across group events, bans, invites, censorship, inactivity tasks, and system health checks to tag messages with appropriate notice categories.

Tests:
- Add unit tests for NoticeTarget parsing, category filtering, string normalization, addressability, and endpoint matching semantics.

</details>

## Summary by Sourcery

通过引入带类型的通知类别，并重构通知发送逻辑，实现按目标、按类别配置通知，同时保持现有通知 ID 的兼容性。

Enhancements:
- 新增 `NoticeType` 和 `NoticeTarget` 抽象，用于建模带分类的通知目标，支持启用/禁用以及按类别过滤。
- 优化路由逻辑，使通知能够在各平台间选择合适的发送端点，包括对 QQ 公众号的特殊处理以及跨平台回退机制。
- 更新通知辅助工具（`Notice`、`NoticeCrossPlatform`、`NoticeForEveryEndpoint`、`SendMail`），使其支持通知类别并遵守按目标配置的类别过滤。
- 将新安装的默认配置设为预配置的 UI 通知目标，并在配置及内存迁移中统一通知 ID 的处理方式。
- 增加一个配置迁移步骤，从现有的 `diceMasters` 中初始化 `noticeIds`，并仅为新添加的目标启用发送类别相关的通知。

Tests:
- 新增单元测试，用于验证 `NoticeTarget` 的解析、类别过滤、字符串规范化、可寻址性以及端点匹配。
- 新增迁移测试，验证 v1.6.1 的 `noticeIds` 初始化仅执行一次、保持无关配置不变，并在不存在 `serve.yaml` 时跳过迁移。
- 新增回归测试，确保默认的 `noticeIds` 始终与新安装中的默认 `diceMasters` 保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce typed notice categories and refactor notification delivery to support per-target, per-category configuration while keeping existing notice IDs compatible.

Enhancements:
- Add NoticeType and NoticeTarget abstractions to model categorized notification targets with enable/disable and per-category filtering.
- Refine routing logic so notifications choose appropriate endpoints across platforms, including special handling for official QQ accounts and cross-platform fallbacks.
- Update notification helpers (Notice, NoticeCrossPlatform, NoticeForEveryEndpoint, SendMail) to accept notice categories and respect per-target category filters.
- Default new installations to a preconfigured UI notice target and normalize notice ID handling in configuration and in-memory migrations.
- Add a configuration migration that seeds noticeIds from existing diceMasters, enabling only send-category notifications for newly added targets.

Tests:
- Add unit tests for NoticeTarget parsing, category filtering, string normalization, addressability, and endpoint matching.
- Add migration tests to verify v1.6.1 noticeIds seeding runs once, preserves unrelated config, and is skipped when no serve.yaml is present.
- Add a regression test ensuring the default noticeIds remain aligned with default diceMasters for new installations.

</details>