### PR TITLE
build: update golangci-lint installer

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,7 @@ tasks:
   install:
     cmds:
       - go mod download
-      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
       - go install golang.org/x/tools/cmd/goimports@latest
       - go install github.com/pointlander/peg@v1.0.1
       - go generate ./...


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 在 Taskfile 的安装任务中，将 golangci-lint 的安装更新为使用 v2 模块路径，并使用 2.4.0 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update golangci-lint installation to use the v2 module path and version 2.4.0 in the Taskfile install task.

</details>