### PR TITLE
fix(official-qqbot): 修复了官方bot在迁移id后代骰依然使用旧id的问题

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -33,6 +33,7 @@ func (kwa *Kwarg) String() string {
 type AtInfo struct {
 	UserID  string `jsbind:"userId"  json:"userId"`
 	IsRobot bool   `jsbind:"isRobot" json:"isRobot"`
+	Name    string `jsbind:"name"    json:"name"`
 	// UID    string `json:"uid"`
 }
 
@@ -49,22 +50,45 @@ func (i *AtInfo) CopyCtx(ctx *MsgContext) (*MsgContext, bool) {
 	}
 
 	if ctx.Group != nil {
-		p := ctx.Group.PlayerGet(ctx.Dice.DBOperator, i.UserID)
+		playerUserID := i.UserID
+		officialQQUIN := ""
+		if ctx.EndPoint != nil {
+			if pa, ok := ctx.EndPoint.Adapter.(*PlatformAdapterOfficialQQ); ok {
+				officialQQUIN = pa.UIN
+				// 官方 QQ 的 @ 仅提供 MemberOpenID；人物卡则以
+				// OpenQQ:<UIN>-<MemberOpenID> 为键，代骰时必须先补全身份。
+				playerUserID = normalizeDiceIDOfficialQQMentionUserID(officialQQUIN, playerUserID)
+			}
+		}
+
+		p := ctx.Group.PlayerGet(ctx.Dice.DBOperator, playerUserID)
 		if p != nil {
-			mctx.Player = p
+			// 平台事件中的 @ 昵称只用于当前代骰消息。PlayerGet 可能返回
+			// 群缓存中的共享指针，因此必须复制后再补名称，不能修改原对象。
+			if p.Name == "" && i.Name != "" {
+				playerCopy := *p
+				playerCopy.Name = i.Name
+				mctx.Player = &playerCopy
+			} else {
+				mctx.Player = p
+			}
 		} else {
 			// TODO: 主动获取用户名
 			mctx.Player = &GroupPlayerInfo{
-				Name:          "",
-				UserID:        i.UserID,
+				Name:          i.Name,
+				UserID:        playerUserID,
 				ValueMapTemp:  &ds.ValueMap{},
 				UpdatedAtTime: 0,
 			}
 			// 特殊处理 official qq
-			if strings.HasPrefix(i.UserID, "OpenQQCH:") {
+			// 只有平台没有提供昵称时，才退回到可发送的 @ 文本。
+			if mctx.Player.Name == "" && strings.HasPrefix(i.UserID, "OpenQQCH:") {
 				mctx.Player.Name = "<@!" + strings.TrimPrefix(i.UserID, "OpenQQCH:") + ">"
-			} else if strings.HasPrefix(i.UserID, "OpenQQ:") {
-				mctx.Player.Name = "<@" + strings.TrimPrefix(i.UserID, "OpenQQ:") + ">"
+			} else if mctx.Player.Name == "" && strings.HasPrefix(i.UserID, "OpenQQ:") {
+				mentionTarget := strings.TrimPrefix(i.UserID, "OpenQQ:")
+				// 若调用方已经传入规范 ID，回复 QQ 时仍只能发送 MemberOpenID。
+				mentionTarget = strings.TrimPrefix(mentionTarget, officialQQUIN+"-")
+				mctx.Player.Name = "<@" + mentionTarget + ">"
 			}
 		}
 		return mctx, p != nil
@@ -189,7 +213,19 @@ func (cmdArgs *CmdArgs) RevokeExecuteTimesParse(ctx *MsgContext, msg *Message) {
 		cmdArgs.commandParseNew(ctx, msg, true)
 	} else {
 		cmdArgs.commandParse(cmdArgs.RawText, []string{cmdArgs.Command}, []string{cmdArgs.prefixStr}, cmdArgs.platformPrefix, true)
+		cmdArgs.applyMentionedInfo(msg)
 		cmdArgs.SetupAtInfo(cmdArgs.uidForAtInfo)
+	}
+}
+
+func (cmdArgs *CmdArgs) applyMentionedInfo(msg *Message) {
+	if cmdArgs == nil || msg == nil || len(msg.MentionedInfo) == 0 {
+		return
+	}
+	for _, at := range cmdArgs.At {
+		if name := msg.MentionedInfo[at.UserID]; name != "" {
+			at.Name = name
+		}
 	}
 }
 
@@ -355,6 +391,7 @@ func (cmdArgs *CmdArgs) commandParseNew(ctx *MsgContext, msg *Message, isParseEx
 	// === 第二步：解析@信息 ===
 	// 分析消息段中的@元素，设置机器人被@状态
 	parseAtInfo(cmdArgs, msg, ctx.EndPoint.UserID)
+	cmdArgs.applyMentionedInfo(msg)
 
 	// === 第三步：处理特殊执行次数和命令前缀 ===
 	restText := strings.TrimSpace(rawCmd)

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -58,6 +58,9 @@ type Message struct {
 	GroupName           string      `json:"groupName"`
 	TmpUID              string      `json:"-"             yaml:"-"`
 	UITestReplySplitLen *int        `json:"-"             yaml:"-"`
+	// MentionedInfo carries platform-provided display names keyed by normalized
+	// or legacy mention user ID. It is runtime metadata and is not persisted.
+	MentionedInfo map[string]string `json:"-" yaml:"-"`
 	// Note(Szzrain): 这里是消息段，为了支持多种消息类型，目前只有 Milky 支持，其他平台也应该尽快迁移支持，并使用 Session.ExecuteNew 方法
 	Segment []message.IMessageElement `jsbind:"segment" json:"-" yaml:"-"`
 }
@@ -974,6 +977,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 		platformPrefix := msg.Platform
 		cmdArgs := CommandParse(msg.Message, cmdLst, d.CommandPrefix, platformPrefix, false)
 		if cmdArgs != nil {
+			cmdArgs.applyMentionedInfo(msg)
 			mctx.CommandID = getNextCommandID()
 
 			var tmpUID string

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -863,6 +863,7 @@ func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(event *dto.WSPayload, msgQ
 		msg.Sender.UserID = formatDiceIDOfficialQQMemberOpenID(pa.UIN, msgQQ.GroupOpenID, msgQQ.Author.MemberOpenID)
 		msg.Sender.GroupRole = msgQQ.Author.MemberRole
 	}
+	pa.populateGroupMentionedInfo(msg, msgQQ.Mentions)
 
 	botSelfOpenID := pa.parseBotSelfOpenID(event)
 
@@ -914,6 +915,7 @@ func (pa *PlatformAdapterOfficialQQ) groupNormalMsgToStdMsg(event *dto.WSPayload
 		msg.Sender.UserID = formatDiceIDOfficialQQMemberOpenID(pa.UIN, msgQQ.GroupOpenID, msgQQ.Author.MemberOpenID)
 		msg.Sender.GroupRole = msgQQ.Author.MemberRole
 	}
+	pa.populateGroupMentionedInfo(msg, msgQQ.Mentions)
 
 	botSelfOpenID := pa.parseBotSelfOpenID(event)
 
@@ -1963,6 +1965,47 @@ func formatDiceIDOfficialQQGroupOpenID(uin, groupOpenID string) string {
 func formatDiceIDOfficialQQMemberOpenID(uin, _ string, memberOpenID string) string {
 	// 官方QQ群成员ID格式
 	return fmt.Sprintf("%s%s-%s", officialQQUserIDPrefix, uin, memberOpenID)
+}
+
+func (pa *PlatformAdapterOfficialQQ) populateGroupMentionedInfo(msg *Message, mentions []*dto.User) {
+	for _, mentioned := range mentions {
+		if mentioned == nil {
+			continue
+		}
+		memberOpenID := strings.TrimSpace(mentioned.MemberOpenID)
+		if memberOpenID == "" {
+			memberOpenID = strings.TrimSpace(mentioned.ID)
+		}
+		nickname := strings.TrimSpace(mentioned.Username)
+		if memberOpenID == "" || nickname == "" {
+			continue
+		}
+		if msg.MentionedInfo == nil {
+			msg.MentionedInfo = map[string]string{}
+		}
+
+		// 官方 QQ 的消息正文仍使用裸 MemberOpenID，而人物卡使用规范 ID；
+		// 同时记录两种键，让旧字符串解析和未来的消息段解析都能取得昵称。
+		msg.MentionedInfo[officialQQUserIDPrefix+memberOpenID] = nickname
+		msg.MentionedInfo[formatDiceIDOfficialQQMemberOpenID(pa.UIN, "", memberOpenID)] = nickname
+	}
+}
+
+// normalizeDiceIDOfficialQQMentionUserID converts the bare MemberOpenID carried
+// by an official QQ mention into the canonical user ID used by player cards.
+// Mentions currently arrive as OpenQQ:<MemberOpenID>, while senders and stored
+// attributes use OpenQQ:<UIN>-<MemberOpenID>.
+func normalizeDiceIDOfficialQQMentionUserID(uin, userID string) string {
+	raw, ok := strings.CutPrefix(userID, officialQQUserIDPrefix)
+	if !ok || uin == "" || raw == "" {
+		return userID
+	}
+
+	// Keep endpoint IDs and already-normalized user IDs unchanged.
+	if raw == uin || strings.HasPrefix(raw, uin+"-") {
+		return userID
+	}
+	return formatDiceIDOfficialQQMemberOpenID(uin, "", raw)
 }
 
 func formatDiceIDOfficialQQUserOpenID(uin, userOpenID string) string {

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -218,6 +218,192 @@ func TestOfficialQQIDRoundTrip(t *testing.T) {
 	}
 }
 
+func TestOfficialQQDelegatedContextUsesCanonicalMemberID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uin          = "3889204361"
+		memberOpenID = "B1F55BD9471139B4427175CC638920CB"
+	)
+	legacyMentionID := "OpenQQ:" + memberOpenID
+	canonicalUserID := formatDiceIDOfficialQQMemberOpenID(uin, "", memberOpenID)
+	targetPlayer := &GroupPlayerInfo{
+		Name:   "target",
+		UserID: canonicalUserID,
+	}
+	group := &GroupInfo{
+		Players: new(SyncMap[string, *GroupPlayerInfo]),
+	}
+	group.Players.Store(canonicalUserID, targetPlayer)
+	ctx := &MsgContext{
+		Dice:  &Dice{},
+		Group: group,
+		Player: &GroupPlayerInfo{
+			ValueMapTemp: &ds.ValueMap{},
+		},
+		EndPoint: &EndPointInfo{
+			Adapter: &PlatformAdapterOfficialQQ{UIN: uin},
+		},
+	}
+	ctx.CreateVmIfNotExists()
+	ctx.vm.StoreNameLocal("$tMsgID", ds.NewStrVal("test-message"))
+	ctx.vm.StoreNameLocal("$tEventID", ds.NewStrVal("test-event"))
+
+	// AtParse reflects the actual legacy command path: the wire mention contains
+	// only MemberOpenID, so CopyCtx must resolve it before looking up the player.
+	_, mentions := AtParse("<@"+memberOpenID+"> .st show", "OpenQQ")
+	if len(mentions) != 1 || mentions[0].UserID != legacyMentionID {
+		t.Fatalf("parsed mentions = %#v, want legacy ID %q", mentions, legacyMentionID)
+	}
+	delegatedCtx, found := mentions[0].CopyCtx(ctx)
+	if !found {
+		t.Fatal("canonical official QQ player was not found for delegated context")
+	}
+	if delegatedCtx.Player != targetPlayer || delegatedCtx.Player.UserID != canonicalUserID {
+		t.Fatalf("delegated player = %#v, want canonical ID %q", delegatedCtx.Player, canonicalUserID)
+	}
+}
+
+func TestOfficialQQDelegatedContextKeepsRawMentionTarget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uin          = "3889204361"
+		memberOpenID = "B1F55BD9471139B4427175CC638920CB"
+	)
+	ctx := &MsgContext{
+		Dice: &Dice{DBOperator: nil},
+		Group: &GroupInfo{
+			Players: new(SyncMap[string, *GroupPlayerInfo]),
+		},
+		Player: &GroupPlayerInfo{
+			ValueMapTemp: &ds.ValueMap{},
+		},
+		EndPoint: &EndPointInfo{
+			Adapter: &PlatformAdapterOfficialQQ{UIN: uin},
+		},
+	}
+	ctx.CreateVmIfNotExists()
+	ctx.vm.StoreNameLocal("$tMsgID", ds.NewStrVal("test-message"))
+	ctx.vm.StoreNameLocal("$tEventID", ds.NewStrVal("test-event"))
+	canonicalUserID := formatDiceIDOfficialQQMemberOpenID(uin, "", memberOpenID)
+	// Avoid a database lookup while exercising the fallback player-name path.
+	ctx.Group.Players.Store(canonicalUserID, nil)
+
+	delegatedCtx, found := (&AtInfo{UserID: canonicalUserID}).CopyCtx(ctx)
+	if found {
+		t.Fatal("unexpected existing player")
+	}
+	if delegatedCtx.Player.UserID != canonicalUserID {
+		t.Fatalf("delegated user ID = %q, want %q", delegatedCtx.Player.UserID, canonicalUserID)
+	}
+	if delegatedCtx.Player.Name != "<@"+memberOpenID+">" {
+		t.Fatalf("delegated mention name = %q, want raw MemberOpenID", delegatedCtx.Player.Name)
+	}
+}
+
+func TestOfficialQQDelegatedContextUsesMentionNickname(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uin          = "3889204361"
+		memberOpenID = "B1F55BD9471139B4427175CC638920CB"
+		nickname     = "(`ᝫ´ )"
+	)
+	pa := &PlatformAdapterOfficialQQ{UIN: uin}
+	msg := pa.groupNormalMsgToStdMsg(nil, &dto.WSGroupMessageData{
+		Content:     "<@" + memberOpenID + "> .st 测试100",
+		GroupOpenID: "group-open-id",
+		Mentions: []*dto.User{{
+			// Current group payloads may expose the mention target through id
+			// instead of member_openid; the adapter supports both forms.
+			ID:       memberOpenID,
+			Username: nickname,
+		}},
+	})
+	cmdArgs := CommandParse(msg.Message, []string{"st"}, []string{"."}, msg.Platform, false)
+	if cmdArgs == nil {
+		t.Fatal("delegated st command was not parsed")
+	}
+	cmdArgs.applyMentionedInfo(msg)
+	if len(cmdArgs.At) != 1 || cmdArgs.At[0].Name != nickname {
+		t.Fatalf("parsed mention = %#v, want nickname %q", cmdArgs.At, nickname)
+	}
+
+	canonicalUserID := formatDiceIDOfficialQQMemberOpenID(uin, "", memberOpenID)
+	ctx := &MsgContext{
+		Dice: &Dice{DBOperator: nil},
+		Group: &GroupInfo{
+			Players: new(SyncMap[string, *GroupPlayerInfo]),
+		},
+		Player: &GroupPlayerInfo{
+			ValueMapTemp: &ds.ValueMap{},
+		},
+		EndPoint: &EndPointInfo{Adapter: pa},
+	}
+	ctx.CreateVmIfNotExists()
+	ctx.vm.StoreNameLocal("$tMsgID", ds.NewStrVal("test-message"))
+	ctx.vm.StoreNameLocal("$tEventID", ds.NewStrVal("test-event"))
+	// Avoid a database lookup and force the same uncached-player branch as the log.
+	ctx.Group.Players.Store(canonicalUserID, nil)
+
+	delegatedCtx, found := cmdArgs.At[0].CopyCtx(ctx)
+	if found {
+		t.Fatal("unexpected existing player")
+	}
+	if delegatedCtx.Player.UserID != canonicalUserID {
+		t.Fatalf("delegated user ID = %q, want %q", delegatedCtx.Player.UserID, canonicalUserID)
+	}
+	if delegatedCtx.Player.Name != nickname {
+		t.Fatalf("delegated player name = %q, want mention nickname %q", delegatedCtx.Player.Name, nickname)
+	}
+}
+
+func TestOfficialQQDelegatedContextDoesNotMutateCachedPlayerName(t *testing.T) {
+	t.Parallel()
+
+	const (
+		uin          = "3889204361"
+		memberOpenID = "B1F55BD9471139B4427175CC638920CB"
+		nickname     = "(`ᝫ´ )"
+	)
+	canonicalUserID := formatDiceIDOfficialQQMemberOpenID(uin, "", memberOpenID)
+	cachedPlayer := &GroupPlayerInfo{
+		UserID:       canonicalUserID,
+		ValueMapTemp: &ds.ValueMap{},
+	}
+	group := &GroupInfo{Players: new(SyncMap[string, *GroupPlayerInfo])}
+	group.Players.Store(canonicalUserID, cachedPlayer)
+	ctx := &MsgContext{
+		Dice:   &Dice{},
+		Group:  group,
+		Player: &GroupPlayerInfo{ValueMapTemp: &ds.ValueMap{}},
+		EndPoint: &EndPointInfo{
+			Adapter: &PlatformAdapterOfficialQQ{UIN: uin},
+		},
+	}
+	ctx.CreateVmIfNotExists()
+	ctx.vm.StoreNameLocal("$tMsgID", ds.NewStrVal("test-message"))
+	ctx.vm.StoreNameLocal("$tEventID", ds.NewStrVal("test-event"))
+
+	delegatedCtx, found := (&AtInfo{
+		UserID: "OpenQQ:" + memberOpenID,
+		Name:   nickname,
+	}).CopyCtx(ctx)
+	if !found {
+		t.Fatal("cached player was not found")
+	}
+	if delegatedCtx.Player == cachedPlayer {
+		t.Fatal("delegated context reused the shared player while adding a message-only nickname")
+	}
+	if delegatedCtx.Player.Name != nickname {
+		t.Fatalf("delegated player name = %q, want %q", delegatedCtx.Player.Name, nickname)
+	}
+	if cachedPlayer.Name != "" {
+		t.Fatalf("shared cached player name was mutated to %q", cachedPlayer.Name)
+	}
+}
+
 func TestOfficialQQLegacyEmptyGroupIdentity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
