### PR TITLE
feat(ext): 根据规则模板提高关联扩展命令优先级

### DIFF
--- a/dice/cmd_priority.go
+++ b/dice/cmd_priority.go
@@ -1,0 +1,59 @@
+package dice
+
+import "strings"
+
+// commandExtensionOrder returns activated extensions in command-resolution
+// order. Extensions related to the current game system are promoted as one
+// stable tier; all relative ordering inside and outside that tier is retained.
+func commandExtensionOrder(group *GroupInfo, d *Dice) []*ExtInfo {
+	if group == nil || d == nil {
+		return nil
+	}
+
+	activated := group.GetActivatedExtList(d)
+	if group.System == "" || d.GameSystemMap == nil {
+		return activated
+	}
+
+	tmpl, ok := d.GameSystemMap.Load(group.System)
+	if !ok || tmpl == nil || len(tmpl.SetConfig.RelatedExt) == 0 {
+		return activated
+	}
+
+	preferred := make(map[string]struct{})
+	graph := d.activeWithGraph()
+	for _, related := range tmpl.SetConfig.RelatedExt {
+		related = strings.TrimSpace(related)
+		if related == "" {
+			continue
+		}
+
+		name := d.ExtAliasToName(related)
+		preferred[strings.ToLower(name)] = struct{}{}
+		for _, chained := range collectChainedNames(d.Logger, graph, name, maxChainDepth) {
+			preferred[strings.ToLower(chained)] = struct{}{}
+		}
+	}
+	if len(preferred) == 0 {
+		return activated
+	}
+
+	ordered := make([]*ExtInfo, 0, len(activated))
+	for _, ext := range activated {
+		if ext == nil {
+			continue
+		}
+		if _, ok := preferred[strings.ToLower(ext.Name)]; ok {
+			ordered = append(ordered, ext)
+		}
+	}
+	for _, ext := range activated {
+		if ext == nil {
+			continue
+		}
+		if _, ok := preferred[strings.ToLower(ext.Name)]; !ok {
+			ordered = append(ordered, ext)
+		}
+	}
+	return ordered
+}

