### PR TITLE
fix(official-qq): 修复ws没有接受群成员变动事件，添加主动消息排队，修改botgo仓库地址

### DIFF
--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -81,6 +81,11 @@ type PlatformAdapterOfficialQQ struct {
 	QrCodeData   []byte                    `json:"-"           yaml:"-"` // 当前二维码图片数据（PNG），参考 milky 的 QrCodeData
 	qrSession    *QQOfficialQrLoginSession `json:"-" yaml:"-"`
 	qrMu         sync.Mutex                `json:"-" yaml:"-"`
+
+	// 主动消息发送队列
+	c2cSendQuota   *OfficialQQSendQuota `json:"-" yaml:"-"`
+	groupSendQuota *OfficialQQSendQuota `json:"-" yaml:"-"`
+	sendQuotaMu    sync.Mutex           `json:"-" yaml:"-"`
 }
 
 type officialQQAdapterJSON struct {
@@ -494,6 +499,8 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 	if !pa.OnlyQQGuild {
 		// 群聊@消息、单聊、好友关系事件
 		intent |= dto.IntentGroupMessages
+		// 群成员进退群事件
+		intent |= dto.IntentGroupMembers
 	}
 
 	go func() {
@@ -1626,6 +1633,14 @@ func (pa *PlatformAdapterOfficialQQ) sendC2CMsgRaw(ctx *MsgContext, rowMsgID, us
 		if toCreate.Media == nil && toCreate.Content == "" && toCreate.Markdown == nil && toCreate.MessageReference == nil {
 			return
 		}
+		// 主动消息（无 msg_id/event_id）需要排队限流
+		if toCreate.MsgID == "" && toCreate.EventID == "" {
+			if err := pa.waitC2CActiveQuota(userOpenID); err != nil {
+				pa.EndPoint.Session.Parent.Logger.Error("official qq 发送单聊消息失败：" + err.Error())
+				lastErr = err
+				return
+			}
+		}
 		res, err := pa.Api.PostC2CMessage(qctx, userOpenID, toCreate)
 		if err != nil {
 			pa.EndPoint.Session.Parent.Logger.Error("official qq 发送单聊消息失败：" + err.Error())
@@ -1682,6 +1697,140 @@ func (pa *PlatformAdapterOfficialQQ) sendC2CMsgRaw(ctx *MsgContext, rowMsgID, us
 
 	sendCurrent(true)
 	return lastRes, lastErr
+}
+
+// 官方QQ主动消息频率限制：
+// 超出频率时消息进入排队，按预约顺序依次发出；
+const (
+	officialQQC2CBotLimit      = 10 // 单聊：10次/秒
+	officialQQC2CBotPeriod     = time.Second
+	officialQQGroupBotLimit    = 60 // 群聊：60次/分钟
+	officialQQGroupBotPeriod   = time.Minute
+	officialQQRelationLimit    = 20 // 单个用户/群：20次/分钟
+	officialQQRelationPeriod   = time.Minute
+	officialQQDailyLimit       = 1000            // 每日上限：1000条/用户或群
+	officialQQMaxQueueDelay    = 5 * time.Minute // 最大排队等待时长
+	officialQQRelationMapLimit = 2048            // 清理阈值
+)
+
+// OfficialQQSendQuota 主动消息发送队列。
+type OfficialQQSendQuota struct {
+	mu sync.Mutex
+
+	botLimit  int
+	botPeriod time.Duration
+	botStamps []time.Time
+
+	relStamps map[string][]time.Time
+
+	dailyDay   string
+	dailyCount map[string]int
+}
+
+// reserve 为 targetID 的一次主动发送预约时刻。
+func (q *OfficialQQSendQuota) reserve(targetID string) (time.Time, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	now := time.Now()
+
+	// 每日计数按本地日期重置
+	day := now.Format("2006-01-02")
+	if day != q.dailyDay {
+		q.dailyDay = day
+		q.dailyCount = make(map[string]int)
+	}
+	if q.dailyCount[targetID] >= officialQQDailyLimit {
+		return time.Time{}, fmt.Errorf("对 %s 的主动消息已达当日上限(%d条)", targetID, officialQQDailyLimit)
+	}
+
+	// 取两个窗口都允许的最早时刻
+	t := now
+	rel := q.relStamps[targetID]
+	if len(rel) >= officialQQRelationLimit {
+		if c := rel[len(rel)-officialQQRelationLimit].Add(officialQQRelationPeriod); c.After(t) {
+			t = c
+		}
+	}
+	if len(q.botStamps) >= q.botLimit {
+		if c := q.botStamps[len(q.botStamps)-q.botLimit].Add(q.botPeriod); c.After(t) {
+			t = c
+		}
+	}
+
+	if t.Sub(now) > officialQQMaxQueueDelay {
+		return time.Time{}, fmt.Errorf("对 %s 的主动消息排队等待超过 %v，放弃发送", targetID, officialQQMaxQueueDelay)
+	}
+
+	// 提交预约
+	rel = append(rel, t)
+	if len(rel) > officialQQRelationLimit {
+		rel = rel[len(rel)-officialQQRelationLimit:]
+	}
+	q.relStamps[targetID] = rel
+
+	q.botStamps = append(q.botStamps, t)
+	if len(q.botStamps) > q.botLimit {
+		q.botStamps = q.botStamps[len(q.botStamps)-q.botLimit:]
+	}
+
+	q.dailyCount[targetID]++
+
+	// 防止关系级记录无限增长，剔除窗口早已滑过的目标
+	if len(q.relStamps) > officialQQRelationMapLimit {
+		for id, stamps := range q.relStamps {
+			if len(stamps) == 0 || now.Sub(stamps[len(stamps)-1]) > officialQQRelationPeriod {
+				delete(q.relStamps, id)
+			}
+		}
+	}
+
+	return t, nil
+}
+
+// acquire 阻塞直到 targetID 可以发送一条主动消息；返回错误时应放弃该条消息
+func (q *OfficialQQSendQuota) acquire(targetID string) error {
+	t, err := q.reserve(targetID)
+	if err != nil {
+		return err
+	}
+	if d := time.Until(t); d > 0 {
+		time.Sleep(d)
+	}
+	return nil
+}
+
+func (pa *PlatformAdapterOfficialQQ) initSendQuota() {
+	pa.sendQuotaMu.Lock()
+	defer pa.sendQuotaMu.Unlock()
+	if pa.c2cSendQuota == nil {
+		pa.c2cSendQuota = &OfficialQQSendQuota{
+			botLimit:   officialQQC2CBotLimit,
+			botPeriod:  officialQQC2CBotPeriod,
+			relStamps:  make(map[string][]time.Time),
+			dailyCount: make(map[string]int),
+		}
+	}
+	if pa.groupSendQuota == nil {
+		pa.groupSendQuota = &OfficialQQSendQuota{
+			botLimit:   officialQQGroupBotLimit,
+			botPeriod:  officialQQGroupBotPeriod,
+			relStamps:  make(map[string][]time.Time),
+			dailyCount: make(map[string]int),
+		}
+	}
+}
+
+// waitC2CActiveQuota 主动单聊消息排队限流，返回错误时应放弃发送
+func (pa *PlatformAdapterOfficialQQ) waitC2CActiveQuota(userOpenID string) error {
+	pa.initSendQuota()
+	return pa.c2cSendQuota.acquire(userOpenID)
+}
+
+// waitGroupActiveQuota 主动群聊消息排队限流，返回错误时应放弃发送
+func (pa *PlatformAdapterOfficialQQ) waitGroupActiveQuota(groupOpenID string) error {
+	pa.initSendQuota()
+	return pa.groupSendQuota.acquire(groupOpenID)
 }
 
 func (pa *PlatformAdapterOfficialQQ) SendToGroup(ctx *MsgContext, uid string, text string, flag string) {
@@ -1813,6 +1962,14 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw(ctx *MsgContext, rowMsgID
 		pa.finalizeMessageToCreate(toCreate, content, keyboardObj, isFinal)
 		if toCreate.Media == nil && toCreate.Content == "" && toCreate.Markdown == nil && toCreate.MessageReference == nil {
 			return
+		}
+		// 主动消息排队限流
+		if toCreate.MsgID == "" && toCreate.EventID == "" {
+			if err := pa.waitGroupActiveQuota(groupID); err != nil {
+				pa.EndPoint.Session.Parent.Logger.Error("official qq 发送群聊消息失败：" + err.Error())
+				lastErr = err
+				return
+			}
 		}
 		res, err := pa.Api.PostGroupMessage(qctx, groupID, toCreate)
 		if err != nil {

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -85,7 +85,7 @@ type PlatformAdapterOfficialQQ struct {
 	// 主动消息发送队列
 	c2cSendQuota   *OfficialQQSendQuota `json:"-" yaml:"-"`
 	groupSendQuota *OfficialQQSendQuota `json:"-" yaml:"-"`
-	sendQuotaMu    sync.Mutex           `json:"-" yaml:"-"`
+	sendQuotaOnce  sync.Once            `json:"-" yaml:"-"`
 }
 
 type officialQQAdapterJSON struct {
@@ -1640,7 +1640,7 @@ func (pa *PlatformAdapterOfficialQQ) sendC2CMsgRaw(ctx *MsgContext, rowMsgID, us
 		}
 		// 主动消息（无 msg_id/event_id）需要排队限流
 		if toCreate.MsgID == "" && toCreate.EventID == "" {
-			if err := pa.waitC2CActiveQuota(userOpenID); err != nil {
+			if err := pa.waitC2CActiveQuota(qctx, userOpenID); err != nil {
 				pa.EndPoint.Session.Parent.Logger.Error("official qq 发送单聊消息失败：" + err.Error())
 				lastErr = err
 				return
@@ -1732,14 +1732,16 @@ type OfficialQQSendQuota struct {
 	dailyCount map[string]int
 }
 
+var officialQQTimeZone = time.FixedZone("CST", 8*3600)
+
 // reserve 为 targetID 的一次主动发送预约时刻。
 func (q *OfficialQQSendQuota) reserve(targetID string) (time.Time, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	now := time.Now()
+	now := time.Now().In(officialQQTimeZone)
 
-	// 每日计数按本地日期重置
+	// 每日计数按UTC+8日期重置
 	day := now.Format("2006-01-02")
 	if day != q.dailyDay {
 		q.dailyDay = day
@@ -1793,49 +1795,53 @@ func (q *OfficialQQSendQuota) reserve(targetID string) (time.Time, error) {
 	return t, nil
 }
 
-// acquire 阻塞直到 targetID 可以发送一条主动消息；返回错误时应放弃该条消息
-func (q *OfficialQQSendQuota) acquire(targetID string) error {
+// acquire 阻塞直到 targetID 可以发送一条主动消息；支持 Context 取消
+func (q *OfficialQQSendQuota) acquire(ctx context.Context, targetID string) error {
 	t, err := q.reserve(targetID)
 	if err != nil {
 		return err
 	}
-	if d := time.Until(t); d > 0 {
-		time.Sleep(d)
+	d := time.Until(t)
+	if d <= 0 {
+		return nil
 	}
-	return nil
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (pa *PlatformAdapterOfficialQQ) initSendQuota() {
-	pa.sendQuotaMu.Lock()
-	defer pa.sendQuotaMu.Unlock()
-	if pa.c2cSendQuota == nil {
+	pa.sendQuotaOnce.Do(func() {
 		pa.c2cSendQuota = &OfficialQQSendQuota{
 			botLimit:   officialQQC2CBotLimit,
 			botPeriod:  officialQQC2CBotPeriod,
 			relStamps:  make(map[string][]time.Time),
 			dailyCount: make(map[string]int),
 		}
-	}
-	if pa.groupSendQuota == nil {
 		pa.groupSendQuota = &OfficialQQSendQuota{
 			botLimit:   officialQQGroupBotLimit,
 			botPeriod:  officialQQGroupBotPeriod,
 			relStamps:  make(map[string][]time.Time),
 			dailyCount: make(map[string]int),
 		}
-	}
+	})
 }
 
 // waitC2CActiveQuota 主动单聊消息排队限流，返回错误时应放弃发送
-func (pa *PlatformAdapterOfficialQQ) waitC2CActiveQuota(userOpenID string) error {
+func (pa *PlatformAdapterOfficialQQ) waitC2CActiveQuota(ctx context.Context, userOpenID string) error {
 	pa.initSendQuota()
-	return pa.c2cSendQuota.acquire(userOpenID)
+	return pa.c2cSendQuota.acquire(ctx, userOpenID)
 }
 
 // waitGroupActiveQuota 主动群聊消息排队限流，返回错误时应放弃发送
-func (pa *PlatformAdapterOfficialQQ) waitGroupActiveQuota(groupOpenID string) error {
+func (pa *PlatformAdapterOfficialQQ) waitGroupActiveQuota(ctx context.Context, groupOpenID string) error {
 	pa.initSendQuota()
-	return pa.groupSendQuota.acquire(groupOpenID)
+	return pa.groupSendQuota.acquire(ctx, groupOpenID)
 }
 
 func (pa *PlatformAdapterOfficialQQ) SendToGroup(ctx *MsgContext, uid string, text string, flag string) {
@@ -1970,7 +1976,7 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw(ctx *MsgContext, rowMsgID
 		}
 		// 主动消息排队限流
 		if toCreate.MsgID == "" && toCreate.EventID == "" {
-			if err := pa.waitGroupActiveQuota(groupID); err != nil {
+			if err := pa.waitGroupActiveQuota(qctx, groupID); err != nil {
 				pa.EndPoint.Session.Parent.Logger.Error("official qq 发送群聊消息失败：" + err.Error())
 				lastErr = err
 				return

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/samber/lo v1.52.0
 	github.com/schollz/progressbar/v3 v3.19.1
-	github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083 // replaced below
+	github.com/sealdice/botgo v0.0.0-20260724133029-df949851f30b
 	github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/slack-go/slack v0.17.3
@@ -234,5 +234,4 @@ replace (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0 => github.com/PaienNate/goja_nodejs v0.0.0-20250924024212-bac2e5ba5231
 	github.com/lonelyevil/kook v0.0.31 => github.com/sealdice/kook v0.0.3
 	github.com/sacOO7/gowebsocket v0.0.0-20221109081133-70ac927be105 => github.com/fy0/GoWebsocket v0.0.0-20231128163937-aa5c110b25c6
-	github.com/sealdice/botgo v0.0.0-20240102160217-e61d5bdfe083 => github.com/baiyu-yu/botgo v0.0.0-20260724092016-620fecba07da
 )

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/axiomhq/hyperloglog v0.2.6 h1:sRhvvF3RIXWQgAXaTphLp4yJiX4S0IN3MWTaAgZoRJw=
 github.com/axiomhq/hyperloglog v0.2.6/go.mod h1:YjX/dQqCR/7QYX0g8mu8UZAjpIenz1FKM71UEsjFoTo=
-github.com/baiyu-yu/botgo v0.0.0-20260724092016-620fecba07da h1:gvwcNchbzpswk/7R/E8MUsBFxb9zHYmlOKHV0Anh6J0=
-github.com/baiyu-yu/botgo v0.0.0-20260724092016-620fecba07da/go.mod h1:oQhXm1mfLdV+1/d27LhnUHVNfhtl5RYwdREQnb4cewI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bits-and-blooms/bitset v1.2.2/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
@@ -496,6 +494,8 @@ github.com/samber/lo v1.52.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRo
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/schollz/progressbar/v3 v3.19.1 h1:iv8BgwOvdML/S3p84uBpy/IMigv4U9594vPZYa2EdrU=
 github.com/schollz/progressbar/v3 v3.19.1/go.mod h1:LFL7jqimKxfhero4K1eCkUr/6R39AgQeiPCJtlTWIW8=
+github.com/sealdice/botgo v0.0.0-20260724133029-df949851f30b h1:z+8xWdjgJ/ZO27U5klh3uQ3KbLhL+Yz6cjhst9871AY=
+github.com/sealdice/botgo v0.0.0-20260724133029-df949851f30b/go.mod h1:oQhXm1mfLdV+1/d27LhnUHVNfhtl5RYwdREQnb4cewI=
 github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070 h1:C5zwdWiRpgMl3g3Q68csBaDWJLdUhYKfPGwJUkHXed0=
 github.com/sealdice/dicescript v0.0.0-20260511210507-209e4d20a070/go.mod h1:uof752qJvEQ4Kze+NVag+RKGgj5C4K3kMHoK3e2vOLg=
 github.com/sealdice/kook v0.0.3 h1:STMtiKRMFjhSFmUxi0BU5ktNkCQ8qi7Y5EEfrmYKvWY=


### PR DESCRIPTION
## Summary by Sourcery

为主动的官方 QQ 消息添加限速队列，并在更新 botgo 依赖来源的同时，启用接收群成员变动事件的能力。

新功能：
- 为官方 QQ 上的主动 C2C 和群聊消息引入可配置的发送配额队列，以遵守平台的频率限制。
- 通过 WebSocket intents 支持接收官方 QQ 群成员加入/离开事件。

增强：
- 将主动消息发送路径接入新的配额队列，在超出限制时丢弃或延迟消息。
- 为 C2C 和群聊消息初始化并复用配额结构，支持按机器人、按目标以及按日的配额限制。

构建：
- 将 botgo 依赖更新到上游的较新版本，并移除自定义的 replace 指令覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add rate-limited queues for proactive Official QQ messages and enable reception of group member change events while updating the botgo dependency source.

New Features:
- Introduce configurable send quota queues for proactive C2C and group messages on Official QQ to respect platform rate limits.
- Support receiving Official QQ group member join/leave events via WebSocket intents.

Enhancements:
- Wire proactive message sending paths through the new quota queues to drop or delay messages when limits are exceeded.
- Initialize and reuse quota structures for C2C and group messaging with per-bot, per-target, and daily limits.

Build:
- Update the botgo dependency to a newer upstream version and remove the custom replace directive override.

</details>