### PR TITLE
fix(ext): 自动激活新扩展时保留原有扩展优先级

### DIFF
--- a/dice/ext.go
+++ b/dice/ext.go
@@ -599,6 +599,7 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 			known[ext.Name] = struct{}{}
 		}
 	}
+	preserveExistingPriority := len(known) > 0
 
 	for _, ext := range extInfos {
 		if ext == nil {
@@ -614,13 +615,17 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 		}
 		// 首次加载的扩展直接激活
 		if first, exists := isFirstTimeLoad[ext.Name]; exists && first {
-			group.extActivateInternal(ext, ActivateReasonFirstMessage)
-			known[ext.Name] = struct{}{}
+			group.autoActivateInternal(ext, preserveExistingPriority)
+			for _, activated := range group.activatedExtList {
+				known[activated.Name] = struct{}{}
+			}
 			continue
 		}
 		if ext.AutoActive {
-			group.extActivateInternal(ext, ActivateReasonFirstMessage)
-			known[ext.Name] = struct{}{}
+			group.autoActivateInternal(ext, preserveExistingPriority)
+			for _, activated := range group.activatedExtList {
+				known[activated.Name] = struct{}{}
+			}
 		} else {
 			group.AddToInactivated(ext.Name)
 		}
@@ -694,6 +699,39 @@ func (group *GroupInfo) promoteExt(ext *ExtInfo) {
 	group.activatedExtList = append([]*ExtInfo{ext}, group.activatedExtList...)
 }
 
+// autoActivateInternal 自动激活新扩展。已有扩展时追加到末尾，避免安装插件改变群内现有规则优先级。
+func (group *GroupInfo) autoActivateInternal(ext *ExtInfo, preserveExistingPriority bool) {
+	if !preserveExistingPriority {
+		group.extActivateInternal(ext, ActivateReasonFirstMessage)
+		return
+	}
+	if ext == nil || ext.dice == nil {
+		return
+	}
+
+	d := ext.dice
+	activationOrder := []*ExtInfo{ext}
+	for _, name := range collectChainedNames(d.Logger, d.activeWithGraph(), ext.Name, maxChainDepth) {
+		if chained := d.ExtFind(name, false); chained != nil {
+			activationOrder = append(activationOrder, chained)
+		}
+	}
+
+	changed := false
+	// 手动激活通过依次前插得到反向优先级；低优先级追加时也保持同样的链内顺序。
+	for index := len(activationOrder) - 1; index >= 0; index-- {
+		item := activationOrder[index]
+		if group.IsExtInactivated(item.Name) || group.indexOfActivated(item.Name) != -1 {
+			continue
+		}
+		group.activatedExtList = append(group.activatedExtList, item)
+		changed = true
+	}
+	if changed {
+		group.MarkDirty(d)
+	}
+}
+
 func (group *GroupInfo) extDeactivateInternal(ei *ExtInfo, reason DeactivateReason, markInactivated bool) *ExtInfo {
 	if ei == nil || ei.dice == nil {
 		return nil
@@ -749,13 +787,17 @@ func (group *GroupInfo) SyncExtensionsOnMessage(d *Dice) {
 	for name := range group.InactivatedExtSet {
 		known[name] = struct{}{}
 	}
+	preserveExistingPriority := len(group.activatedExtList) > 0
 
 	for _, ext := range d.ExtList {
 		if _, exists := known[ext.Name]; exists {
 			continue
 		}
 		if ext != nil && ext.AutoActive {
-			group.extActivateInternal(ext, ActivateReasonFirstMessage)
+			group.autoActivateInternal(ext, preserveExistingPriority)
+			for _, activated := range group.activatedExtList {
+				known[activated.Name] = struct{}{}
+			}
 		} else {
 			group.AddToInactivated(ext.Name)
 		}

--- a/dice/ext.go
+++ b/dice/ext.go
@@ -38,6 +38,13 @@ const (
 // ActiveWithGraph 描述扩展伴随关系：A -> [B,C] 表示激活 A 时需要附带 B、C。
 type ActiveWithGraph map[string][]string
 
+type extensionActivationPlacement uint8
+
+const (
+	extensionActivationPromote extensionActivationPlacement = iota
+	extensionActivationAppend
+)
+
 func (d *Dice) rebuildActiveWithGraph() {
 	d.ActiveWithGraphMu.Lock()
 	defer d.ActiveWithGraphMu.Unlock()
@@ -593,13 +600,16 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 	group.ensureInactivatedSet()
 
 	// 构建已知扩展集合
-	known := make(map[string]struct{}, len(group.activatedExtList))
+	known := make(map[string]struct{}, len(group.activatedExtList)+len(group.InactivatedExtSet))
 	for _, ext := range group.activatedExtList {
 		if ext != nil {
 			known[ext.Name] = struct{}{}
 		}
 	}
-	preserveExistingPriority := len(known) > 0
+	for name := range group.InactivatedExtSet {
+		known[name] = struct{}{}
+	}
+	preserveExistingPriority := hasExistingExtensionState(group.activatedExtList, group.InactivatedExtSet)
 
 	for _, ext := range extInfos {
 		if ext == nil {
@@ -609,21 +619,15 @@ func (group *GroupInfo) ExtActivateBatch(extInfos []*ExtInfo, isFirstTimeLoad ma
 		if _, exists := known[ext.Name]; exists {
 			continue
 		}
-		// 跳过被用户关闭的扩展
-		if group.IsExtInactivated(ext.Name) {
-			continue
-		}
 		// 首次加载的扩展直接激活
 		if first, exists := isFirstTimeLoad[ext.Name]; exists && first {
-			group.autoActivateInternal(ext, preserveExistingPriority)
-			for _, activated := range group.activatedExtList {
+			for _, activated := range group.autoActivateInternal(ext, preserveExistingPriority, known) {
 				known[activated.Name] = struct{}{}
 			}
 			continue
 		}
 		if ext.AutoActive {
-			group.autoActivateInternal(ext, preserveExistingPriority)
-			for _, activated := range group.activatedExtList {
+			for _, activated := range group.autoActivateInternal(ext, preserveExistingPriority, known) {
 				known[activated.Name] = struct{}{}
 			}
 		} else {
@@ -671,23 +675,71 @@ func (group *GroupInfo) ExtGetActive(name string) *ExtInfo {
 	return nil
 }
 
+func hasExistingExtensionState(activated []*ExtInfo, inactivated StringSet) bool {
+	if len(inactivated) > 0 {
+		return true
+	}
+	for _, ext := range activated {
+		if ext != nil {
+			return true
+		}
+	}
+	return false
+}
+
 func (group *GroupInfo) extActivateInternal(ei *ExtInfo, reason ActivateReason) {
+	group.activateExtensionChain(ei, reason, extensionActivationPromote, nil)
+}
+
+// activateExtensionChain 统一处理主扩展及其伴随扩展的激活顺序和状态更新。
+func (group *GroupInfo) activateExtensionChain(
+	ei *ExtInfo,
+	reason ActivateReason,
+	placement extensionActivationPlacement,
+	known map[string]struct{},
+) []*ExtInfo {
 	if ei == nil || ei.dice == nil {
-		return
+		return nil
 	}
 	group.ensureInactivatedSet()
 	d := ei.dice
-	graph := d.activeWithGraph()
-	// 先激活主扩展
-	group.promoteExt(ei)
-	// 再激活伴随扩展，使其指令优先级更高（越晚激活优先级越高）
-	names := collectChainedNames(d.Logger, graph, ei.Name, maxChainDepth)
-	for _, name := range names {
-		if ext := d.ExtFind(name, false); ext != nil {
-			group.promoteExt(ext)
+	activationOrder := []*ExtInfo{ei}
+	for _, name := range collectChainedNames(d.Logger, d.activeWithGraph(), ei.Name, maxChainDepth) {
+		if chained := d.ExtFind(name, false); chained != nil {
+			activationOrder = append(activationOrder, chained)
 		}
 	}
-	group.MarkDirty(d)
+
+	activated := make([]*ExtInfo, 0, len(activationOrder))
+	switch placement {
+	case extensionActivationAppend:
+		// 头插会反转激活链顺序；尾插也按反序追加，以保持相同的链内优先级。
+		for index := len(activationOrder) - 1; index >= 0; index-- {
+			item := activationOrder[index]
+			if group.IsExtInactivated(item.Name) {
+				continue
+			}
+			if known != nil {
+				if _, exists := known[item.Name]; exists {
+					continue
+				}
+			} else if group.indexOfActivated(item.Name) != -1 {
+				continue
+			}
+			group.activatedExtList = append(group.activatedExtList, item)
+			activated = append(activated, item)
+		}
+	default:
+		for _, item := range activationOrder {
+			group.promoteExt(item)
+			activated = append(activated, item)
+		}
+	}
+
+	if len(activated) > 0 {
+		group.MarkDirty(d)
+	}
+	return activated
 }
 
 func (group *GroupInfo) promoteExt(ext *ExtInfo) {
@@ -699,37 +751,17 @@ func (group *GroupInfo) promoteExt(ext *ExtInfo) {
 	group.activatedExtList = append([]*ExtInfo{ext}, group.activatedExtList...)
 }
 
-// autoActivateInternal 自动激活新扩展。已有扩展时追加到末尾，避免安装插件改变群内现有规则优先级。
-func (group *GroupInfo) autoActivateInternal(ext *ExtInfo, preserveExistingPriority bool) {
-	if !preserveExistingPriority {
-		group.extActivateInternal(ext, ActivateReasonFirstMessage)
-		return
+// autoActivateInternal 自动激活新扩展。已有扩展状态时追加到末尾，避免改变群内现有规则优先级。
+func (group *GroupInfo) autoActivateInternal(
+	ext *ExtInfo,
+	preserveExistingPriority bool,
+	known map[string]struct{},
+) []*ExtInfo {
+	placement := extensionActivationPromote
+	if preserveExistingPriority {
+		placement = extensionActivationAppend
 	}
-	if ext == nil || ext.dice == nil {
-		return
-	}
-
-	d := ext.dice
-	activationOrder := []*ExtInfo{ext}
-	for _, name := range collectChainedNames(d.Logger, d.activeWithGraph(), ext.Name, maxChainDepth) {
-		if chained := d.ExtFind(name, false); chained != nil {
-			activationOrder = append(activationOrder, chained)
-		}
-	}
-
-	changed := false
-	// 手动激活通过依次前插得到反向优先级；低优先级追加时也保持同样的链内顺序。
-	for index := len(activationOrder) - 1; index >= 0; index-- {
-		item := activationOrder[index]
-		if group.IsExtInactivated(item.Name) || group.indexOfActivated(item.Name) != -1 {
-			continue
-		}
-		group.activatedExtList = append(group.activatedExtList, item)
-		changed = true
-	}
-	if changed {
-		group.MarkDirty(d)
-	}
+	return group.activateExtensionChain(ext, ActivateReasonFirstMessage, placement, known)
 }
 
 func (group *GroupInfo) extDeactivateInternal(ei *ExtInfo, reason DeactivateReason, markInactivated bool) *ExtInfo {
@@ -787,15 +819,14 @@ func (group *GroupInfo) SyncExtensionsOnMessage(d *Dice) {
 	for name := range group.InactivatedExtSet {
 		known[name] = struct{}{}
 	}
-	preserveExistingPriority := len(group.activatedExtList) > 0
+	preserveExistingPriority := hasExistingExtensionState(group.activatedExtList, group.InactivatedExtSet)
 
 	for _, ext := range d.ExtList {
 		if _, exists := known[ext.Name]; exists {
 			continue
 		}
 		if ext != nil && ext.AutoActive {
-			group.autoActivateInternal(ext, preserveExistingPriority)
-			for _, activated := range group.activatedExtList {
+			for _, activated := range group.autoActivateInternal(ext, preserveExistingPriority, known) {
 				known[activated.Name] = struct{}{}
 			}
 		} else {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -159,6 +159,7 @@ func (g *GroupInfo) GetActivatedExtList(d *Dice) []*ExtInfo {
 			activated[item.Name] = true
 		}
 	}
+	preserveExistingPriority := len(newList) > 0
 
 	// 延迟激活新扩展：检查 ExtList 中是否有新扩展需要激活
 	// 新扩展 = 不在 activatedExtList 中，也不在 InactivatedExtSet 中
@@ -178,7 +179,12 @@ func (g *GroupInfo) GetActivatedExtList(d *Dice) []*ExtInfo {
 		}
 		// 新扩展：根据 AutoActive 决定是否激活
 		if ext.AutoActive {
-			newList = append([]*ExtInfo{ext}, newList...) // 插入头部
+			if preserveExistingPriority {
+				// 已有群保持当前规则优先级，新安装扩展仅追加到末尾。
+				newList = append(newList, ext)
+			} else {
+				newList = append([]*ExtInfo{ext}, newList...)
+			}
 			activated[ext.Name] = true
 			newExtCount++
 		} else {

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -159,11 +159,10 @@ func (g *GroupInfo) GetActivatedExtList(d *Dice) []*ExtInfo {
 			activated[item.Name] = true
 		}
 	}
-	preserveExistingPriority := len(newList) > 0
-
 	// 延迟激活新扩展：检查 ExtList 中是否有新扩展需要激活
 	// 新扩展 = 不在 activatedExtList 中，也不在 InactivatedExtSet 中
 	g.ensureInactivatedSet()
+	preserveExistingPriority := hasExistingExtensionState(newList, g.InactivatedExtSet)
 	newExtCount := 0
 	for _, ext := range d.ExtList {
 		if ext == nil {


### PR DESCRIPTION
## Summary by Sourcery

在分组中自动激活新安装扩展时，保留已有扩展的优先级。

New Features:
- 添加 `autoActivateInternal`，以支持在自动激活扩展及其依赖链时，保留其优先级。

Bug Fixes:
- 防止新安装的自动激活扩展更改分组中现有规则/优先级顺序。

Enhancements:
- 调整批量激活和同步逻辑，以使用新的自动激活行为，并相应刷新已知扩展集。
- 更新 `GetActivatedExtList` 中的延迟激活逻辑，当某个分组中已经存在激活规则时，将新的自动激活扩展追加其后，从而保持当前优先级不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve existing extension priority when auto-activating newly installed extensions in groups.

New Features:
- Add autoActivateInternal to support priority-preserving auto-activation of extensions and their dependency chains.

Bug Fixes:
- Prevent newly installed auto-active extensions from changing the existing rule/priority order in groups.

Enhancements:
- Adjust batch activation and sync logic to use the new auto-activation behavior and refresh known extension sets accordingly.
- Update delayed activation in GetActivatedExtList to append new auto-active extensions when a group already has active rules, keeping current priorities intact.

</details>