官方bot迁移id后，代骰依旧走旧id获取，导致代骰失效；修复代骰id问题后同步修复了代骰时角色名显示问题

## 由 Sourcery 提供的摘要

确保官方 QQ 的委托掷骰在解析和显示提及目标时，使用规范的成员 ID 和平台提供的昵称。

错误修复：
- 修复官方 QQ 的委托上下文解析，使 @ 提及映射到迁移后的规范成员 ID，而不是旧版 ID，从而恢复委托掷骰的正常行为。
- 修复官方 QQ 上的委托掷骰显示，使被提及玩家名称使用平台昵称或原始提及目标，而不是为空或过期的名称。

增强功能：
- 在消息和指令解析过程中传递平台提供的提及元数据，丰富 AtInfo 的显示名称，以便在指令执行期间使用。

测试：
- 添加单元测试，覆盖官方 QQ 委托上下文 ID 规范化、原始提及名称回退逻辑，以及在委托掷骰中使用提及昵称的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure official QQ delegated rolls resolve and display mention targets using canonical member IDs and platform-provided nicknames.

Bug Fixes:
- Fix delegated context resolution for official QQ so @ mentions map to the migrated canonical member ID instead of the legacy ID, restoring delegated roll behavior.
- Fix delegated roll display on official QQ so mentioned player names use platform nicknames or the raw mention target rather than empty or stale names.

Enhancements:
- Propagate platform-provided mention metadata through messages and command parsing to enrich AtInfo with display names for use during command execution.

Tests:
- Add unit tests covering official QQ delegated context ID normalization, raw mention fallback naming, and use of mention nicknames during delegated rolls.

</details>