--- a/dice/cmd_priority_internal_test.go
+++ b/dice/cmd_priority_internal_test.go
@@ -1,0 +1,321 @@
+package dice
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func addTestGameSystem(d *Dice, name string, relatedExt ...string) {
+	tmpl := &GameSystemTemplate{
+		GameSystemTemplateV2: &GameSystemTemplateV2{
+			Name: name,
+			Commands: Commands{
+				Set: SetConfig{RelatedExt: relatedExt},
+			},
+		},
+	}
+	tmpl.Init()
+	if d.GameSystemMap == nil {
+		d.GameSystemMap = new(SyncMap[string, *GameSystemTemplate])
+	}
+	d.GameSystemMap.Store(name, tmpl)
+}
+
+func TestCommandExtensionOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		system     string
+		relatedExt []string
+		exts       []*ExtInfo
+		activated  []string
+		want       []string
+	}{
+		{
+			name:      "no selected system preserves activation order",
+			exts:      []*ExtInfo{{Name: "cpr"}, {Name: "coc7"}, {Name: "dnd5e"}},
+			activated: []string{"cpr", "coc7", "dnd5e"},
+			want:      []string{"cpr", "coc7", "dnd5e"},
+		},
+		{
+			name:       "coc promotes only coc extension",
+			system:     "coc7",
+			relatedExt: []string{"coc7"},
+			exts:       []*ExtInfo{{Name: "cpr"}, {Name: "dnd5e"}, {Name: "coc7"}},
+			activated:  []string{"cpr", "dnd5e", "coc7"},
+			want:       []string{"coc7", "cpr", "dnd5e"},
+		},
+		{
+			name:       "cpr tier preserves member order",
+			system:     "cpr",
+			relatedExt: []string{"coc7", "cpr"},
+			exts:       []*ExtInfo{{Name: "dnd5e"}, {Name: "coc7"}, {Name: "cpr"}},
+			activated:  []string{"cpr", "dnd5e", "coc7"},
+			want:       []string{"cpr", "coc7", "dnd5e"},
+		},
+		{
+			name:       "active-with chain joins system tier recursively",
+			system:     "base",
+			relatedExt: []string{"base"},
+			exts: []*ExtInfo{
+				{Name: "other"},
+				{Name: "base"},
+				{Name: "level1", ActiveWith: []string{"base"}},
+				{Name: "level2", ActiveWith: []string{"level1"}},
+			},
+			activated: []string{"other", "level2", "base", "level1"},
+			want:      []string{"level2", "base", "level1", "other"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := newTestDice(tt.exts)
+			if tt.system != "" {
+				addTestGameSystem(d, tt.system, tt.relatedExt...)
+			}
+			group := newTestGroupInfo()
+			activated := make([]*ExtInfo, 0, len(tt.activated))
+			for _, name := range tt.activated {
+				activated = append(activated, d.ExtFind(name, false))
+			}
+			group.SetActivatedExtList(activated, d)
+			group.System = tt.system
+
+			got := extListToNames(commandExtensionOrder(group, d))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("commandExtensionOrder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandPriorityFollowsSelectedGameSystem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		system        string
+		relatedExt    []string
+		activated     []string
+		command       string
+		wantExtension string
+	}{
+		{
+			name:          "coc ra wins over cpr",
+			system:        "coc7",
+			relatedExt:    []string{"coc7"},
+			activated:     []string{"cpr", "coc7", "dnd5e"},
+			command:       "ra",
+			wantExtension: "coc7",
+		},
+		{
+			name:          "cpr ra wins inside cpr tier",
+			system:        "cpr",
+			relatedExt:    []string{"coc7", "cpr"},
+			activated:     []string{"cpr", "coc7", "dnd5e"},
+			command:       "ra",
+			wantExtension: "cpr",
+		},
+		{
+			name:          "dnd st wins over generic coc st",
+			system:        "dnd5e",
+			relatedExt:    []string{"dnd5e"},
+			activated:     []string{"coc7", "dnd5e", "cpr"},
+			command:       "st",
+			wantExtension: "dnd5e",
+		},
+		{
+			name:          "cpr falls back to generic coc st in its tier",
+			system:        "cpr",
+			relatedExt:    []string{"coc7", "cpr"},
+			activated:     []string{"dnd5e", "cpr", "coc7"},
+			command:       "st",
+			wantExtension: "coc7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			calls := map[string]int{}
+			exts := make([]*ExtInfo, 0, 3)
+			for _, name := range []string{"coc7", "dnd5e", "cpr"} {
+				extName := name
+				cmdMap := CmdMapCls{}
+				if tt.command != "st" || name != "cpr" {
+					cmdMap[tt.command] = &CmdItemInfo{
+						Name: tt.command,
+						Solve: func(_ *MsgContext, _ *Message, _ *CmdArgs) CmdExecuteResult {
+							calls[extName]++
+							return CmdExecuteResult{Matched: true, Solved: true}
+						},
+					}
+				}
+				exts = append(exts, &ExtInfo{
+					Name:           name,
+					CmdMap:         cmdMap,
+					DefaultSetting: &ExtDefaultSettingItem{DisabledCommand: map[string]bool{}},
+				})
+			}
+
+			d := newTestDice(exts)
+			d.CmdMap = CmdMapCls{}
+			addTestGameSystem(d, tt.system, tt.relatedExt...)
+			group := newTestGroupInfo()
+			activated := make([]*ExtInfo, 0, len(tt.activated))
+			for _, name := range tt.activated {
+				activated = append(activated, d.ExtFind(name, false))
+			}
+			group.SetActivatedExtList(activated, d)
+			group.Active = true
+			group.System = tt.system
+			session := &IMSession{Parent: d}
+			ctx := &MsgContext{
+				Dice:      d,
+				Session:   session,
+				Group:     group,
+				IsPrivate: true,
+			}
+
+			if !session.commandSolve(ctx, &Message{}, &CmdArgs{Command: tt.command}) {
+				t.Fatal("expected command to be solved")
+			}
+			if calls[tt.wantExtension] != 1 {
+				t.Fatalf("calls = %v, want only %s", calls, tt.wantExtension)
+			}
+			for name, count := range calls {
+				if name != tt.wantExtension && count != 0 {
+					t.Fatalf("calls = %v, unexpected execution by %s", calls, name)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandPrioritySurvivesGroupReload(t *testing.T) {
+	t.Parallel()
+
+	coc := &ExtInfo{Name: "coc7"}
+	cpr := &ExtInfo{Name: "cpr"}
+	d := newTestDice([]*ExtInfo{coc, cpr})
+	addTestGameSystem(d, "cpr", "coc7", "cpr")
+
+	group := newTestGroupInfo()
+	group.System = "cpr"
+	group.SetActivatedExtList([]*ExtInfo{cpr, coc}, d)
+	data, err := json.Marshal(group)
+	if err != nil {
+		t.Fatalf("marshal group: %v", err)
+	}
+
+	reloaded := &GroupInfo{}
+	if err := json.Unmarshal(data, reloaded); err != nil {
+		t.Fatalf("unmarshal group: %v", err)
+	}
+	got := extListToNames(commandExtensionOrder(reloaded, d))
+	want := []string{"cpr", "coc7"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command order after reload = %v, want %v", got, want)
+	}
+}
+
+func TestCommandPrioritySurvivesJSWrapperRefresh(t *testing.T) {
+	t.Parallel()
+
+	coc := &ExtInfo{Name: "coc7"}
+	cprWrapper := &ExtInfo{
+		Name:           "cpr",
+		TargetName:     "cpr",
+		IsWrapper:      true,
+		DefaultSetting: &ExtDefaultSettingItem{DisabledCommand: map[string]bool{}},
+	}
+	d := newTestDice([]*ExtInfo{coc, cprWrapper})
+	d.JsExtRegistry = new(SyncMap[string, *ExtInfo])
+	d.JsExtRegistry.Store("cpr", &ExtInfo{Name: "cpr", CmdMap: CmdMapCls{"ra": {Name: "old"}}})
+	addTestGameSystem(d, "cpr", "coc7", "cpr")
+	group := newTestGroupInfo()
+	group.System = "cpr"
+	group.SetActivatedExtList([]*ExtInfo{cprWrapper, coc}, d)
+
+	d.JsExtRegistry.Store("cpr", &ExtInfo{Name: "cpr", CmdMap: CmdMapCls{"ra": {Name: "reloaded"}}})
+	got := extListToNames(commandExtensionOrder(group, d))
+	want := []string{"cpr", "coc7"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command order after JS wrapper refresh = %v, want %v", got, want)
+	}
+	if gotItem := cprWrapper.GetCmdMap()["ra"]; gotItem == nil || gotItem.Name != "reloaded" {
+		t.Fatalf("wrapper did not expose reloaded command: %#v", gotItem)
+	}
+}
+
+func TestBuiltinGameSystemsRelateTheirRuleExtensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		file string
+		want []string
+	}{
+		{file: "coc7.yaml", want: []string{"coc7"}},
+		{file: "dnd5e.yaml", want: []string{"dnd5e"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			t.Parallel()
+
+			tmpl, err := loadBuiltinTemplate(tt.file)
+			if err != nil {
+				t.Fatalf("load built-in template: %v", err)
+			}
+			if !reflect.DeepEqual(tmpl.SetConfig.RelatedExt, tt.want) {
+				t.Fatalf("related extensions = %v, want %v", tmpl.SetConfig.RelatedExt, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandReceivedHooksStillUseAllActivatedExtensions(t *testing.T) {
+	t.Parallel()
+
+	hookCalls := map[string]int{}
+	newExt := func(name string) *ExtInfo {
+		return &ExtInfo{
+			Name: name,
+			OnCommandReceived: func(_ *MsgContext, _ *Message, _ *CmdArgs) {
+				hookCalls[name]++
+			},
+			DefaultSetting: &ExtDefaultSettingItem{DisabledCommand: map[string]bool{}},
+		}
+	}
+	coc := newExt("coc7")
+	coc.CmdMap = CmdMapCls{
+		"st": {
+			Name: "st",
+			Solve: func(_ *MsgContext, _ *Message, _ *CmdArgs) CmdExecuteResult {
+				return CmdExecuteResult{Matched: true, Solved: true}
+			},
+		},
+	}
+	lowPriority := newExt("unrelated")
+	d := newTestDice([]*ExtInfo{coc, lowPriority})
+	d.CmdMap = CmdMapCls{}
+	addTestGameSystem(d, "fu", "coc7")
+	group := newTestGroupInfo()
+	group.Active = true
+	group.System = "fu"
+	group.SetActivatedExtList([]*ExtInfo{lowPriority, coc}, d)
+	session := &IMSession{Parent: d}
+	ctx := &MsgContext{Dice: d, Session: session, Group: group, IsPrivate: true}
+
+	if !session.commandSolve(ctx, &Message{}, &CmdArgs{Command: "st"}) {
+		t.Fatal("expected st command to be solved")
+	}
+	if hookCalls["coc7"] != 1 || hookCalls["unrelated"] != 1 {
+		t.Fatalf("OnCommandReceived calls = %v, want every activated extension once", hookCalls)
+	}
+}

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -219,6 +219,10 @@ func (d *Dice) JsInit() {
 				wrapper.IsDeleted = false         // 重新激活（清除删除标记）
 				wrapper.dice = d                  // 确保 dice 引用正确（可能从配置恢复时为 nil）
 				wrapper.JSLoopVersion = versionID // 同步新的 loop 版本号，避免 callWithJsCheck 时版本不匹配
+				d.ActiveWithGraphMu.Lock()
+				wrapper.ActiveWith = append([]string(nil), realExt.ActiveWith...)
+				d.ActiveWithGraph = nil
+				d.ActiveWithGraphMu.Unlock()
 			} else {
 				// 首次加载：创建新 wrapper
 				wrapper = &ExtInfo{
@@ -233,6 +237,7 @@ func (d *Dice) JsInit() {
 					IsJsExt:       true,               // 标记为 JS 扩展
 					Brief:         "一个JS自定义扩展",
 					Official:      realExt.Official,
+					ActiveWith:    append([]string(nil), realExt.ActiveWith...),
 					CmdMap:        CmdMapCls{},
 					JSLoopVersion: versionID,
 					dice:          d,

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1562,7 +1562,7 @@ func (ep *EndPointInfo) TriggerCommand(mctx *MsgContext, msg *Message, cmdArgs *
 	var ret bool
 	// 试图匹配自定义指令
 	if mctx.Group != nil && mctx.Group.IsActive(mctx) {
-		for _, wrapper := range mctx.Group.GetActivatedExtList(mctx.Dice) {
+		for _, wrapper := range commandExtensionOrder(mctx.Group, mctx.Dice) {
 			ext := wrapper.GetRealExt()
 			if ext == nil {
 				continue
@@ -2218,7 +2218,7 @@ func (s *IMSession) commandSolve(ctx *MsgContext, msg *Message, cmdArgs *CmdArgs
 		}
 
 		if group != nil && (group.Active || ctx.IsCurGroupBotOn) {
-			for _, wrapper := range group.GetActivatedExtList(ctx.Dice) {
+			for _, wrapper := range commandExtensionOrder(group, ctx.Dice) {
 				cmdMap := wrapper.GetCmdMap()
 				item := cmdMap[cmdArgs.Command]
 				if tryItemSolve(wrapper, item) {


### PR DESCRIPTION
> 根据规则模板关联扩展调整指令优先级。

## Summary

- derive a non-persistent command-priority tier from the selected game-system template’s existing `relatedExt`
- recursively include extensions connected through the existing `ActiveWith` relationship
- preserve relative order within both the rule-related and ordinary extension tiers
- keep unrelated extension commands available while preventing them from overriding commands related to the selected system
- preserve `OnCommandReceived` broadcasts and JS wrapper ordering across reloads

## Behavior

Core commands retain their existing priority. Active extensions are resolved in this order:

1. extensions related to the selected game system, including recursive `ActiveWith` followers
2. all remaining active extensions

No new extension or command fields are introduced, and the persisted activated-extension order is not rewritten.

## Tests

- `go test ./dice -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 run --timeout 10m`

## Summary by Sourcery

根据所选游戏系统优先解析扩展命令，同时保留现有的激活与钩子行为。

新功能：
- 引入 `commandExtensionOrder`，用于重新排序已激活的扩展，使与当前游戏系统相关的扩展（包括 ActiveWith 链）优先被解析。

缺陷修复：
- 确保 JS 扩展包装器能够保持并刷新 ActiveWith 关联关系，从而在重载过程中继续保证命令优先级和基于图的解析逻辑正确。

改进：
- 调整群组和会话处理器中的命令分发逻辑，以使用新的优先扩展排序，同时不更改已有的激活列表存储。
- 添加全面测试，覆盖命令优先级行为、在群组重载和 JS 包装器刷新后的持久性、内置模板 `RelatedExt` 配置，以及 `OnCommandReceived` 钩子调用语义。

测试：
- 添加 `cmd_priority_internal_test`，用于验证扩展排序、基于游戏系统驱动的命令优先级、ActiveWith 链式关系、跨重载的持久性、JS 包装器更新、内置模板 `RelatedExt` 值以及命令接收钩子行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prioritize extension command resolution based on the selected game system while preserving existing activation and hook behavior.

New Features:
- Introduce commandExtensionOrder to reorder activated extensions so those related to the current game system (including ActiveWith chains) are resolved first.

Bug Fixes:
- Ensure JS extension wrappers retain and refresh ActiveWith relationships so command priority and graph-based resolution remain correct across reloads.

Enhancements:
- Adjust command dispatch in group and session handlers to use the new prioritized extension ordering without altering stored activation lists.
- Add comprehensive tests covering command priority behavior, persistence across group reloads and JS wrapper refreshes, built-in template RelatedExt configuration, and OnCommandReceived hook invocation semantics.

Tests:
- Add cmd_priority_internal_test to validate extension ordering, game-system-driven command priority, ActiveWith chaining, persistence across reloads, JS wrapper updates, built-in template RelatedExt values, and command-received hook behavior.

</details>