### PR TITLE
feat: 支持自定义托盘提示与账号菜单

### DIFF
--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -126,10 +126,10 @@ func DiceConfigSet(c echo.Context) error {
 			})
 		}
 		value = strings.TrimSpace(value)
-		if utf8.RuneCountInString(value) > 10 {
+		if utf8.RuneCountInString(value) > dice.MaxTrayTooltipPrefixLength {
 			return c.JSON(http.StatusBadRequest, Response{
 				"result": false,
-				"err":    "托盘提示文本不能超过10个字符",
+				"err":    "托盘提示文本前缀不能超过" + strconv.Itoa(dice.MaxTrayTooltipPrefixLength) + "个字符",
 			})
 		}
 		trayTooltip = value

--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/labstack/echo/v4"
 	"golang.org/x/time/rate"
@@ -25,6 +26,7 @@ type DiceConfigInfo struct {
 	MaxExecuteTime      string   `json:"maxExecuteTime"`      // 最大骰点次数
 	MaxCocCardGen       string   `json:"maxCocCardGen"`       // 最大coc制卡数
 	ServerAddress       string   `form:"serveAddress"        json:"serveAddress"`
+	TrayTooltip         string   `json:"trayTooltip"`
 	HelpDocEngineType   int      `json:"helpDocEngineType"`
 }
 
@@ -76,6 +78,7 @@ func DiceConfig(c echo.Context) error {
 		LogPageItemLimit:    limit,
 		DefaultCocRuleIndex: cocRule,
 		ServerAddress:       myDice.Parent.ServeAddress,
+		TrayTooltip:         myDice.Parent.GetTrayTooltip(),
 		HelpDocEngineType:   myDice.Parent.HelpDocEngineType,
 		MaxExecuteTime:      maxExec,
 		MaxCocCardGen:       maxCard,
@@ -111,6 +114,28 @@ func DiceConfigSet(c echo.Context) error {
 		myDice.Logger.Error("DiceConfigSet", err)
 		return c.JSON(http.StatusOK, nil)
 	}
+
+	trayTooltip := ""
+	trayTooltipModified := false
+	if val, ok := jsonMap["trayTooltip"]; ok {
+		value, ok := val.(string)
+		if !ok {
+			return c.JSON(http.StatusBadRequest, Response{
+				"result": false,
+				"err":    "托盘提示文本必须是字符串",
+			})
+		}
+		value = strings.TrimSpace(value)
+		if utf8.RuneCountInString(value) > 10 {
+			return c.JSON(http.StatusBadRequest, Response{
+				"result": false,
+				"err":    "托盘提示文本不能超过10个字符",
+			})
+		}
+		trayTooltip = value
+		trayTooltipModified = true
+	}
+
 	if val, ok := jsonMap["commandPrefix"]; ok {
 		myDice.CommandPrefix = stringConvert(val)
 	}
@@ -346,6 +371,9 @@ func DiceConfigSet(c echo.Context) error {
 		if !dm.JustForTest {
 			myDice.Parent.ServeAddress = val.(string)
 		}
+	}
+	if trayTooltipModified {
+		myDice.Parent.SetTrayTooltip(trayTooltip)
 	}
 
 	// if val, ok := jsonMap["customBotExtraText"]; ok {

--- a/dice/config.go
+++ b/dice/config.go
@@ -2371,10 +2371,12 @@ func (d *Dice) loads() {
 func (d *Dice) loadIMSessionEndpoints(imSession *IMSession) bool {
 	if imSession == nil || imSession.EndPoints == nil {
 		d.ImSession.EndPoints = make([]*EndPointInfo, 0)
+		d.ImSession.RefreshEndPointsSnapshot()
 		return true
 	}
 
 	d.ImSession.EndPoints = imSession.EndPoints
+	d.ImSession.RefreshEndPointsSnapshot()
 	return false
 }
 
@@ -2502,6 +2504,7 @@ func (d *Dice) ApplyExtDefaultSettings() {
 }
 
 func (d *Dice) Save(isAuto bool) {
+	d.ImSession.RefreshEndPointsSnapshot()
 	saveStartTime := time.Now()
 
 	configStartTime := time.Now()

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"errors"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,6 +36,7 @@ type GroupNameCacheItem struct {
 
 type DiceManager struct { //nolint:revive
 	Dice                 []*Dice
+	diceLock             sync.RWMutex
 	Operator             engine.DatabaseOperator
 	ServeAddress         string
 	trayTooltip          string
@@ -234,7 +236,7 @@ func (dm *DiceManager) LoadDice() {
 		newDice := new(Dice)
 		newDice.BaseConfig = i
 		newDice.ContainerMode = dm.ContainerMode
-		dm.Dice = append(dm.Dice, newDice)
+		dm.appendDice(newDice)
 	}
 }
 
@@ -278,10 +280,33 @@ func (dm *DiceManager) GetTrayTooltip() string {
 	return dm.trayTooltip
 }
 
+// NormalizeTrayTooltipPrefix 规范化托盘提示前缀，并按 Unicode 字符数限制长度。
+func NormalizeTrayTooltipPrefix(tooltip string) string {
+	tooltip = strings.TrimSpace(tooltip)
+	runes := []rune(tooltip)
+	if len(runes) > MaxTrayTooltipPrefixLength {
+		return string(runes[:MaxTrayTooltipPrefixLength])
+	}
+	return tooltip
+}
+
 func (dm *DiceManager) SetTrayTooltip(tooltip string) {
 	dm.trayTooltipLock.Lock()
 	defer dm.trayTooltipLock.Unlock()
-	dm.trayTooltip = tooltip
+	dm.trayTooltip = NormalizeTrayTooltipPrefix(tooltip)
+}
+
+// DiceSnapshot 返回当前 Dice 实例切片的副本。
+func (dm *DiceManager) DiceSnapshot() []*Dice {
+	dm.diceLock.RLock()
+	defer dm.diceLock.RUnlock()
+	return append([]*Dice(nil), dm.Dice...)
+}
+
+func (dm *DiceManager) appendDice(instance *Dice) {
+	dm.diceLock.Lock()
+	defer dm.diceLock.Unlock()
+	dm.Dice = append(dm.Dice, instance)
 }
 
 func (dm *DiceManager) InitDice(writer *logger.UIWriter) {
@@ -374,6 +399,8 @@ func (dm *DiceManager) TryCreateDefault() {
 		dm.ServeAddress = "0.0.0.0:3211"
 	}
 
+	dm.diceLock.Lock()
+	defer dm.diceLock.Unlock()
 	if len(dm.Dice) == 0 {
 		defaultDice := new(Dice)
 		defaultDice.BaseConfig.Name = "default"

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -34,6 +34,8 @@ type DiceManager struct { //nolint:revive
 	Dice                 []*Dice
 	Operator             engine.DatabaseOperator
 	ServeAddress         string
+	trayTooltip          string
+	trayTooltipLock      sync.RWMutex
 	Help                 *HelpManager
 	IsHelpReloading      bool
 	helpReloadLock       sync.Mutex
@@ -89,6 +91,7 @@ type DiceManager struct { //nolint:revive
 type Configs struct { //nolint:revive
 	DiceConfigs       []BaseConfig `yaml:"diceConfigs"`
 	ServeAddress      string       `yaml:"serveAddress"`
+	TrayTooltip       string       `yaml:"trayTooltip"`
 	WebUIAddress      string       `yaml:"webUIAddress"`
 	HelpDocEngineType int          `yaml:"helpDocEngineType"`
 
@@ -199,6 +202,7 @@ func (dm *DiceManager) LoadDice() {
 	}
 
 	dm.ServeAddress = dc.ServeAddress
+	dm.SetTrayTooltip(dc.TrayTooltip)
 	dm.HelpDocEngineType = dc.HelpDocEngineType
 	dm.UIPasswordHash = dc.UIPasswordHash
 	dm.UIPasswordSalt = dc.UIPasswordSalt
@@ -234,6 +238,7 @@ func (dm *DiceManager) LoadDice() {
 func (dm *DiceManager) Save() {
 	var dc Configs
 	dc.ServeAddress = dm.ServeAddress
+	dc.TrayTooltip = dm.GetTrayTooltip()
 	dc.HelpDocEngineType = dm.HelpDocEngineType
 	dc.UIPasswordSalt = dm.UIPasswordSalt
 	dc.UIPasswordHash = dm.UIPasswordHash
@@ -262,6 +267,18 @@ func (dm *DiceManager) Save() {
 	if err == nil {
 		_ = os.WriteFile("./data/dice.yaml", data, 0644)
 	}
+}
+
+func (dm *DiceManager) GetTrayTooltip() string {
+	dm.trayTooltipLock.RLock()
+	defer dm.trayTooltipLock.RUnlock()
+	return dm.trayTooltip
+}
+
+func (dm *DiceManager) SetTrayTooltip(tooltip string) {
+	dm.trayTooltipLock.Lock()
+	defer dm.trayTooltipLock.Unlock()
+	dm.trayTooltip = tooltip
 }
 
 func (dm *DiceManager) InitDice(writer *logger.UIWriter) {

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -25,6 +25,9 @@ type VersionInfo struct {
 	UpdaterURLPrefix        string `json:"updaterUrlPrefix"        yaml:"updaterUrlPrefix"`
 }
 
+// MaxTrayTooltipPrefixLength 自定义托盘提示前缀的最大字符数。
+const MaxTrayTooltipPrefixLength = 10
+
 type GroupNameCacheItem struct {
 	Name string
 	time int64

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -655,6 +655,29 @@ type IMSession struct {
 	EndPoints    []*EndPointInfo                    `yaml:"endPoints"`
 	ServiceAtNew *SyncMap[string, *GroupInfo]       `json:"servicesAt" yaml:"-"`
 	PendingQuits *SyncMap[string, *PendingQuitInfo] `json:"-" yaml:"-"`
+
+	endPointsSnapshot atomic.Pointer[[]*EndPointInfo]
+}
+
+// RefreshEndPointsSnapshot 发布当前端点列表的只读快照。
+func (s *IMSession) RefreshEndPointsSnapshot() {
+	if s == nil {
+		return
+	}
+	snapshot := append([]*EndPointInfo(nil), s.EndPoints...)
+	s.endPointsSnapshot.Store(&snapshot)
+}
+
+// EndPointsSnapshot 返回最近发布的端点列表，调用方不得修改返回的切片。
+func (s *IMSession) EndPointsSnapshot() []*EndPointInfo {
+	if s == nil {
+		return nil
+	}
+	snapshot := s.endPointsSnapshot.Load()
+	if snapshot == nil {
+		return nil
+	}
+	return *snapshot
 }
 
 func (s *IMSession) ResolveLiveEndpoint(ep *EndPointInfo) (*EndPointInfo, error) {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -662,6 +662,14 @@ type IMSession struct {
 	endPointsSnapshot atomic.Pointer[[]*EndPointInfo]
 }
 
+// EndPointDisplaySnapshot 是托盘菜单所需的端点展示值快照。
+// 它不包含适配器、会话、锁或通道，发布后不会随原端点对象继续变化。
+type EndPointDisplaySnapshot struct {
+	Nickname string
+	UserID   string
+	State    EndpointState
+}
+
 // RefreshEndPointsSnapshot 发布当前端点列表的只读快照。
 func (s *IMSession) RefreshEndPointsSnapshot() {
 	if s == nil {
@@ -671,8 +679,9 @@ func (s *IMSession) RefreshEndPointsSnapshot() {
 	s.endPointsSnapshot.Store(&snapshot)
 }
 
-// EndPointsSnapshot 返回最近发布的端点列表，调用方不得修改返回的切片。
-func (s *IMSession) EndPointsSnapshot() []*EndPointInfo {
+// EndPointsSnapshot 返回最近发布列表中各端点展示字段的单次采样。
+// 端点状态由各适配器独立更新，因此该快照提供最终一致的托盘展示语义。
+func (s *IMSession) EndPointsSnapshot() []EndPointDisplaySnapshot {
 	if s == nil {
 		return nil
 	}
@@ -680,7 +689,18 @@ func (s *IMSession) EndPointsSnapshot() []*EndPointInfo {
 	if snapshot == nil {
 		return nil
 	}
-	return *snapshot
+	display := make([]EndPointDisplaySnapshot, 0, len(*snapshot))
+	for _, endpoint := range *snapshot {
+		if endpoint == nil {
+			continue
+		}
+		display = append(display, EndPointDisplaySnapshot{
+			Nickname: endpoint.Nickname,
+			UserID:   endpoint.UserID,
+			State:    endpoint.State,
+		})
+	}
+	return display
 }
 
 func (s *IMSession) ResolveLiveEndpoint(ep *EndPointInfo) (*EndPointInfo, error) {

--- a/tray_common.go
+++ b/tray_common.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/fy0/systray"
@@ -11,7 +12,26 @@ import (
 	"sealdice-core/dice"
 )
 
-const defaultTrayTooltip = "海豹TRPG骰点核心"
+const (
+	defaultTrayTooltip = "海豹TRPG骰点核心"
+	defaultTrayPort    = "3211"
+)
+
+var (
+	trayPort atomic.Pointer[string]
+)
+
+func getTrayPort() string {
+	port := trayPort.Load()
+	if port == nil {
+		return defaultTrayPort
+	}
+	return *port
+}
+
+func setTrayPort(port string) {
+	trayPort.Store(&port)
+}
 
 type trayAccountMenu struct {
 	root                *systray.MenuItem

--- a/tray_common.go
+++ b/tray_common.go
@@ -4,36 +4,20 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/fy0/systray"
-	"gopkg.in/yaml.v3"
 
 	"sealdice-core/dice"
-	"sealdice-core/logger"
 )
 
 const defaultTrayTooltip = "海豹TRPG骰点核心"
-
-type trayAccountConfig struct {
-	IMSession struct {
-		EndPoints []struct {
-			BaseInfo struct {
-				Nickname string `yaml:"nickname"`
-				UserID   string `yaml:"userId"`
-			} `yaml:"baseInfo"`
-		} `yaml:"endPoints"`
-	} `yaml:"imSession"`
-}
 
 type trayAccountMenu struct {
 	root       *systray.MenuItem
 	addAccount *systray.MenuItem
 	account    []*systray.MenuItem
-	lastError  string
 }
 
 func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
@@ -68,19 +52,7 @@ func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
 }
 
 func (menu *trayAccountMenu) refresh(dm *dice.DiceManager) {
-	titles, err := loadTrayAccountTitles(dm)
-	if err != nil {
-		message := err.Error()
-		if message != menu.lastError {
-			logger.M().Warnf("刷新托盘账号列表失败: %v", err)
-			menu.lastError = message
-		}
-		return
-	}
-	if menu.lastError != "" {
-		logger.M().Info("托盘账号列表已恢复刷新")
-		menu.lastError = ""
-	}
+	titles := loadTrayAccountTitles(dm)
 
 	for len(menu.account) < len(titles) {
 		item := menu.root.AddSubMenuItem(titles[len(menu.account)], "")
@@ -104,25 +76,38 @@ func (menu *trayAccountMenu) refresh(dm *dice.DiceManager) {
 	}
 }
 
-func loadTrayAccountTitles(dm *dice.DiceManager) ([]string, error) {
+func loadTrayAccountTitles(dm *dice.DiceManager) []string {
 	var titles []string
 	for _, instance := range dm.Dice {
-		path := filepath.Join(instance.BaseConfig.DataDir, "serve.yaml")
-		data, err := os.ReadFile(path)
-		if err != nil {
-			if os.IsNotExist(err) {
+		if instance == nil || instance.ImSession == nil {
+			continue
+		}
+		for _, endpoint := range instance.ImSession.EndPoints {
+			if endpoint == nil {
 				continue
 			}
-			return nil, fmt.Errorf("读取 %s: %w", path, err)
-		}
-
-		var config trayAccountConfig
-		if err = yaml.Unmarshal(data, &config); err != nil {
-			return nil, fmt.Errorf("解析 %s: %w", path, err)
-		}
-		for _, endpoint := range config.IMSession.EndPoints {
-			titles = append(titles, fmt.Sprintf("%s(%s)", endpoint.BaseInfo.Nickname, endpoint.BaseInfo.UserID))
+			titles = append(titles, fmt.Sprintf(
+				"%s(%s) [%s]",
+				endpoint.Nickname,
+				endpoint.UserID,
+				trayEndpointStateText(endpoint.State),
+			))
 		}
 	}
-	return titles, nil
+	return titles
+}
+
+func trayEndpointStateText(state dice.EndpointState) string {
+	switch state {
+	case dice.StateDisconnected:
+		return "已断开"
+	case dice.StateConnected:
+		return "已连接"
+	case dice.StateConnecting:
+		return "连接中"
+	case dice.StateConnectionFailed:
+		return "连接失败"
+	default:
+		return "未知状态"
+	}
 }

--- a/tray_common.go
+++ b/tray_common.go
@@ -29,6 +29,7 @@ func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
 }
 
 func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
+	instances := append([]*dice.Dice(nil), dm.Dice...)
 	root := systray.AddMenuItem("账号列表", "查看已配置的平台账号")
 	menu := &trayAccountMenu{
 		root:       root,
@@ -41,18 +42,18 @@ func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
 		}
 	}()
 
-	menu.refresh(dm)
+	menu.refresh(instances)
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 		for range ticker.C {
-			menu.refresh(dm)
+			menu.refresh(instances)
 		}
 	}()
 }
 
-func (menu *trayAccountMenu) refresh(dm *dice.DiceManager) {
-	titles := loadTrayAccountTitles(dm)
+func (menu *trayAccountMenu) refresh(instances []*dice.Dice) {
+	titles := loadTrayAccountTitles(instances)
 
 	for len(menu.account) < len(titles) {
 		item := menu.root.AddSubMenuItem(titles[len(menu.account)], "")
@@ -76,13 +77,13 @@ func (menu *trayAccountMenu) refresh(dm *dice.DiceManager) {
 	}
 }
 
-func loadTrayAccountTitles(dm *dice.DiceManager) []string {
+func loadTrayAccountTitles(instances []*dice.Dice) []string {
 	var titles []string
-	for _, instance := range dm.Dice {
+	for _, instance := range instances {
 		if instance == nil || instance.ImSession == nil {
 			continue
 		}
-		for _, endpoint := range instance.ImSession.EndPoints {
+		for _, endpoint := range instance.ImSession.EndPointsSnapshot() {
 			if endpoint == nil {
 				continue
 			}

--- a/tray_common.go
+++ b/tray_common.go
@@ -14,9 +14,10 @@ import (
 const defaultTrayTooltip = "海豹TRPG骰点核心"
 
 type trayAccountMenu struct {
-	root       *systray.MenuItem
-	addAccount *systray.MenuItem
-	account    []*systray.MenuItem
+	root                *systray.MenuItem
+	addAccount          *systray.MenuItem
+	account             []*systray.MenuItem
+	openAccountSettings func()
 }
 
 func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
@@ -30,8 +31,9 @@ func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
 func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
 	root := systray.AddMenuItem("账号列表", "查看已配置的平台账号")
 	menu := &trayAccountMenu{
-		root:       root,
-		addAccount: root.AddSubMenuItem("添加账号", "打开账号设置"),
+		root:                root,
+		addAccount:          root.AddSubMenuItem("添加账号", "打开账号设置"),
+		openAccountSettings: openAccountSettings,
 	}
 
 	go func() {
@@ -55,7 +57,11 @@ func (menu *trayAccountMenu) refresh(instances []*dice.Dice) {
 
 	for len(menu.account) < len(titles) {
 		item := menu.root.AddSubMenuItem(titles[len(menu.account)], "")
-		item.Disable()
+		go func(item *systray.MenuItem) {
+			for range item.ClickedCh {
+				menu.openAccountSettings()
+			}
+		}(item)
 		menu.account = append(menu.account, item)
 	}
 

--- a/tray_common.go
+++ b/tray_common.go
@@ -1,0 +1,128 @@
+//go:build windows || darwin
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fy0/systray"
+	"gopkg.in/yaml.v3"
+
+	"sealdice-core/dice"
+	"sealdice-core/logger"
+)
+
+const defaultTrayTooltip = "海豹TRPG骰点核心"
+
+type trayAccountConfig struct {
+	IMSession struct {
+		EndPoints []struct {
+			BaseInfo struct {
+				Nickname string `yaml:"nickname"`
+				UserID   string `yaml:"userId"`
+			} `yaml:"baseInfo"`
+		} `yaml:"endPoints"`
+	} `yaml:"imSession"`
+}
+
+type trayAccountMenu struct {
+	root       *systray.MenuItem
+	addAccount *systray.MenuItem
+	account    []*systray.MenuItem
+	lastError  string
+}
+
+func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
+	text := strings.TrimSpace(dm.GetTrayTooltip())
+	if text == "" {
+		text = defaultTrayTooltip
+	}
+	return fmt.Sprintf("%s %s #%s", text, version, port)
+}
+
+func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
+	root := systray.AddMenuItem("账号列表", "查看已配置的平台账号")
+	menu := &trayAccountMenu{
+		root:       root,
+		addAccount: root.AddSubMenuItem("添加账号", "打开账号设置"),
+	}
+
+	go func() {
+		for range menu.addAccount.ClickedCh {
+			openAccountSettings()
+		}
+	}()
+
+	menu.refresh(dm)
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			menu.refresh(dm)
+		}
+	}()
+}
+
+func (menu *trayAccountMenu) refresh(dm *dice.DiceManager) {
+	titles, err := loadTrayAccountTitles(dm)
+	if err != nil {
+		message := err.Error()
+		if message != menu.lastError {
+			logger.M().Warnf("刷新托盘账号列表失败: %v", err)
+			menu.lastError = message
+		}
+		return
+	}
+	if menu.lastError != "" {
+		logger.M().Info("托盘账号列表已恢复刷新")
+		menu.lastError = ""
+	}
+
+	for len(menu.account) < len(titles) {
+		item := menu.root.AddSubMenuItem(titles[len(menu.account)], "")
+		item.Disable()
+		menu.account = append(menu.account, item)
+	}
+
+	for index, item := range menu.account {
+		if index < len(titles) {
+			item.SetTitle(titles[index])
+			item.Show()
+		} else {
+			item.Hide()
+		}
+	}
+
+	if len(titles) == 0 {
+		menu.addAccount.Show()
+	} else {
+		menu.addAccount.Hide()
+	}
+}
+
+func loadTrayAccountTitles(dm *dice.DiceManager) ([]string, error) {
+	var titles []string
+	for _, instance := range dm.Dice {
+		path := filepath.Join(instance.BaseConfig.DataDir, "serve.yaml")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("读取 %s: %w", path, err)
+		}
+
+		var config trayAccountConfig
+		if err = yaml.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("解析 %s: %w", path, err)
+		}
+		for _, endpoint := range config.IMSession.EndPoints {
+			titles = append(titles, fmt.Sprintf("%s(%s)", endpoint.BaseInfo.Nickname, endpoint.BaseInfo.UserID))
+		}
+	}
+	return titles, nil
+}

--- a/tray_common.go
+++ b/tray_common.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/fy0/systray"
@@ -21,7 +20,7 @@ type trayAccountMenu struct {
 }
 
 func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
-	text := strings.TrimSpace(dm.GetTrayTooltip())
+	text := dice.NormalizeTrayTooltipPrefix(dm.GetTrayTooltip())
 	if text == "" {
 		text = defaultTrayTooltip
 	}
@@ -29,7 +28,6 @@ func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
 }
 
 func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
-	instances := append([]*dice.Dice(nil), dm.Dice...)
 	root := systray.AddMenuItem("账号列表", "查看已配置的平台账号")
 	menu := &trayAccountMenu{
 		root:       root,
@@ -42,12 +40,12 @@ func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
 		}
 	}()
 
-	menu.refresh(instances)
+	menu.refresh(dm.DiceSnapshot())
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 		for range ticker.C {
-			menu.refresh(instances)
+			menu.refresh(dm.DiceSnapshot())
 		}
 	}()
 }
@@ -84,9 +82,6 @@ func loadTrayAccountTitles(instances []*dice.Dice) []string {
 			continue
 		}
 		for _, endpoint := range instance.ImSession.EndPointsSnapshot() {
-			if endpoint == nil {
-				continue
-			}
 			titles = append(titles, fmt.Sprintf(
 				"%s(%s) [%s]",
 				endpoint.Nickname,

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -64,13 +64,17 @@ var _trayPortStr = "3211"
 var systrayQuited bool = false
 
 func onReady() {
+	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("海豹核心")
-	systray.SetTooltip("海豹TRPG骰点核心")
+	systray.SetTooltip(formatTrayTooltip(theDm, ver, _trayPortStr))
 
 	mOpen := systray.AddMenuItem("打开界面", "开启WebUI")
 	mOpen.SetIcon(icon.Data)
 	mOpenExeDir := systray.AddMenuItem("打开海豹目录", "访达访问程序所在目录")
+	startTrayAccountMenu(theDm, func() {
+		_ = exec.Command(`open`, `http://localhost:`+_trayPortStr+`/#/connect`).Start()
+	})
 	mQuit := systray.AddMenuItem("退出", "退出程序")
 
 	go func() {
@@ -100,6 +104,7 @@ func onExit() {
 func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	log := logger.M()
 	portStr := "3211"
+	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 
 	go func() {
 		for {
@@ -108,7 +113,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 				break
 			}
 			runtime.LockOSThread()
-			systray.SetTooltip("海豹TRPG骰点核心 #" + portStr)
+			systray.SetTooltip(formatTrayTooltip(dm, ver, portStr))
 			runtime.UnlockOSThread()
 		}
 	}()
@@ -117,6 +122,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	m := rePort.FindStringSubmatch(dm.ServeAddress)
 	if len(m) > 0 {
 		portStr = m[1]
+		_trayPortStr = portStr
 	}
 
 	ln, err := net.Listen("tcp", ":"+portStr)

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -59,21 +59,19 @@ func executeWin(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-var _trayPortStr = "3211"
-
 var systrayQuited bool = false
 
 func onReady() {
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("海豹核心")
-	systray.SetTooltip(formatTrayTooltip(theDm, ver, _trayPortStr))
+	systray.SetTooltip(formatTrayTooltip(theDm, ver, getTrayPort()))
 
 	mOpen := systray.AddMenuItem("打开界面", "开启WebUI")
 	mOpen.SetIcon(icon.Data)
 	mOpenExeDir := systray.AddMenuItem("打开海豹目录", "访达访问程序所在目录")
 	startTrayAccountMenu(theDm, func() {
-		_ = exec.Command(`open`, `http://localhost:`+_trayPortStr+`/#/connect`).Start()
+		_ = exec.Command(`open`, `http://localhost:`+getTrayPort()+`/#/connect`).Start()
 	})
 	mQuit := systray.AddMenuItem("退出", "退出程序")
 
@@ -84,7 +82,7 @@ func onReady() {
 	for {
 		select {
 		case <-mOpen.ClickedCh:
-			_ = exec.Command(`open`, `http://localhost:`+_trayPortStr).Start()
+			_ = exec.Command(`open`, `http://localhost:`+getTrayPort()).Start()
 		case <-mOpenExeDir.ClickedCh:
 			_ = exec.Command(`open`, filepath.Dir(os.Args[0])).Start()
 		case <-mQuit.ClickedCh:
@@ -103,7 +101,7 @@ func onExit() {
 
 func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	log := logger.M()
-	portStr := "3211"
+	portStr := defaultTrayPort
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 
 	go func() {
@@ -113,7 +111,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 				break
 			}
 			runtime.LockOSThread()
-			systray.SetTooltip(formatTrayTooltip(dm, ver, portStr))
+			systray.SetTooltip(formatTrayTooltip(dm, ver, getTrayPort()))
 			runtime.UnlockOSThread()
 		}
 	}()
@@ -122,7 +120,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	m := rePort.FindStringSubmatch(dm.ServeAddress)
 	if len(m) > 0 {
 		portStr = m[1]
-		_trayPortStr = portStr
+		setTrayPort(portStr)
 	}
 
 	ln, err := net.Listen("tcp", ":"+portStr)

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -230,8 +230,9 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 		m := rePort.FindStringSubmatch(dm.ServeAddress)
 		if len(m) > 0 {
 			portStr = m[1]
-			_trayPortStr = portStr
 		}
+		// 同步托盘菜单使用的端口，确保自定义端口和自动换端口后链接正确。
+		_trayPortStr = portStr
 
 		err := e.Start(dm.ServeAddress)
 

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -106,12 +106,12 @@ func onReady() {
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("海豹TRPG骰点核心")
-	systray.SetTooltip(formatTrayTooltip(theDM, ver, _trayPortStr))
+	systray.SetTooltip(formatTrayTooltip(theDM, ver, getTrayPort()))
 
 	mOpen := systray.AddMenuItem("打开界面", "开启WebUI")
 	mOpenExeDir := systray.AddMenuItem("打开海豹目录", "资源管理器访问程序所在目录")
 	startTrayAccountMenu(theDM, func() {
-		_ = exec.Command(`cmd`, `/c`, `start`, `http://localhost:`+_trayPortStr+`/#/connect`).Start()
+		_ = exec.Command(`cmd`, `/c`, `start`, `http://localhost:`+getTrayPort()+`/#/connect`).Start()
 	})
 	mShowHide := systray.AddMenuItemCheckbox("显示终端窗口", "显示终端窗口", false)
 	mAutoBoot := systray.AddMenuItemCheckbox("开机自启动", "开机自启动", false)
@@ -142,7 +142,7 @@ func onReady() {
 	for {
 		select {
 		case <-mOpen.ClickedCh:
-			_ = exec.Command(`cmd`, `/c`, `start`, `http://localhost:`+_trayPortStr).Start()
+			_ = exec.Command(`cmd`, `/c`, `start`, `http://localhost:`+getTrayPort()).Start()
 		case <-mOpenExeDir.ClickedCh:
 			_ = exec.Command(`cmd`, `/c`, `explorer`, filepath.Dir(os.Args[0])).Start()
 		case <-mQuit.ClickedCh:
@@ -187,11 +187,9 @@ func onExit() {
 	// clean up here
 }
 
-var _trayPortStr = "3211"
-
 func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	log := logger.M()
-	portStr := "3211"
+	portStr := defaultTrayPort
 	// runtime.LockOSThread()
 
 	go func() {
@@ -202,7 +200,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 				break
 			}
 			runtime.LockOSThread()
-			systray.SetTooltip(formatTrayTooltip(dm, ver, portStr))
+			systray.SetTooltip(formatTrayTooltip(dm, ver, getTrayPort()))
 			runtime.UnlockOSThread()
 		}
 	}()
@@ -210,8 +208,9 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	showUI := func() {
 		if !hideUI {
 			time.Sleep(2 * time.Second)
-			url := fmt.Sprintf(`http://localhost:%s`, portStr)
-			url2 := fmt.Sprintf(`http://127.0.0.1:%s`, portStr) // 因为dns被换了，localhost不能解析
+			currentPort := getTrayPort()
+			url := fmt.Sprintf(`http://localhost:%s`, currentPort)
+			url2 := fmt.Sprintf(`http://127.0.0.1:%s`, currentPort) // 因为dns被换了，localhost不能解析
 			c := request.Client{
 				URL:     url2,
 				Method:  "GET",
@@ -232,7 +231,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 			portStr = m[1]
 		}
 		// 同步托盘菜单使用的端口，确保自定义端口和自动换端口后链接正确。
-		_trayPortStr = portStr
+		setTrayPort(portStr)
 
 		err := e.Start(dm.ServeAddress)
 

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -106,10 +106,13 @@ func onReady() {
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("海豹TRPG骰点核心")
-	systray.SetTooltip("海豹TRPG骰点核心 " + ver)
+	systray.SetTooltip(formatTrayTooltip(theDM, ver, _trayPortStr))
 
 	mOpen := systray.AddMenuItem("打开界面", "开启WebUI")
 	mOpenExeDir := systray.AddMenuItem("打开海豹目录", "资源管理器访问程序所在目录")
+	startTrayAccountMenu(theDM, func() {
+		_ = exec.Command(`cmd`, `/c`, `start`, `http://localhost:`+_trayPortStr+`/#/connect`).Start()
+	})
 	mShowHide := systray.AddMenuItemCheckbox("显示终端窗口", "显示终端窗口", false)
 	mAutoBoot := systray.AddMenuItemCheckbox("开机自启动", "开机自启动", false)
 	mQuit := systray.AddMenuItem("退出", "退出程序")
@@ -199,7 +202,7 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 				break
 			}
 			runtime.LockOSThread()
-			systray.SetTooltip("海豹TRPG骰点核心 " + ver + " #" + portStr)
+			systray.SetTooltip(formatTrayTooltip(dm, ver, portStr))
 			runtime.UnlockOSThread()
 		}
 	}()


### PR DESCRIPTION
https://github.com/sealdice/sealdice-ui/pull/313
close #1764 
<img width="722" height="256" alt="image" src="https://github.com/user-attachments/assets/9d01c0ba-851d-43aa-88c0-9b48a9139650" />

## Summary by Sourcery

引入可配置的托盘提示文本和跨平台的托盘账号菜单，并集中托盘提示格式化逻辑，同时改进托盘显示所用的端点处理。

New Features:
- 允许配置自定义托盘提示文本，将其持久化到核心配置中，并通过 Dice 配置 API 对外暴露。
- 在 Windows 和 macOS 上添加系统托盘账号菜单，显示已配置的平台账号，并提供快捷方式以打开账号设置。

Enhancements:
- 在各桌面平台上统一托盘提示文本的格式，通过共享的辅助逻辑包含自定义文本、版本和端口信息。
- 发布只读的 IM 端点快照，用于托盘账号列表的安全使用，并定期刷新托盘账号菜单。
- 使托盘菜单中的链接与实际监听端口保持同步，包括自定义端口和自动切换的端口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable tray tooltip text and a cross-platform tray account menu, while centralizing tray tooltip formatting and improving endpoint handling for tray display.

New Features:
- Allow configuring a custom tray tooltip text, persisted in core config and exposed via the Dice configuration API.
- Add a system tray account menu on Windows and macOS showing configured platform accounts with a shortcut to open account settings.

Enhancements:
- Unify tray tooltip formatting across desktop platforms to include custom text, version, and port via shared helper logic.
- Publish read-only IM endpoint snapshots for safe use in tray account listing and periodically refresh the tray account menu.
- Keep the tray menu links in sync with the effective listening port, including custom and auto-switched ports.

</details>

新功能：
- 允许配置自定义托盘工具提示文本，在核心配置中持久化，并通过 Dice 配置 API 对外提供
- 在 Windows 和 macOS 上新增系统托盘账号菜单，显示已配置的平台账号，并提供打开账号设置的快捷入口

改进：
- 统一桌面平台上托盘工具提示的格式，通过共享的辅助逻辑，将自定义文本、版本和端口一并纳入显示

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入可配置的托盘提示文本和跨平台的托盘账号菜单，并集中托盘提示格式化逻辑，同时改进托盘显示所用的端点处理。

New Features:
- 允许配置自定义托盘提示文本，将其持久化到核心配置中，并通过 Dice 配置 API 对外暴露。
- 在 Windows 和 macOS 上添加系统托盘账号菜单，显示已配置的平台账号，并提供快捷方式以打开账号设置。

Enhancements:
- 在各桌面平台上统一托盘提示文本的格式，通过共享的辅助逻辑包含自定义文本、版本和端口信息。
- 发布只读的 IM 端点快照，用于托盘账号列表的安全使用，并定期刷新托盘账号菜单。
- 使托盘菜单中的链接与实际监听端口保持同步，包括自定义端口和自动切换的端口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable tray tooltip text and a cross-platform tray account menu, while centralizing tray tooltip formatting and improving endpoint handling for tray display.

New Features:
- Allow configuring a custom tray tooltip text, persisted in core config and exposed via the Dice configuration API.
- Add a system tray account menu on Windows and macOS showing configured platform accounts with a shortcut to open account settings.

Enhancements:
- Unify tray tooltip formatting across desktop platforms to include custom text, version, and port via shared helper logic.
- Publish read-only IM endpoint snapshots for safe use in tray account listing and periodically refresh the tray account menu.
- Keep the tray menu links in sync with the effective listening port, including custom and auto-switched ports.

</details>

</details>