### PR TITLE
fix: 修复 XLSX 正文转义符无效问题

### DIFF
--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -81,6 +81,8 @@ const (
 
 const HelpConfigFilename = "help_config.yaml"
 
+const helpContentParserVersion = 1
+
 type HelpConfig struct {
 	Aliases map[string][]string `json:"aliases" yaml:"aliases"`
 }
@@ -105,11 +107,15 @@ type HelpFileMeta struct {
 }
 
 type HelpIndexMeta struct {
-	Files map[string]HelpFileMeta `json:"files"`
+	ContentParserVersion int                     `json:"contentParserVersion"`
+	Files                map[string]HelpFileMeta `json:"files"`
 }
 
 func newEmptyHelpIndexMeta() *HelpIndexMeta {
-	return &HelpIndexMeta{Files: make(map[string]HelpFileMeta)}
+	return &HelpIndexMeta{
+		ContentParserVersion: helpContentParserVersion,
+		Files:                make(map[string]HelpFileMeta),
+	}
 }
 
 func reconcileHelpIndexMeta(indexMeta *HelpIndexMeta, metaTrusted, indexFreshlyCreated bool) (*HelpIndexMeta, bool) {
@@ -477,7 +483,7 @@ func (m *HelpManager) loadHelpDoc(group string, path string) bool {
 						}
 					}
 					key := keyBuilder.String()
-					content := row[synonymCount+1]
+					content := unescapeXlsxHelpContent(row[synonymCount+1])
 
 					_ = m.AddItem(docengine.HelpTextItem{
 						Group:       group,
@@ -497,6 +503,33 @@ func (m *HelpManager) loadHelpDoc(group string, path string) bool {
 		return true
 	}
 	return false
+}
+
+func unescapeXlsxHelpContent(content string) string {
+	if !strings.Contains(content, `\`) {
+		return content
+	}
+
+	var result strings.Builder
+	result.Grow(len(content))
+	for i := 0; i < len(content); i++ {
+		if content[i] != '\\' || i+1 >= len(content) {
+			result.WriteByte(content[i])
+			continue
+		}
+
+		switch content[i+1] {
+		case 'n':
+			result.WriteByte('\n')
+			i++
+		case '\\':
+			result.WriteByte('\\')
+			i++
+		default:
+			result.WriteByte(content[i])
+		}
+	}
+	return result.String()
 }
 
 // validateXlsxHeaders 验证 xlsx 格式 helpdoc 的表头是否是 Key Synonym（可能有多列） Content Description Catalogue Tag
@@ -686,6 +719,14 @@ func (m *HelpManager) loadHelpIndexMeta() (*HelpIndexMeta, bool) {
 	}
 	if meta.Files == nil {
 		meta.Files = make(map[string]HelpFileMeta)
+	}
+	if meta.ContentParserVersion != helpContentParserVersion {
+		logger.M().Infof(
+			"[帮助文档] 内容解析版本已更新(%d -> %d)，将重新构建索引",
+			meta.ContentParserVersion,
+			helpContentParserVersion,
+		)
+		return newEmptyHelpIndexMeta(), false
 	}
 	return &meta, true
 }

--- a/dice/dice_help_internal_test.go
+++ b/dice/dice_help_internal_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"sealdice-core/dice/docengine"
+
+	"github.com/xuri/excelize/v2"
 )
 
 var errFakeSearchNotImplemented = errors.New("fake search engine: term title lookup not implemented")
@@ -28,6 +31,7 @@ func TestHelpManagerSaveHelpIndexMetaWritesToConfiguredPath(t *testing.T) {
 	}()
 
 	meta := &HelpIndexMeta{
+		ContentParserVersion: helpContentParserVersion,
 		Files: map[string]HelpFileMeta{
 			"data/helpdoc/example.json": {
 				Hash:  1,
@@ -53,6 +57,13 @@ func TestHelpManagerSaveHelpIndexMetaWritesToConfiguredPath(t *testing.T) {
 	if len(got.Files) != 1 {
 		t.Fatalf("saved meta files count = %d, want 1", len(got.Files))
 	}
+	if got.ContentParserVersion != helpContentParserVersion {
+		t.Fatalf(
+			"saved content parser version = %d, want %d",
+			got.ContentParserVersion,
+			helpContentParserVersion,
+		)
+	}
 	if got.Files["data/helpdoc/example.json"].Group != "default" {
 		t.Fatalf("saved meta group = %q, want %q", got.Files["data/helpdoc/example.json"].Group, "default")
 	}
@@ -61,6 +72,7 @@ func TestHelpManagerSaveHelpIndexMetaWritesToConfiguredPath(t *testing.T) {
 type fakeHelpSearchEngine struct {
 	docs     map[string]*docengine.HelpTextItem
 	pageDocs []*docengine.HelpTextItem
+	added    []docengine.HelpTextItem
 }
 
 func (f *fakeHelpSearchEngine) GetSuffixText() string { return "" }
@@ -73,7 +85,10 @@ func (f *fakeHelpSearchEngine) Init() error { return nil }
 
 func (f *fakeHelpSearchEngine) Close() {}
 
-func (f *fakeHelpSearchEngine) AddItem(docengine.HelpTextItem) (string, error) { return "", nil }
+func (f *fakeHelpSearchEngine) AddItem(item docengine.HelpTextItem) (string, error) {
+	f.added = append(f.added, item)
+	return "", nil
+}
 
 func (f *fakeHelpSearchEngine) AddItemApply(bool) error { return nil }
 
@@ -102,6 +117,78 @@ func (f *fakeHelpSearchEngine) GetTotalID() uint64 { return uint64(len(f.docs)) 
 func (f *fakeHelpSearchEngine) DeleteByFrom(string) error { return nil }
 
 func (f *fakeHelpSearchEngine) DeleteByGroup(string) error { return nil }
+
+func TestUnescapeXlsxHelpContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "escaped newline",
+			content: `first\nsecond`,
+			want:    "first\nsecond",
+		},
+		{
+			name:    "real newline remains unchanged",
+			content: "first\nsecond",
+			want:    "first\nsecond",
+		},
+		{
+			name:    "escaped backslash protects newline sequence",
+			content: `first\\nsecond`,
+			want:    `first\nsecond`,
+		},
+		{
+			name:    "unknown escape remains unchanged",
+			content: `first\xsecond`,
+			want:    `first\xsecond`,
+		},
+		{
+			name:    "trailing backslash remains unchanged",
+			content: `first\`,
+			want:    `first\`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unescapeXlsxHelpContent(tt.content); got != tt.want {
+				t.Fatalf("unescapeXlsxHelpContent(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelpManagerLoadHelpDocUnescapesXlsxContent(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "help.xlsx")
+	file := excelize.NewFile()
+	sheet := file.GetSheetName(0)
+	if err := file.SetSheetRow(sheet, "A1", &[]any{"Key", "Synonym", "Content"}); err != nil {
+		t.Fatalf("SetSheetRow(header) error = %v", err)
+	}
+	if err := file.SetSheetRow(sheet, "A2", &[]any{"entry", "", `first\nsecond`}); err != nil {
+		t.Fatalf("SetSheetRow(content) error = %v", err)
+	}
+	if err := file.SaveAs(filePath); err != nil {
+		t.Fatalf("SaveAs(%q) error = %v", filePath, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	searchEngine := &fakeHelpSearchEngine{}
+	manager := &HelpManager{searchEngine: searchEngine}
+	if ok := manager.loadHelpDoc("test", filePath); !ok {
+		t.Fatal("loadHelpDoc() = false, want true")
+	}
+	if len(searchEngine.added) != 1 {
+		t.Fatalf("added help items = %d, want 1", len(searchEngine.added))
+	}
+	if got, want := searchEngine.added[0].Content, "first\nsecond"; got != want {
+		t.Fatalf("loaded XLSX content = %q, want %q", got, want)
+	}
+}
 
 func TestHelpManagerGetItemByNumericID_InvalidBounds(t *testing.T) {
 	manager := &HelpManager{
@@ -209,6 +296,7 @@ func TestHelpManagerGetHelpItemPageMapsPaginationInternalIDs(t *testing.T) {
 
 func TestReconcileHelpIndexMeta(t *testing.T) {
 	existing := &HelpIndexMeta{
+		ContentParserVersion: helpContentParserVersion,
 		Files: map[string]HelpFileMeta{
 			"data/helpdoc/example.json": {
 				Hash:  1,


### PR DESCRIPTION
## Summary by Sourcery

处理 XLSX 帮助内容中的转义序列，并对帮助索引元数据中的解析器版本进行管理，以便在解析器发生变更时触发重新索引。

Bug Fixes:
- 确保加载到帮助管理器中的 XLSX 帮助内容能正确解析转义的换行符和反斜杠，而不是将它们视为字面文本。

Enhancements:
- 在帮助索引元数据中记录帮助内容解析器的版本，并在解析器版本发生变化时强制重建索引，以保持搜索数据一致性。

Tests:
- 添加针对 XLSX 帮助内容反转义的单元测试，以及通过帮助管理器加载 XLSX 帮助文档的测试，包括对存储内容和解析器版本元数据的校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle XLSX help content escape sequences and version help index metadata to trigger reindexing when the parser changes.

Bug Fixes:
- Ensure XLSX help content loaded into the help manager correctly interprets escaped newline sequences and backslashes instead of treating them as literal text.

Enhancements:
- Version the help content parser in help index metadata and force index rebuild when the parser version changes to keep search data consistent.

Tests:
- Add unit tests for XLSX help content unescaping and for loading XLSX help docs through the help manager, including verification of stored content and parser version metadata.

</details>