### PR TITLE
perf(store): 降低扩展包安装的内存占用

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -773,7 +773,6 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.GET(prefix+"/store/file/:namespace/:package/:version", storePackageFilePreview)
 	e.GET("/dice/api/store/files/:namespace/:package/:version", storePackageFiles)
 	e.GET("/dice/api/store/file/:namespace/:package/:version", storePackageFilePreview)
-	e.POST(prefix+"/store/preview-download", storePreviewDownload)
 	e.POST(prefix+"/store/download", storeDownload)
 	e.POST(prefix+"/store/package-info-list", storePackageInfoList)
 	e.POST(prefix+"/store/install-list", storeInstallList)

--- a/api/package.go
+++ b/api/package.go
@@ -170,7 +170,7 @@ func packageInstallFromUpload(c echo.Context) error {
 	}
 	defer req.Body.Close()
 
-	if err := myDice.PackageManager.InstallFromStream(req.Body); err != nil {
+	if err := myDice.PackageManager.InstallFromStreamContext(req.Context(), req.Body); err != nil {
 		return Error(&c, err.Error(), Response{})
 	}
 
@@ -199,7 +199,7 @@ func packagePreviewFromUpload(c echo.Context) error {
 	}
 	defer req.Body.Close()
 
-	preview, err := myDice.PackageManager.PreviewFromStream(req.Body)
+	preview, err := myDice.PackageManager.PreviewFromStreamContext(req.Context(), req.Body)
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}
@@ -231,7 +231,7 @@ func packageInstallFromURL(c echo.Context) error {
 		return Error(&c, err.Error(), Response{})
 	}
 
-	err = myDice.PackageManager.InstallFromURL(params.URL, nil)
+	err = myDice.PackageManager.InstallFromURLContext(c.Request().Context(), params.URL, nil)
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}

--- a/api/store.go
+++ b/api/store.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -106,7 +107,7 @@ func storeSetBackendEnabled(c echo.Context, enabled bool) error {
 }
 
 func storeRecommend(c echo.Context) error {
-	data, err := myDice.StoreManager.StoreQueryRecommend()
+	data, err := myDice.StoreManager.StoreQueryRecommendContext(c.Request().Context())
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}
@@ -122,7 +123,7 @@ func storeGetPage(c echo.Context) error {
 		return Error(&c, err.Error(), Response{})
 	}
 
-	page, err := myDice.StoreManager.StoreQueryPage(params)
+	page, err := myDice.StoreManager.StoreQueryPageContext(c.Request().Context(), params)
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}
@@ -136,7 +137,7 @@ func storeGetPage(c echo.Context) error {
 }
 
 func storePackageFiles(c echo.Context) error {
-	files, err := myDice.StoreManager.StoreQueryPackageFiles(c.Param("namespace"), c.Param("package"), c.Param("version"))
+	files, err := myDice.StoreManager.StoreQueryPackageFilesContext(c.Request().Context(), c.Param("namespace"), c.Param("package"), c.Param("version"))
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}
@@ -194,7 +195,7 @@ func storeDownload(c echo.Context) error {
 		return Error(&c, err.Error(), Response{})
 	}
 
-	if _, err := installStorePackage(target, true); err != nil {
+	if _, err := installStorePackageContext(c.Request().Context(), target, true); err != nil {
 		return Error(&c, err.Error(), Response{})
 	}
 
@@ -315,7 +316,10 @@ func storeInstallList(c echo.Context) error {
 		pending = append(pending, pendingStoreInstall{target: target, resultIndex: index})
 	}
 
-	installStorePackageBatch(results, pending, installStorePackage)
+	ctx := c.Request().Context()
+	installStorePackageBatch(results, pending, func(target *dice.StorePackage, reinstallExactVersion bool) (string, error) {
+		return installStorePackageContext(ctx, target, reinstallExactVersion)
+	})
 
 	installedCount := 0
 	skippedCount := 0
@@ -385,7 +389,10 @@ func installStorePackageBatch(
 	}
 }
 
-func installStorePackage(target *dice.StorePackage, reinstallExactVersion bool) (string, error) {
+func installStorePackageContext(ctx context.Context, target *dice.StorePackage, reinstallExactVersion bool) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	if installedPkg, exists := myDice.PackageManager.Get(target.ID); exists && installedPkg != nil && installedPkg.Manifest != nil {
 		existingVer, existingErr := semver.NewVersion(installedPkg.Manifest.Package.Version)
 		targetVer, targetErr := semver.NewVersion(target.Version)
@@ -402,7 +409,10 @@ func installStorePackage(target *dice.StorePackage, reinstallExactVersion bool) 
 		}
 	}
 
-	if err := myDice.PackageManager.InstallFromURL(target.Download.URL, target.Download.Hash); err != nil {
+	if err := myDice.PackageManager.InstallFromURLWithOptionsContext(ctx, target.Download.URL, dice.PackageDownloadOptions{
+		Hashes:       target.Download.Hash,
+		ExpectedSize: target.Download.Size,
+	}); err != nil {
 		return "", err
 	}
 	myDice.StoreManager.RefreshInstalled([]*dice.StorePackage{target})
@@ -426,7 +436,10 @@ func storePreviewDownload(c echo.Context) error {
 		return Error(&c, "未找到已缓存的商店包，请先刷新商店列表后重试", Response{})
 	}
 
-	preview, err := myDice.PackageManager.PreviewFromURL(target.Download.URL, target.Download.Hash)
+	preview, err := myDice.PackageManager.PreviewFromURLWithOptionsContext(c.Request().Context(), target.Download.URL, dice.PackageDownloadOptions{
+		Hashes:       target.Download.Hash,
+		ExpectedSize: target.Download.Size,
+	})
 	if err != nil {
 		return Error(&c, err.Error(), Response{})
 	}

--- a/api/store.go
+++ b/api/store.go
@@ -419,36 +419,6 @@ func installStorePackageContext(ctx context.Context, target *dice.StorePackage, 
 	return "installed", nil
 }
 
-func storePreviewDownload(c echo.Context) error {
-	if !doAuth(c) {
-		return c.JSON(http.StatusForbidden, "auth")
-	}
-	var params struct {
-		ID      string `json:"id"`
-		Version string `json:"version"`
-	}
-	if err := c.Bind(&params); err != nil {
-		return Error(&c, err.Error(), Response{})
-	}
-
-	target, ok := myDice.StoreManager.FindPackage(params.ID, params.Version)
-	if !ok {
-		return Error(&c, "未找到已缓存的商店包，请先刷新商店列表后重试", Response{})
-	}
-
-	preview, err := myDice.PackageManager.PreviewFromURLWithOptionsContext(c.Request().Context(), target.Download.URL, dice.PackageDownloadOptions{
-		Hashes:       target.Download.Hash,
-		ExpectedSize: target.Download.Size,
-	})
-	if err != nil {
-		return Error(&c, err.Error(), Response{})
-	}
-
-	return Success(&c, Response{
-		"data": preview,
-	})
-}
-
 func storeRating(c echo.Context) error {
 	if !doAuth(c) {
 		return c.JSON(http.StatusForbidden, "auth")

--- a/dice/package_disk_space.go
+++ b/dice/package_disk_space.go
@@ -1,0 +1,154 @@
+package dice
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
+)
+
+const (
+	packageDiskReserve       uint64 = 10 << 20
+	packageDiskCheckInterval uint64 = 8 << 20
+)
+
+type packageDiskSpace struct {
+	Volume    string
+	Available uint64
+	Total     uint64
+}
+
+var probePackageDiskSpace = platformPackageDiskSpace
+
+type packageDiskRequirement struct {
+	path  string
+	bytes uint64
+}
+
+func (pm *PackageManager) checkPackageDiskRequirements(requirements ...packageDiskRequirement) error {
+	type volumeRequirement struct {
+		path      string
+		available uint64
+		required  uint64
+	}
+	volumes := map[string]*volumeRequirement{}
+	for _, requirement := range requirements {
+		if requirement.path == "" {
+			continue
+		}
+		space, err := probePackageDiskSpace(requirement.path)
+		if err != nil {
+			pm.warnDiskProbe(requirement.path, err)
+			continue
+		}
+		entry := volumes[space.Volume]
+		if entry == nil {
+			entry = &volumeRequirement{path: requirement.path, available: space.Available}
+			volumes[space.Volume] = entry
+		}
+		if math.MaxUint64-entry.required < requirement.bytes {
+			return errors.New("扩展包所需磁盘空间计算溢出")
+		}
+		entry.required += requirement.bytes
+	}
+
+	for _, volume := range volumes {
+		if math.MaxUint64-volume.required < packageDiskReserve {
+			return errors.New("扩展包所需磁盘空间计算溢出")
+		}
+		required := volume.required + packageDiskReserve
+		if volume.available < required {
+			return fmt.Errorf("磁盘空间不足: %s 需要 %s（含 10 MiB 预留），当前可用 %s",
+				filepath.Clean(volume.path), formatPackageBytes(required), formatPackageBytes(volume.available))
+		}
+	}
+	return nil
+}
+
+func (pm *PackageManager) warnDiskProbe(path string, err error) {
+	if pm != nil && pm.parent != nil && pm.parent.Logger != nil {
+		pm.parent.Logger.Warnf("无法查询扩展包目录磁盘空间 %s，将继续操作: %v", filepath.Clean(path), err)
+	}
+}
+
+type packageDiskGuard struct {
+	pm            *PackageManager
+	path          string
+	expectedTotal uint64
+	written       uint64
+	nextCheck     uint64
+	probeFailed   bool
+}
+
+func newPackageDiskGuard(pm *PackageManager, path string, expectedTotal uint64) *packageDiskGuard {
+	return &packageDiskGuard{
+		pm:            pm,
+		path:          path,
+		expectedTotal: expectedTotal,
+	}
+}
+
+func (g *packageDiskGuard) BeforeWrite(chunk uint64) error {
+	if math.MaxUint64-g.written < chunk {
+		return errors.New("扩展包写入大小计算溢出")
+	}
+	projected := g.written + chunk
+	if projected < g.nextCheck && (g.expectedTotal == 0 || projected < g.expectedTotal) {
+		g.written = projected
+		return nil
+	}
+
+	if !g.probeFailed {
+		space, err := probePackageDiskSpace(g.path)
+		if err != nil {
+			g.pm.warnDiskProbe(g.path, err)
+			g.probeFailed = true
+		} else {
+			remaining := uint64(0)
+			if g.expectedTotal > projected {
+				remaining = g.expectedTotal - projected
+			}
+			writeBudget := chunk
+			if g.expectedTotal == 0 && writeBudget < packageDiskCheckInterval {
+				writeBudget = packageDiskCheckInterval
+			}
+			if math.MaxUint64-packageDiskReserve < writeBudget {
+				return errors.New("扩展包所需磁盘空间计算溢出")
+			}
+			reservedWrite := packageDiskReserve + writeBudget
+			if math.MaxUint64-remaining < reservedWrite {
+				return errors.New("扩展包所需磁盘空间计算溢出")
+			}
+			required := remaining + reservedWrite
+			if space.Available < required {
+				return fmt.Errorf("磁盘空间不足: %s 继续写入至少需要 %s，当前可用 %s",
+					filepath.Clean(g.path), formatPackageBytes(required), formatPackageBytes(space.Available))
+			}
+		}
+	}
+	g.written = projected
+	if math.MaxUint64-projected < packageDiskCheckInterval {
+		g.nextCheck = math.MaxUint64
+	} else {
+		g.nextCheck = projected + packageDiskCheckInterval
+	}
+	return nil
+}
+
+func formatPackageBytes(value uint64) string {
+	const (
+		kiB = 1 << 10
+		miB = 1 << 20
+		giB = 1 << 30
+	)
+	switch {
+	case value >= giB:
+		return fmt.Sprintf("%.2f GiB", float64(value)/giB)
+	case value >= miB:
+		return fmt.Sprintf("%.2f MiB", float64(value)/miB)
+	case value >= kiB:
+		return fmt.Sprintf("%.2f KiB", float64(value)/kiB)
+	default:
+		return fmt.Sprintf("%d B", value)
+	}
+}

--- a/dice/package_disk_space_other.go
+++ b/dice/package_disk_space_other.go
@@ -1,0 +1,9 @@
+//go:build !windows && !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+
+package dice
+
+import "errors"
+
+func platformPackageDiskSpace(string) (packageDiskSpace, error) {
+	return packageDiskSpace{}, errors.New("当前平台不支持磁盘空间探测")
+}

--- a/dice/package_disk_space_other.go
+++ b/dice/package_disk_space_other.go
@@ -1,4 +1,4 @@
-//go:build !windows && !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
+//go:build !windows && !aix && !darwin && !dragonfly && !freebsd && !linux
 
 package dice
 

--- a/dice/package_disk_space_test.go
+++ b/dice/package_disk_space_test.go
@@ -1,0 +1,84 @@
+package dice //nolint:testpackage
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCheckPackageDiskRequirementsCombinesSameVolume(t *testing.T) {
+	originalProbe := probePackageDiskSpace
+	t.Cleanup(func() { probePackageDiskSpace = originalProbe })
+
+	available := packageDiskReserve + 300
+	probePackageDiskSpace = func(string) (packageDiskSpace, error) {
+		return packageDiskSpace{Volume: "same", Available: available, Total: available}, nil
+	}
+	pm := &PackageManager{}
+	if err := pm.checkPackageDiskRequirements(
+		packageDiskRequirement{path: "source", bytes: 100},
+		packageDiskRequirement{path: "cache", bytes: 200},
+	); err != nil {
+		t.Fatalf("checkPackageDiskRequirements() error = %v", err)
+	}
+
+	available = packageDiskReserve + 299
+	err := pm.checkPackageDiskRequirements(
+		packageDiskRequirement{path: "source", bytes: 100},
+		packageDiskRequirement{path: "cache", bytes: 200},
+	)
+	if err == nil || !strings.Contains(err.Error(), "磁盘空间不足") {
+		t.Fatalf("checkPackageDiskRequirements() error = %v, want insufficient-space rejection", err)
+	}
+}
+
+func TestCheckPackageDiskRequirementsChecksSeparateVolumes(t *testing.T) {
+	originalProbe := probePackageDiskSpace
+	t.Cleanup(func() { probePackageDiskSpace = originalProbe })
+
+	probePackageDiskSpace = func(path string) (packageDiskSpace, error) {
+		available := packageDiskReserve + 100
+		if path == "cache" {
+			available = packageDiskReserve + 199
+		}
+		return packageDiskSpace{Volume: path, Available: available, Total: available}, nil
+	}
+	pm := &PackageManager{}
+	err := pm.checkPackageDiskRequirements(
+		packageDiskRequirement{path: "source", bytes: 100},
+		packageDiskRequirement{path: "cache", bytes: 200},
+	)
+	if err == nil || !strings.Contains(err.Error(), "cache") {
+		t.Fatalf("checkPackageDiskRequirements() error = %v, want cache-volume rejection", err)
+	}
+}
+
+func TestCheckPackageDiskRequirementsContinuesWhenProbeFails(t *testing.T) {
+	originalProbe := probePackageDiskSpace
+	t.Cleanup(func() { probePackageDiskSpace = originalProbe })
+	probePackageDiskSpace = func(string) (packageDiskSpace, error) {
+		return packageDiskSpace{}, errors.New("unsupported")
+	}
+	pm := &PackageManager{}
+	if err := pm.checkPackageDiskRequirements(packageDiskRequirement{path: "source", bytes: 1 << 40}); err != nil {
+		t.Fatalf("checkPackageDiskRequirements() error = %v, want fail-open behavior", err)
+	}
+}
+
+func TestPackageDiskGuardKeepsReserve(t *testing.T) {
+	originalProbe := probePackageDiskSpace
+	t.Cleanup(func() { probePackageDiskSpace = originalProbe })
+	available := packageDiskReserve + packageDiskCheckInterval
+	probePackageDiskSpace = func(string) (packageDiskSpace, error) {
+		return packageDiskSpace{Volume: "same", Available: available, Total: available}, nil
+	}
+	guard := newPackageDiskGuard(&PackageManager{}, "source", 0)
+	if err := guard.BeforeWrite(32); err != nil {
+		t.Fatalf("BeforeWrite() error = %v", err)
+	}
+	available = packageDiskReserve
+	guard.nextCheck = 0
+	if err := guard.BeforeWrite(1); err == nil {
+		t.Fatal("BeforeWrite() error = nil, want reserve rejection")
+	}
+}

--- a/dice/package_disk_space_unix.go
+++ b/dice/package_disk_space_unix.go
@@ -1,0 +1,30 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package dice
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func platformPackageDiskSpace(path string) (packageDiskSpace, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return packageDiskSpace{}, err
+	}
+	var fsStat unix.Statfs_t
+	if err := unix.Statfs(absPath, &fsStat); err != nil {
+		return packageDiskSpace{}, err
+	}
+	var fileStat unix.Stat_t
+	if err := unix.Stat(absPath, &fileStat); err != nil {
+		return packageDiskSpace{}, err
+	}
+	return packageDiskSpace{
+		Volume:    fmt.Sprintf("%d", uint64(fileStat.Dev)),
+		Available: uint64(fsStat.Bavail) * uint64(fsStat.Bsize),
+		Total:     uint64(fsStat.Blocks) * uint64(fsStat.Bsize),
+	}, nil
+}

--- a/dice/package_disk_space_unix.go
+++ b/dice/package_disk_space_unix.go
@@ -1,13 +1,24 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+//go:build aix || darwin || dragonfly || freebsd || linux
 
 package dice
 
 import (
-	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
+
+type packageDiskStatValue interface {
+	~int32 | ~int64 | ~uint32 | ~uint64
+}
+
+func packageDiskStatUint64[T packageDiskStatValue](value T) uint64 {
+	if value < 0 {
+		return 0
+	}
+	return uint64(value)
+}
 
 func platformPackageDiskSpace(path string) (packageDiskSpace, error) {
 	absPath, err := filepath.Abs(path)
@@ -22,9 +33,10 @@ func platformPackageDiskSpace(path string) (packageDiskSpace, error) {
 	if err := unix.Stat(absPath, &fileStat); err != nil {
 		return packageDiskSpace{}, err
 	}
+	blockSize := packageDiskStatUint64(fsStat.Bsize)
 	return packageDiskSpace{
-		Volume:    fmt.Sprintf("%d", uint64(fileStat.Dev)),
-		Available: uint64(fsStat.Bavail) * uint64(fsStat.Bsize),
-		Total:     uint64(fsStat.Blocks) * uint64(fsStat.Bsize),
+		Volume:    strconv.FormatUint(packageDiskStatUint64(fileStat.Dev), 10),
+		Available: packageDiskStatUint64(fsStat.Bavail) * blockSize,
+		Total:     packageDiskStatUint64(fsStat.Blocks) * blockSize,
 	}, nil
 }

--- a/dice/package_disk_space_windows.go
+++ b/dice/package_disk_space_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package dice
+
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func platformPackageDiskSpace(path string) (packageDiskSpace, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return packageDiskSpace{}, err
+	}
+	pathPtr, err := windows.UTF16PtrFromString(absPath)
+	if err != nil {
+		return packageDiskSpace{}, err
+	}
+	var available uint64
+	var total uint64
+	var totalFree uint64
+	if err := windows.GetDiskFreeSpaceEx(pathPtr, &available, &total, &totalFree); err != nil {
+		return packageDiskSpace{}, err
+	}
+	return packageDiskSpace{
+		Volume:    strings.ToUpper(filepath.VolumeName(absPath)),
+		Available: available,
+		Total:     total,
+	}, nil
+}

--- a/dice/package_manager.go
+++ b/dice/package_manager.go
@@ -918,7 +918,7 @@ func (pm *PackageManager) installFromSourceContext(ctx context.Context, pkgPath 
 	return nil
 }
 
-func (pm *PackageManager) prepareDownloadedPackageContext(ctx context.Context, url string, options PackageDownloadOptions, targetDir, pattern string, forInstall bool) (string, uint64, error) {
+func (pm *PackageManager) prepareDownloadedPackageContext(ctx context.Context, url string, options PackageDownloadOptions, targetDir, pattern string) (string, uint64, error) {
 	if strings.TrimSpace(url) == "" {
 		return "", 0, errors.New("未提供下载链接")
 	}
@@ -929,7 +929,7 @@ func (pm *PackageManager) prepareDownloadedPackageContext(ctx context.Context, u
 		return "", 0, errors.New("创建临时目录失败: " + err.Error())
 	}
 	if options.ExpectedSize > 0 {
-		if err := pm.checkIncomingPackageEstimate(targetDir, options.ExpectedSize, forInstall); err != nil {
+		if err := pm.checkIncomingPackageEstimate(targetDir, options.ExpectedSize); err != nil {
 			return "", 0, err
 		}
 	}
@@ -960,7 +960,7 @@ func (pm *PackageManager) prepareDownloadedPackageContext(ctx context.Context, u
 	expectedSize := options.ExpectedSize
 	if resp.ContentLength > 0 {
 		expectedSize = uint64(resp.ContentLength)
-		if diskErr := pm.checkIncomingPackageEstimate(targetDir, expectedSize, forInstall); diskErr != nil {
+		if diskErr := pm.checkIncomingPackageEstimate(targetDir, expectedSize); diskErr != nil {
 			return "", 0, diskErr
 		}
 	}
@@ -988,12 +988,11 @@ func (pm *PackageManager) prepareDownloadedPackageContext(ctx context.Context, u
 	return path, written, nil
 }
 
-func (pm *PackageManager) checkIncomingPackageEstimate(targetDir string, compressedSize uint64, forInstall bool) error {
-	requirements := []packageDiskRequirement{{path: targetDir, bytes: compressedSize}}
-	if forInstall {
-		requirements = append(requirements, packageDiskRequirement{path: pm.getCachePackagesPath(), bytes: compressedSize})
-	}
-	return pm.checkPackageDiskRequirements(requirements...)
+func (pm *PackageManager) checkIncomingPackageEstimate(targetDir string, compressedSize uint64) error {
+	return pm.checkPackageDiskRequirements(
+		packageDiskRequirement{path: targetDir, bytes: compressedSize},
+		packageDiskRequirement{path: pm.getCachePackagesPath(), bytes: compressedSize},
+	)
 }
 
 // InstallFromStream streams an uploaded .sealpack into managed staging, then installs it.
@@ -1022,12 +1021,7 @@ func (pm *PackageManager) InstallFromStreamContext(ctx context.Context, src io.R
 	return pm.installFromSourceContext(ctx, stagedPath, true)
 }
 
-// PreviewFromStream streams an uploaded .sealpack into a temporary file, then inspects it.
-func (pm *PackageManager) PreviewFromStream(src io.Reader) (*PackageUploadPreview, error) {
-	return pm.PreviewFromStreamContext(context.Background(), src)
-}
-
-// PreviewFromStreamContext is the cancellable form of PreviewFromStream.
+// PreviewFromStreamContext streams an uploaded .sealpack into a temporary file, then inspects it.
 func (pm *PackageManager) PreviewFromStreamContext(ctx context.Context, src io.Reader) (*PackageUploadPreview, error) {
 	if src == nil {
 		return nil, errors.New("未提供上传内容")
@@ -1044,19 +1038,6 @@ func (pm *PackageManager) PreviewFromStreamContext(ctx context.Context, src io.R
 	}
 	defer os.Remove(path)
 	return pm.previewFromSourceContext(ctx, path)
-}
-
-func (pm *PackageManager) Preview(pkgPath string) (*PackageUploadPreview, error) {
-	return pm.PreviewContext(context.Background(), pkgPath)
-}
-
-// PreviewContext inspects a managed package source with cancellation support.
-func (pm *PackageManager) PreviewContext(ctx context.Context, pkgPath string) (*PackageUploadPreview, error) {
-	validatedPath, err := pm.validateManagedPackageSource(pkgPath)
-	if err != nil {
-		return nil, err
-	}
-	return pm.previewFromSourceContext(ctx, validatedPath)
 }
 
 func (pm *PackageManager) previewFromSourceContext(ctx context.Context, pkgPath string) (*PackageUploadPreview, error) {
@@ -2398,42 +2379,12 @@ func (pm *PackageManager) InstallFromURLWithOptionsContext(ctx context.Context, 
 	if dirErr := pm.ensurePackageDirs(); dirErr != nil {
 		return dirErr
 	}
-	stagedPath, _, err := pm.prepareDownloadedPackageContext(ctx, url, options, pm.getPackageStagingDir(), "package_download_*.part", true)
+	stagedPath, _, err := pm.prepareDownloadedPackageContext(ctx, url, options, pm.getPackageStagingDir(), "package_download_*.part")
 	if err != nil {
 		return err
 	}
 	defer os.Remove(stagedPath)
 	return pm.installFromSourceContext(ctx, stagedPath, true)
-}
-
-// PreviewFromURL 从 URL 下载扩展包并返回包内容预览。
-func (pm *PackageManager) PreviewFromURL(url string, hashes map[string]string) (*PackageUploadPreview, error) {
-	return pm.PreviewFromURLContext(context.Background(), url, hashes)
-}
-
-// PreviewFromURLContext is the cancellable form of PreviewFromURL.
-func (pm *PackageManager) PreviewFromURLContext(ctx context.Context, url string, hashes map[string]string) (*PackageUploadPreview, error) {
-	return pm.PreviewFromURLWithOptionsContext(ctx, url, PackageDownloadOptions{Hashes: hashes})
-}
-
-// PreviewFromURLWithOptionsContext downloads a package into temporary storage and inspects it.
-func (pm *PackageManager) PreviewFromURLWithOptionsContext(ctx context.Context, url string, options PackageDownloadOptions) (*PackageUploadPreview, error) {
-	release, err := acquirePackageOperation(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer release()
-	tmpPath, _, err := pm.prepareDownloadedPackageContext(ctx, url, options, pm.getPackageTempDir(), "package_preview_download_*.sealpack", false)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if removeErr := os.Remove(tmpPath); removeErr != nil && pm.parent != nil && pm.parent.Logger != nil {
-			pm.parent.Logger.Warnf("清理临时扩展包文件失败 %s: %v", tmpPath, removeErr)
-		}
-	}()
-
-	return pm.previewFromSourceContext(ctx, tmpPath)
 }
 
 func acquirePackageOperation(ctx context.Context) (func(), error) {

--- a/dice/package_manager.go
+++ b/dice/package_manager.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -22,12 +23,26 @@ import (
 	"sealdice-core/dice/sealpack"
 )
 
-const maxPackageArchiveSize int64 = 128 << 20
+const (
+	packageStreamBufferSize           = 32 << 10
+	defaultPackageDownloadIdleTimeout = 2 * time.Minute
+)
+
+var packageOperations = make(chan struct{}, 1)
+
+var packageHTTPClient = newPackageHTTPClient()
+
+func newPackageHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = 30 * time.Second
+	return &http.Client{Transport: transport}
+}
 
 // PackageManager 扩展包管理器
 type PackageManager struct {
-	lock   *sync.RWMutex
-	parent *Dice
+	lock                *sync.RWMutex
+	parent              *Dice
+	downloadIdleTimeout time.Duration
 
 	// 已安装的包
 	packages map[string]*sealpack.Instance
@@ -74,11 +89,18 @@ type PackageUploadPreview struct {
 	InstallAction   string             `json:"installAction"`
 }
 
+// PackageDownloadOptions carries optional store metadata used for early checks.
+type PackageDownloadOptions struct {
+	Hashes       map[string]string
+	ExpectedSize uint64
+}
+
 // NewPackageManager 创建包管理器
 func NewPackageManager(parent *Dice) *PackageManager {
 	pm := &PackageManager{
 		lock:                   new(sync.RWMutex),
 		parent:                 parent,
+		downloadIdleTimeout:    defaultPackageDownloadIdleTimeout,
 		packages:               make(map[string]*sealpack.Instance),
 		dependencyGraph:        make(map[string][]string),
 		reverseDependencyGraph: make(map[string][]string),
@@ -93,6 +115,9 @@ func (pm *PackageManager) Init() error {
 	}
 	if err := pm.ensurePackageDirs(); err != nil {
 		return err
+	}
+	if err := pm.cleanupPackageStagingDir(); err != nil && pm.parent != nil && pm.parent.Logger != nil {
+		pm.parent.Logger.Warnf("清理遗留扩展包暂存文件失败: %v", err)
 	}
 
 	pm.lock.Lock()
@@ -113,7 +138,10 @@ func (pm *PackageManager) ensurePackageDirs() error {
 	if err := os.MkdirAll(pm.getSourcePackagesPath(), 0o755); err != nil {
 		return err
 	}
-	return os.MkdirAll(pm.getCachePackagesPath(), 0o755)
+	if err := os.MkdirAll(pm.getCachePackagesPath(), 0o755); err != nil {
+		return err
+	}
+	return os.MkdirAll(pm.getPackageStagingDir(), 0o755)
 }
 
 func (pm *PackageManager) RefreshFromDisk() (*PackageRefreshResult, error) {
@@ -284,10 +312,14 @@ func (pm *PackageManager) scanCacheArtifacts() map[string]*packageCacheCandidate
 			pm.parent.Logger.Warnf("读取扩展包缓存 manifest 失败 %s: %v", infoPath, openErr)
 			return nil
 		}
-		data, readErr := io.ReadAll(infoFile)
+		data, readErr := io.ReadAll(io.LimitReader(infoFile, sealpack.MaxManifestSize+1))
 		_ = infoFile.Close()
 		if readErr != nil {
 			pm.parent.Logger.Warnf("读取扩展包缓存 manifest 失败 %s: %v", infoPath, readErr)
+			return nil
+		}
+		if int64(len(data)) > sealpack.MaxManifestSize {
+			pm.parent.Logger.Warnf("扩展包缓存 manifest 超过 %d MiB: %s", sealpack.MaxManifestSize/(1024*1024), infoPath)
 			return nil
 		}
 		manifest, parseErr := sealpack.ParseManifest(data)
@@ -447,11 +479,7 @@ func (pm *PackageManager) installCacheMatchesCandidate(candidate *packageArtifac
 	if statErr != nil {
 		return false
 	}
-	data, err := os.ReadFile(infoPath)
-	if err != nil {
-		return false
-	}
-	manifest, parseErr := sealpack.ParseManifest(data)
+	manifest, parseErr := sealpack.ParseManifestFile(infoPath)
 	if parseErr != nil || manifest.Package.ID != candidate.Manifest.Package.ID || manifest.Package.Version != candidate.Manifest.Package.Version {
 		return false
 	}
@@ -463,11 +491,33 @@ func (pm *PackageManager) installCacheMatchesCandidate(candidate *packageArtifac
 }
 
 func (pm *PackageManager) stageExtractPackage(pkgPath, pkgID string) (string, error) {
+	archiveInfo, err := sealpack.InspectArchive(pkgPath)
+	if err != nil {
+		return "", err
+	}
+	return pm.stageExtractPackageContext(context.Background(), pkgPath, pkgID, archiveInfo.UncompressedSize)
+}
+
+func (pm *PackageManager) stageExtractPackageContext(ctx context.Context, pkgPath, pkgID string, uncompressedSize uint64) (string, error) {
+	if err := pm.checkPackageDiskRequirements(packageDiskRequirement{path: pm.getCachePackagesPath(), bytes: uncompressedSize}); err != nil {
+		return "", err
+	}
 	tempDir, err := os.MkdirTemp(pm.getCachePackagesPath(), strings.ReplaceAll(sealpack.PackageIDToSafePath(pkgID), string(os.PathSeparator), "-")+"-")
 	if err != nil {
 		return "", err
 	}
-	if _, err := sealpack.ExtractArchive(pkgPath, tempDir); err != nil {
+	diskGuard := newPackageDiskGuard(pm, pm.getCachePackagesPath(), uncompressedSize)
+	progress := func(written, _ uint64) error {
+		if written < diskGuard.nextCheck && written < uncompressedSize {
+			return nil
+		}
+		chunk := uint64(0)
+		if written > diskGuard.written {
+			chunk = written - diskGuard.written
+		}
+		return diskGuard.BeforeWrite(chunk)
+	}
+	if _, err := sealpack.ExtractArchiveWithProgress(ctx, pkgPath, tempDir, progress); err != nil {
 		_ = os.RemoveAll(tempDir)
 		return "", err
 	}
@@ -726,18 +776,26 @@ func loadPackageConfigFromUserData(userDataPath string) (map[string]interface{},
 // Install 安装扩展包
 // 将 .sealpack 复制到 data/packages/，并解压到 cache/packages/
 func (pm *PackageManager) Install(pkgPath string) error {
+	return pm.InstallContext(context.Background(), pkgPath)
+}
+
+// InstallContext installs a managed package source with cancellation support.
+func (pm *PackageManager) InstallContext(ctx context.Context, pkgPath string) error {
 	validatedPath, err := pm.validateManagedPackageSource(pkgPath)
 	if err != nil {
 		return err
 	}
-	return pm.installFromSource(validatedPath)
+	return pm.installFromSourceContext(ctx, validatedPath, false)
 }
 
-func (pm *PackageManager) installFromSource(pkgPath string) error {
+func (pm *PackageManager) installFromSourceContext(ctx context.Context, pkgPath string, sourceAlreadyStaged bool) error {
 	pm.lock.Lock()
 	defer pm.lock.Unlock()
 
-	archiveInfo, err := sealpack.InspectArchive(pkgPath)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	archiveInfo, err := sealpack.InspectArchiveContext(ctx, pkgPath)
 	if err != nil {
 		return err
 	}
@@ -778,18 +836,32 @@ func (pm *PackageManager) installFromSource(pkgPath string) error {
 		}
 	}
 
-	stagedSourcePath, err := pm.stageSourceArtifact(pkgPath, destDir)
-	if err != nil {
-		return err
+	stagedSourcePath := pkgPath
+	if !sourceAlreadyStaged {
+		stagedSourcePath, err = pm.stageSourceArtifact(pkgPath, destDir)
+		if err != nil {
+			return err
+		}
 	}
-	stagedCachePath, err := pm.stageExtractPackage(pkgPath, pkgID)
+	stagedCachePath, err := pm.stageExtractPackageContext(ctx, pkgPath, pkgID, archiveInfo.UncompressedSize)
 	if err != nil {
-		_ = os.Remove(stagedSourcePath)
+		if !sourceAlreadyStaged {
+			_ = os.Remove(stagedSourcePath)
+		}
 		return err
 	}
 
+	if err := ctx.Err(); err != nil {
+		if !sourceAlreadyStaged {
+			_ = os.Remove(stagedSourcePath)
+		}
+		_ = os.RemoveAll(stagedCachePath)
+		return err
+	}
 	if err := os.Rename(stagedSourcePath, destPkgPath); err != nil {
-		_ = os.Remove(stagedSourcePath)
+		if !sourceAlreadyStaged {
+			_ = os.Remove(stagedSourcePath)
+		}
 		_ = os.RemoveAll(stagedCachePath)
 		return err
 	}
@@ -846,126 +918,149 @@ func (pm *PackageManager) installFromSource(pkgPath string) error {
 	return nil
 }
 
-func (pm *PackageManager) prepareDownloadedPackage(url string, hashes map[string]string, tempFilePrefix string) (string, error) {
-	if len(url) == 0 {
-		return "", errors.New("未提供下载链接")
+func (pm *PackageManager) prepareDownloadedPackageContext(ctx context.Context, url string, options PackageDownloadOptions, targetDir, pattern string, forInstall bool) (string, uint64, error) {
+	if strings.TrimSpace(url) == "" {
+		return "", 0, errors.New("未提供下载链接")
+	}
+	if _, err := packageSHA256Expectation(options.Hashes); err != nil {
+		return "", 0, err
+	}
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return "", 0, errors.New("创建临时目录失败: " + err.Error())
+	}
+	if options.ExpectedSize > 0 {
+		if err := pm.checkIncomingPackageEstimate(targetDir, options.ExpectedSize, forInstall); err != nil {
+			return "", 0, err
+		}
+	}
+	if pm.parent != nil && pm.parent.Logger != nil {
+		pm.parent.Logger.Infof("正在从 URL 下载扩展包: %s", url)
 	}
 
-	pm.parent.Logger.Infof("正在从 URL 下载扩展包: %s", url)
-
-	statusCode, data, err := downloadPackageArchive(url)
+	downloadCtx, cancelDownload := context.WithCancel(ctx)
+	defer cancelDownload()
+	req, err := http.NewRequestWithContext(downloadCtx, http.MethodGet, url, http.NoBody)
 	if err != nil {
-		return "", errors.New("下载扩展包失败: " + err.Error())
+		return "", 0, err
 	}
-	if statusCode != http.StatusOK {
-		return "", fmt.Errorf("无法获取扩展包内容，状态码: %d", statusCode)
+	req.Header.Set("Accept-Encoding", "identity")
+	resp, err := packageHTTPClient.Do(req) //nolint:gosec
+	if err != nil {
+		return "", 0, errors.New("下载扩展包失败: " + err.Error())
 	}
-	if hashErr := verifyDownloadedPackageHash(data, hashes); hashErr != nil {
-		return "", hashErr
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if len(message) == 0 {
+			return "", 0, fmt.Errorf("无法获取扩展包内容，状态码: %d", resp.StatusCode)
+		}
+		return "", 0, fmt.Errorf("无法获取扩展包内容，状态码: %d: %s", resp.StatusCode, strings.TrimSpace(string(message)))
 	}
-	if unsupported := unsupportedPackageHashAlgorithms(hashes); len(unsupported) > 0 && pm.parent != nil && pm.parent.Logger != nil {
+
+	expectedSize := options.ExpectedSize
+	if resp.ContentLength > 0 {
+		expectedSize = uint64(resp.ContentLength)
+		if diskErr := pm.checkIncomingPackageEstimate(targetDir, expectedSize, forInstall); diskErr != nil {
+			return "", 0, diskErr
+		}
+	}
+	startedAt := time.Now()
+	idleTimeout := pm.downloadIdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = defaultPackageDownloadIdleTimeout
+	}
+	idleWatchdog := newPackageIdleWatchdog(cancelDownload, idleTimeout)
+	defer idleWatchdog.Stop()
+	body := &progressPackageReader{src: resp.Body, progress: idleWatchdog.Progress}
+	path, written, err := pm.writePackageStream(downloadCtx, targetDir, pattern, body, expectedSize, options.Hashes)
+	if err != nil {
+		if idleWatchdog.TimedOut() {
+			return "", written, fmt.Errorf("下载扩展包失败: 连续 %s 没有接收到数据", idleTimeout)
+		}
+		return "", written, errors.New("下载扩展包失败: " + err.Error())
+	}
+	if unsupported := unsupportedPackageHashAlgorithms(options.Hashes); len(unsupported) > 0 && pm.parent != nil && pm.parent.Logger != nil {
 		pm.parent.Logger.Warnf("下载校验目前仅支持 sha256，已忽略以下算法: %s", strings.Join(unsupported, ", "))
 	}
-
-	tmpDir := pm.getPackageTempDir()
-	if mkdirErr := os.MkdirAll(tmpDir, 0755); mkdirErr != nil {
-		return "", errors.New("创建临时目录失败: " + mkdirErr.Error())
+	if pm.parent != nil && pm.parent.Logger != nil {
+		pm.parent.Logger.Infof("扩展包下载完成: %s, 用时 %s", formatPackageBytes(written), time.Since(startedAt).Round(time.Millisecond))
 	}
-
-	tmpFile, err := os.CreateTemp(tmpDir, tempFilePrefix)
-	if err != nil {
-		return "", errors.New("创建临时文件失败: " + err.Error())
-	}
-	tmpPath := tmpFile.Name()
-	if _, writeErr := tmpFile.Write(data); writeErr != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpPath)
-		return "", errors.New("保存临时文件失败: " + writeErr.Error())
-	}
-	if closeErr := tmpFile.Close(); closeErr != nil {
-		_ = os.Remove(tmpPath)
-		return "", errors.New("保存临时文件失败: " + closeErr.Error())
-	}
-
-	return tmpPath, nil
+	return path, written, nil
 }
 
-// InstallFromStream streams an uploaded .sealpack into a temporary file, then installs it.
+func (pm *PackageManager) checkIncomingPackageEstimate(targetDir string, compressedSize uint64, forInstall bool) error {
+	requirements := []packageDiskRequirement{{path: targetDir, bytes: compressedSize}}
+	if forInstall {
+		requirements = append(requirements, packageDiskRequirement{path: pm.getCachePackagesPath(), bytes: compressedSize})
+	}
+	return pm.checkPackageDiskRequirements(requirements...)
+}
+
+// InstallFromStream streams an uploaded .sealpack into managed staging, then installs it.
 func (pm *PackageManager) InstallFromStream(src io.Reader) error {
+	return pm.InstallFromStreamContext(context.Background(), src)
+}
+
+// InstallFromStreamContext is the cancellable form of InstallFromStream.
+func (pm *PackageManager) InstallFromStreamContext(ctx context.Context, src io.Reader) error {
 	if src == nil {
 		return errors.New("未提供上传内容")
 	}
-
-	tmpDir := pm.getPackageTempDir()
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
-		return errors.New("创建临时目录失败: " + err.Error())
-	}
-
-	tmpFile, err := os.CreateTemp(tmpDir, "package_upload_*.sealpack")
+	release, err := acquirePackageOperation(ctx)
 	if err != nil {
-		return errors.New("创建临时文件失败: " + err.Error())
+		return err
 	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-
-	written, copyErr := copyPackageArchive(tmpFile, src)
-	closeErr := tmpFile.Close()
-	if copyErr != nil {
-		return errors.New("保存上传文件失败: " + copyErr.Error())
+	defer release()
+	if dirErr := pm.ensurePackageDirs(); dirErr != nil {
+		return dirErr
 	}
-	if closeErr != nil {
-		return errors.New("保存上传文件失败: " + closeErr.Error())
+	stagedPath, _, err := pm.writePackageStream(ctx, pm.getPackageStagingDir(), "package_upload_*.part", src, 0, nil)
+	if err != nil {
+		return errors.New("保存上传文件失败: " + err.Error())
 	}
-	if written == 0 {
-		return errors.New("上传文件为空")
-	}
-
-	return pm.Install(tmpPath)
+	defer os.Remove(stagedPath)
+	return pm.installFromSourceContext(ctx, stagedPath, true)
 }
 
 // PreviewFromStream streams an uploaded .sealpack into a temporary file, then inspects it.
 func (pm *PackageManager) PreviewFromStream(src io.Reader) (*PackageUploadPreview, error) {
+	return pm.PreviewFromStreamContext(context.Background(), src)
+}
+
+// PreviewFromStreamContext is the cancellable form of PreviewFromStream.
+func (pm *PackageManager) PreviewFromStreamContext(ctx context.Context, src io.Reader) (*PackageUploadPreview, error) {
 	if src == nil {
 		return nil, errors.New("未提供上传内容")
 	}
-
-	tmpDir := pm.getPackageTempDir()
-	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
-		return nil, errors.New("创建临时目录失败: " + err.Error())
-	}
-
-	tmpFile, err := os.CreateTemp(tmpDir, "package_preview_*.sealpack")
+	release, err := acquirePackageOperation(ctx)
 	if err != nil {
-		return nil, errors.New("创建临时文件失败: " + err.Error())
+		return nil, err
 	}
-	tmpPath := tmpFile.Name()
-	defer os.Remove(tmpPath)
-
-	written, copyErr := copyPackageArchive(tmpFile, src)
-	closeErr := tmpFile.Close()
-	if copyErr != nil {
-		return nil, errors.New("保存上传文件失败: " + copyErr.Error())
+	defer release()
+	tmpDir := pm.getPackageTempDir()
+	path, _, err := pm.writePackageStream(ctx, tmpDir, "package_preview_*.sealpack", src, 0, nil)
+	if err != nil {
+		return nil, errors.New("保存上传文件失败: " + err.Error())
 	}
-	if closeErr != nil {
-		return nil, errors.New("保存上传文件失败: " + closeErr.Error())
-	}
-	if written == 0 {
-		return nil, errors.New("上传文件为空")
-	}
-
-	return pm.Preview(tmpPath)
+	defer os.Remove(path)
+	return pm.previewFromSourceContext(ctx, path)
 }
 
 func (pm *PackageManager) Preview(pkgPath string) (*PackageUploadPreview, error) {
+	return pm.PreviewContext(context.Background(), pkgPath)
+}
+
+// PreviewContext inspects a managed package source with cancellation support.
+func (pm *PackageManager) PreviewContext(ctx context.Context, pkgPath string) (*PackageUploadPreview, error) {
 	validatedPath, err := pm.validateManagedPackageSource(pkgPath)
 	if err != nil {
 		return nil, err
 	}
-	return pm.previewFromSource(validatedPath)
+	return pm.previewFromSourceContext(ctx, validatedPath)
 }
 
-func (pm *PackageManager) previewFromSource(pkgPath string) (*PackageUploadPreview, error) {
-	archiveInfo, err := sealpack.InspectArchive(pkgPath)
+func (pm *PackageManager) previewFromSourceContext(ctx context.Context, pkgPath string) (*PackageUploadPreview, error) {
+	archiveInfo, err := sealpack.InspectArchiveContext(ctx, pkgPath)
 	if err != nil {
 		return nil, err
 	}
@@ -1015,15 +1110,170 @@ func packageUploadContentCounts(files []string) map[string]int {
 }
 
 func copyPackageArchive(dst io.Writer, src io.Reader) (int64, error) {
-	limited := &io.LimitedReader{R: src, N: maxPackageArchiveSize + 1}
-	written, err := io.Copy(dst, limited)
+	return io.CopyBuffer(dst, src, make([]byte, packageStreamBufferSize))
+}
+
+type contextPackageReader struct {
+	ctx context.Context
+	src io.Reader
+}
+
+type progressPackageReader struct {
+	src      io.Reader
+	progress func()
+}
+
+func (r *progressPackageReader) Read(data []byte) (int, error) {
+	n, err := r.src.Read(data)
+	if n > 0 {
+		r.progress()
+	}
+	return n, err
+}
+
+type packageIdleWatchdog struct {
+	progress chan struct{}
+	stop     chan struct{}
+	timedOut chan struct{}
+	stopOnce sync.Once
+}
+
+func newPackageIdleWatchdog(cancel context.CancelFunc, timeout time.Duration) *packageIdleWatchdog {
+	watchdog := &packageIdleWatchdog{
+		progress: make(chan struct{}, 1),
+		stop:     make(chan struct{}),
+		timedOut: make(chan struct{}),
+	}
+	go func() {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-watchdog.progress:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(timeout)
+			case <-timer.C:
+				close(watchdog.timedOut)
+				cancel()
+				return
+			case <-watchdog.stop:
+				return
+			}
+		}
+	}()
+	return watchdog
+}
+
+func (w *packageIdleWatchdog) Progress() {
+	select {
+	case w.progress <- struct{}{}:
+	default:
+	}
+}
+
+func (w *packageIdleWatchdog) Stop() {
+	w.stopOnce.Do(func() { close(w.stop) })
+}
+
+func (w *packageIdleWatchdog) TimedOut() bool {
+	select {
+	case <-w.timedOut:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *contextPackageReader) Read(data []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.src.Read(data)
+}
+
+type guardedPackageWriter struct {
+	dst   io.Writer
+	guard *packageDiskGuard
+}
+
+func (w *guardedPackageWriter) Write(data []byte) (int, error) {
+	if err := w.guard.BeforeWrite(uint64(len(data))); err != nil {
+		return 0, err
+	}
+	return w.dst.Write(data)
+}
+
+func (pm *PackageManager) writePackageStream(ctx context.Context, targetDir, pattern string, src io.Reader, expectedSize uint64, hashes map[string]string) (string, uint64, error) {
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return "", 0, err
+	}
+	expectedSHA256, err := packageSHA256Expectation(hashes)
 	if err != nil {
-		return written, err
+		return "", 0, err
 	}
-	if written > maxPackageArchiveSize {
-		return written, fmt.Errorf("扩展包文件超过大小限制 %d MiB", maxPackageArchiveSize/(1024*1024))
+
+	file, err := os.CreateTemp(targetDir, pattern)
+	if err != nil {
+		return "", 0, err
 	}
-	return written, nil
+	path := file.Name()
+	keep := false
+	defer func() {
+		_ = file.Close()
+		if !keep {
+			_ = os.Remove(path)
+		}
+	}()
+
+	var destination io.Writer = file
+	hasher := sha256.New()
+	if expectedSHA256 != "" {
+		destination = io.MultiWriter(file, hasher)
+	}
+	guard := newPackageDiskGuard(pm, targetDir, expectedSize)
+	written, err := copyPackageArchive(
+		&guardedPackageWriter{dst: destination, guard: guard},
+		&contextPackageReader{ctx: ctx, src: src},
+	)
+	if err != nil {
+		return "", uint64(max(written, 0)), err
+	}
+	if written == 0 {
+		return "", 0, errors.New("扩展包文件为空")
+	}
+	if err := file.Close(); err != nil {
+		return "", uint64(written), err
+	}
+	if expectedSHA256 != "" {
+		actual := hex.EncodeToString(hasher.Sum(nil))
+		if !strings.EqualFold(actual, expectedSHA256) {
+			return "", uint64(written), fmt.Errorf("扩展包 SHA-256 校验失败，期望 %s，实际 %s", strings.ToLower(expectedSHA256), actual)
+		}
+	}
+	keep = true
+	return path, uint64(written), nil
+}
+
+func packageSHA256Expectation(hashes map[string]string) (string, error) {
+	if len(hashes) == 0 {
+		return "", nil
+	}
+	for algorithm, expected := range hashes {
+		if !strings.EqualFold(algorithm, "sha256") {
+			continue
+		}
+		expected = strings.TrimSpace(expected)
+		if expected == "" {
+			return "", errors.New("download.hash.sha256 不能为空")
+		}
+		return expected, nil
+	}
+	return "", errors.New("下载校验不支持提供的哈希算法，仅支持 sha256")
 }
 
 func (pm *PackageManager) getPackageTempDir() string {
@@ -1035,6 +1285,18 @@ func (pm *PackageManager) getPackageTempDir() string {
 		baseDir = pm.parent.BaseConfig.DataDir
 	}
 	return filepath.Join(baseDir, "temp")
+}
+
+func (pm *PackageManager) getPackageStagingDir() string {
+	return filepath.Join(pm.getSourcePackagesPath(), ".staging")
+}
+
+func (pm *PackageManager) cleanupPackageStagingDir() error {
+	stagingDir := pm.getPackageStagingDir()
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return err
+	}
+	return os.MkdirAll(stagingDir, 0o755)
 }
 
 func (pm *PackageManager) cleanupLegacyPackageTempDir() error {
@@ -2088,54 +2350,17 @@ func (pm *PackageManager) copyFile(src, dst string) error {
 	return dstFile.Sync()
 }
 
-func downloadPackageArchive(url string) (int, []byte, error) {
-	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
-	if err != nil {
-		return 0, nil, err
-	}
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec
-	if err != nil {
-		return 0, nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, nil, nil
-	}
-	if resp.ContentLength > maxPackageArchiveSize {
-		return 0, nil, fmt.Errorf("扩展包文件超过大小限制 %d MiB", maxPackageArchiveSize/(1024*1024))
-	}
-
-	data, err := io.ReadAll(io.LimitReader(resp.Body, maxPackageArchiveSize+1))
-	if err != nil {
-		return 0, nil, err
-	}
-	if int64(len(data)) > maxPackageArchiveSize {
-		return 0, nil, fmt.Errorf("扩展包文件超过大小限制 %d MiB", maxPackageArchiveSize/(1024*1024))
-	}
-	return http.StatusOK, data, nil
-}
-
 func verifyDownloadedPackageHash(data []byte, hashes map[string]string) error {
-	if len(hashes) == 0 {
-		return nil
+	expected, err := packageSHA256Expectation(hashes)
+	if err != nil || expected == "" {
+		return err
 	}
-	for algorithm, expected := range hashes {
-		if !strings.EqualFold(algorithm, "sha256") {
-			continue
-		}
-		expected = strings.TrimSpace(expected)
-		if expected == "" {
-			return errors.New("download.hash.sha256 不能为空")
-		}
-		sum := sha256.Sum256(data)
-		actual := hex.EncodeToString(sum[:])
-		if !strings.EqualFold(actual, expected) {
-			return fmt.Errorf("扩展包 SHA-256 校验失败，期望 %s，实际 %s", strings.ToLower(expected), actual)
-		}
-		return nil
+	sum := sha256.Sum256(data)
+	actual := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("扩展包 SHA-256 校验失败，期望 %s，实际 %s", strings.ToLower(expected), actual)
 	}
-	return errors.New("下载校验不支持提供的哈希算法，仅支持 sha256")
+	return nil
 }
 
 func unsupportedPackageHashAlgorithms(hashes map[string]string) []string {
@@ -2155,25 +2380,50 @@ func unsupportedPackageHashAlgorithms(hashes map[string]string) []string {
 
 // InstallFromURL 从 URL 下载并安装扩展包
 func (pm *PackageManager) InstallFromURL(url string, hashes map[string]string) error {
-	tmpPath, err := pm.prepareDownloadedPackage(url, hashes, "package_download_*.sealpack")
+	return pm.InstallFromURLContext(context.Background(), url, hashes)
+}
+
+// InstallFromURLContext is the cancellable form of InstallFromURL.
+func (pm *PackageManager) InstallFromURLContext(ctx context.Context, url string, hashes map[string]string) error {
+	return pm.InstallFromURLWithOptionsContext(ctx, url, PackageDownloadOptions{Hashes: hashes})
+}
+
+// InstallFromURLWithOptionsContext downloads directly into managed staging and installs it.
+func (pm *PackageManager) InstallFromURLWithOptionsContext(ctx context.Context, url string, options PackageDownloadOptions) error {
+	release, err := acquirePackageOperation(ctx)
 	if err != nil {
 		return err
 	}
-
-	// 安装扩展包
-	err = pm.Install(tmpPath)
-
-	// 清理临时文件
-	if removeErr := os.Remove(tmpPath); removeErr != nil {
-		pm.parent.Logger.Warnf("清理临时扩展包文件失败 %s: %v", tmpPath, removeErr)
+	defer release()
+	if dirErr := pm.ensurePackageDirs(); dirErr != nil {
+		return dirErr
 	}
-
-	return err
+	stagedPath, _, err := pm.prepareDownloadedPackageContext(ctx, url, options, pm.getPackageStagingDir(), "package_download_*.part", true)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(stagedPath)
+	return pm.installFromSourceContext(ctx, stagedPath, true)
 }
 
 // PreviewFromURL 从 URL 下载扩展包并返回包内容预览。
 func (pm *PackageManager) PreviewFromURL(url string, hashes map[string]string) (*PackageUploadPreview, error) {
-	tmpPath, err := pm.prepareDownloadedPackage(url, hashes, "package_preview_download_*.sealpack")
+	return pm.PreviewFromURLContext(context.Background(), url, hashes)
+}
+
+// PreviewFromURLContext is the cancellable form of PreviewFromURL.
+func (pm *PackageManager) PreviewFromURLContext(ctx context.Context, url string, hashes map[string]string) (*PackageUploadPreview, error) {
+	return pm.PreviewFromURLWithOptionsContext(ctx, url, PackageDownloadOptions{Hashes: hashes})
+}
+
+// PreviewFromURLWithOptionsContext downloads a package into temporary storage and inspects it.
+func (pm *PackageManager) PreviewFromURLWithOptionsContext(ctx context.Context, url string, options PackageDownloadOptions) (*PackageUploadPreview, error) {
+	release, err := acquirePackageOperation(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	tmpPath, _, err := pm.prepareDownloadedPackageContext(ctx, url, options, pm.getPackageTempDir(), "package_preview_download_*.sealpack", false)
 	if err != nil {
 		return nil, err
 	}
@@ -2183,5 +2433,14 @@ func (pm *PackageManager) PreviewFromURL(url string, hashes map[string]string) (
 		}
 	}()
 
-	return pm.Preview(tmpPath)
+	return pm.previewFromSourceContext(ctx, tmpPath)
+}
+
+func acquirePackageOperation(ctx context.Context) (func(), error) {
+	select {
+	case packageOperations <- struct{}{}:
+		return func() { <-packageOperations }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }

--- a/dice/package_manager_test.go
+++ b/dice/package_manager_test.go
@@ -398,7 +398,7 @@ func TestPackageManagerInstallFromStream(t *testing.T) {
 	}
 }
 
-func TestPackageManagerPreviewFromStream(t *testing.T) {
+func TestPackageManagerPreviewFromStreamContext(t *testing.T) {
 	_, pm := newTestPackageManager(t)
 	if err := pm.Init(); err != nil {
 		t.Fatalf("Init() error = %v", err)
@@ -418,9 +418,9 @@ func TestPackageManagerPreviewFromStream(t *testing.T) {
 	}
 	defer src.Close()
 
-	preview, err := pm.PreviewFromStream(src)
+	preview, err := pm.PreviewFromStreamContext(context.Background(), src)
 	if err != nil {
-		t.Fatalf("PreviewFromStream() error = %v", err)
+		t.Fatalf("PreviewFromStreamContext() error = %v", err)
 	}
 	if preview.Manifest.Package.ID != pkgID {
 		t.Fatalf("preview package ID = %q, want %q", preview.Manifest.Package.ID, pkgID)
@@ -436,18 +436,18 @@ func TestPackageManagerPreviewFromStream(t *testing.T) {
 	}
 }
 
-func TestPackageManagerPreviewFromURL(t *testing.T) {
+func TestPackageManagerInstallFromURL(t *testing.T) {
 	_, pm := newTestPackageManager(t)
 	if err := pm.Init(); err != nil {
 		t.Fatalf("Init() error = %v", err)
 	}
 
-	pkgID := "alice/preview-url"
+	pkgID := "alice/install-url"
 	archive := createTestSealPack(t, "", pkgID, "1.0.0", map[string][]string{
 		"scripts": {"scripts/*.js"},
 		"reply":   {"reply/*.yaml"},
 	}, map[string]string{
-		"scripts/main.js": "// preview-url",
+		"scripts/main.js": "// install-url",
 		"reply/main.yaml": "replies: []",
 	})
 	data, err := os.ReadFile(archive)
@@ -460,22 +460,19 @@ func TestPackageManagerPreviewFromURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	preview, err := pm.PreviewFromURL(server.URL, map[string]string{"sha256": hex.EncodeToString(sum[:])})
-	if err != nil {
-		t.Fatalf("PreviewFromURL() error = %v", err)
+	if err := pm.InstallFromURL(server.URL, map[string]string{"sha256": hex.EncodeToString(sum[:])}); err != nil {
+		t.Fatalf("InstallFromURL() error = %v", err)
 	}
-	if preview.Manifest.Package.ID != pkgID {
-		t.Fatalf("preview package ID = %q, want %q", preview.Manifest.Package.ID, pkgID)
+	pkg, ok := pm.Get(pkgID)
+	if !ok || pkg == nil || pkg.Manifest == nil {
+		t.Fatalf("expected package %s to be installed", pkgID)
 	}
-	if preview.FileCount != 3 {
-		t.Fatalf("FileCount = %d, want 3", preview.FileCount)
-	}
-	if preview.ContentCounts["scripts"] != 1 || preview.ContentCounts["reply"] != 1 {
-		t.Fatalf("ContentCounts = %#v, want scripts/reply counts", preview.ContentCounts)
+	if pkg.Manifest.Package.ID != pkgID {
+		t.Fatalf("installed package ID = %q, want %q", pkg.Manifest.Package.ID, pkgID)
 	}
 }
 
-func TestPackageManagerPreviewFromURLRejectsKnownSizeBeforeRequest(t *testing.T) {
+func TestPackageManagerInstallFromURLRejectsKnownSizeBeforeRequest(t *testing.T) {
 	_, pm := newTestPackageManager(t)
 	if err := pm.Init(); err != nil {
 		t.Fatalf("Init() error = %v", err)
@@ -493,16 +490,16 @@ func TestPackageManagerPreviewFromURLRejectsKnownSizeBeforeRequest(t *testing.T)
 	}))
 	defer server.Close()
 
-	_, err := pm.PreviewFromURLWithOptionsContext(context.Background(), server.URL, PackageDownloadOptions{ExpectedSize: 1})
+	err := pm.InstallFromURLWithOptionsContext(context.Background(), server.URL, PackageDownloadOptions{ExpectedSize: 1})
 	if err == nil || !strings.Contains(err.Error(), "磁盘空间不足") {
-		t.Fatalf("PreviewFromURLWithOptionsContext() error = %v, want disk rejection", err)
+		t.Fatalf("InstallFromURLWithOptionsContext() error = %v, want disk rejection", err)
 	}
 	if requests.Load() != 0 {
 		t.Fatalf("server received %d requests, want 0", requests.Load())
 	}
 }
 
-func TestPackageManagerPreviewFromURLStopsAfterIdleTimeout(t *testing.T) {
+func TestPackageManagerInstallFromURLStopsAfterIdleTimeout(t *testing.T) {
 	_, pm := newTestPackageManager(t)
 	if err := pm.Init(); err != nil {
 		t.Fatalf("Init() error = %v", err)
@@ -518,9 +515,9 @@ func TestPackageManagerPreviewFromURLStopsAfterIdleTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	_, err := pm.PreviewFromURLContext(context.Background(), server.URL, nil)
+	err := pm.InstallFromURLContext(context.Background(), server.URL, nil)
 	if err == nil || !strings.Contains(err.Error(), "没有接收到数据") {
-		t.Fatalf("PreviewFromURLContext() error = %v, want idle timeout", err)
+		t.Fatalf("InstallFromURLContext() error = %v, want idle timeout", err)
 	}
 }
 

--- a/dice/package_manager_test.go
+++ b/dice/package_manager_test.go
@@ -2,8 +2,10 @@ package dice //nolint:testpackage
 
 import (
 	"archive/zip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,9 +14,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -366,8 +369,8 @@ func TestPackageManagerInstallFromStream(t *testing.T) {
 	}
 	defer src.Close()
 
-	if err := pm.InstallFromStream(src); err != nil {
-		t.Fatalf("InstallFromStream() error = %v", err)
+	if installErr := pm.InstallFromStream(src); installErr != nil {
+		t.Fatalf("InstallFromStream() error = %v", installErr)
 	}
 
 	pkg, ok := pm.Get(pkgID)
@@ -380,26 +383,18 @@ func TestPackageManagerInstallFromStream(t *testing.T) {
 	if !strings.HasSuffix(filepath.ToSlash(pkg.SourcePath), "data/packages/alice/uploaded@1.0.0.sealpack") {
 		t.Fatalf("SourcePath = %q", pkg.SourcePath)
 	}
-	if _, err := os.Stat(pkg.SourcePath); err != nil {
-		t.Fatalf("expected streamed source artifact to exist: %v", err)
+	if _, statErr := os.Stat(pkg.SourcePath); statErr != nil {
+		t.Fatalf("expected streamed source artifact to exist: %v", statErr)
 	}
 	if got, want := strings.Join(pkg.Files, ","), "info.toml,scripts/main.js"; got != want {
 		t.Fatalf("Files = %q, want %q", got, want)
 	}
-}
-
-func TestPackageManagerInstallFromStreamRejectsOversizedArchive(t *testing.T) {
-	_, pm := newTestPackageManager(t)
-	if err := pm.Init(); err != nil {
-		t.Fatalf("Init() error = %v", err)
+	staged, err := os.ReadDir(pm.getPackageStagingDir())
+	if err != nil {
+		t.Fatalf("ReadDir(staging) error = %v", err)
 	}
-
-	err := pm.InstallFromStream(io.LimitReader(zeroReader{}, maxPackageArchiveSize+1))
-	if err == nil {
-		t.Fatal("InstallFromStream() error = nil, want size rejection")
-	}
-	if !strings.Contains(err.Error(), "超过大小限制") {
-		t.Fatalf("InstallFromStream() error = %v, want size rejection", err)
+	if len(staged) != 0 {
+		t.Fatalf("staging directory contains %d files after install", len(staged))
 	}
 }
 
@@ -480,20 +475,66 @@ func TestPackageManagerPreviewFromURL(t *testing.T) {
 	}
 }
 
-func TestDownloadPackageArchiveRejectsOversizedResponse(t *testing.T) {
+func TestPackageManagerPreviewFromURLRejectsKnownSizeBeforeRequest(t *testing.T) {
+	_, pm := newTestPackageManager(t)
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	originalProbe := probePackageDiskSpace
+	t.Cleanup(func() { probePackageDiskSpace = originalProbe })
+	probePackageDiskSpace = func(string) (packageDiskSpace, error) {
+		return packageDiskSpace{Volume: "test", Available: packageDiskReserve, Total: packageDiskReserve}, nil
+	}
+	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Length", strconv.FormatInt(maxPackageArchiveSize+1, 10))
+		requests.Add(1)
 		w.WriteHeader(http.StatusOK)
-		_, _ = io.Copy(w, io.LimitReader(zeroReader{}, maxPackageArchiveSize+1))
 	}))
 	defer server.Close()
 
-	_, _, err := downloadPackageArchive(server.URL)
-	if err == nil {
-		t.Fatal("downloadPackageArchive() error = nil, want size rejection")
+	_, err := pm.PreviewFromURLWithOptionsContext(context.Background(), server.URL, PackageDownloadOptions{ExpectedSize: 1})
+	if err == nil || !strings.Contains(err.Error(), "磁盘空间不足") {
+		t.Fatalf("PreviewFromURLWithOptionsContext() error = %v, want disk rejection", err)
 	}
-	if !strings.Contains(err.Error(), "超过大小限制") {
-		t.Fatalf("downloadPackageArchive() error = %v, want size rejection", err)
+	if requests.Load() != 0 {
+		t.Fatalf("server received %d requests, want 0", requests.Load())
+	}
+}
+
+func TestPackageManagerPreviewFromURLStopsAfterIdleTimeout(t *testing.T) {
+	_, pm := newTestPackageManager(t)
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	pm.downloadIdleTimeout = 50 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	_, err := pm.PreviewFromURLContext(context.Background(), server.URL, nil)
+	if err == nil || !strings.Contains(err.Error(), "没有接收到数据") {
+		t.Fatalf("PreviewFromURLContext() error = %v, want idle timeout", err)
+	}
+}
+
+func TestAcquirePackageOperationHonorsCancellation(t *testing.T) {
+	release, err := acquirePackageOperation(context.Background())
+	if err != nil {
+		t.Fatalf("acquirePackageOperation() error = %v", err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := acquirePackageOperation(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("acquirePackageOperation() error = %v, want context cancellation", err)
 	}
 }
 
@@ -960,6 +1001,32 @@ func (zeroReader) Read(p []byte) (int, error) {
 		p[i] = 0
 	}
 	return len(p), nil
+}
+
+func BenchmarkCopyPackageArchiveStreaming(b *testing.B) {
+	const packageSize = 160 << 20
+	b.ReportAllocs()
+	b.SetBytes(packageSize)
+	for range b.N {
+		written, err := copyPackageArchive(io.Discard, io.LimitReader(zeroReader{}, packageSize))
+		if err != nil {
+			b.Fatalf("copyPackageArchive() error = %v", err)
+		}
+		if written != packageSize {
+			b.Fatalf("copyPackageArchive() wrote %d bytes, want %d", written, packageSize)
+		}
+	}
+}
+
+func TestCopyPackageArchiveHasNoFixedSizeLimit(t *testing.T) {
+	const formerLimit = int64(128 << 20)
+	written, err := copyPackageArchive(io.Discard, io.LimitReader(zeroReader{}, formerLimit+1))
+	if err != nil {
+		t.Fatalf("copyPackageArchive() error = %v", err)
+	}
+	if written != formerLimit+1 {
+		t.Fatalf("copyPackageArchive() wrote %d bytes, want %d", written, formerLimit+1)
+	}
 }
 
 func copyTestFile(t *testing.T, src, dst string) {

--- a/dice/sealpack/archive.go
+++ b/dice/sealpack/archive.go
@@ -2,12 +2,39 @@ package sealpack
 
 import (
 	"archive/zip"
+	"context"
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+)
+
+const (
+	MaxManifestSize         int64  = 1 << 20
+	maxArchiveEntries              = 10_000
+	maxArchiveDirectorySize uint64 = 16 << 20
+	maxArchivePathSize             = 1 << 10
+	archiveCopyBufferSize          = 32 << 10
+)
+
+const (
+	directoryHeaderSignature    = 0x02014b50
+	directoryEndSignature       = 0x06054b50
+	directory64EndSignature     = 0x06064b50
+	directory64LocatorSignature = 0x07064b50
+	directoryDigitalSignature   = 0x05054b50
+)
+
+const (
+	directoryHeaderLen    = 46
+	directoryEndLen       = 22
+	directory64EndLen     = 56
+	directory64LocatorLen = 20
 )
 
 var allowedArchiveRoots = map[string]struct{}{
@@ -21,36 +48,63 @@ var allowedArchiveRoots = map[string]struct{}{
 	"templates": {},
 }
 
+// ExtractProgressFunc is called before the next extracted chunk is written.
+type ExtractProgressFunc func(written, total uint64) error
+
+type openedArchive struct {
+	file   *os.File
+	reader *zip.Reader
+	info   *ArchiveInfo
+}
+
+func (a *openedArchive) Close() error {
+	return a.file.Close()
+}
+
 // InspectArchive validates a .sealpack archive and returns its manifest and file list.
 func InspectArchive(pkgPath string) (*ArchiveInfo, error) {
-	reader, err := zip.OpenReader(pkgPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open extension package: %w", err)
-	}
-	defer reader.Close()
+	return InspectArchiveContext(context.Background(), pkgPath)
+}
 
-	return inspectArchiveFiles(reader.File)
+// InspectArchiveContext is the cancellable form of InspectArchive.
+func InspectArchiveContext(ctx context.Context, pkgPath string) (*ArchiveInfo, error) {
+	archive, err := openArchive(ctx, pkgPath)
+	if err != nil {
+		return nil, err
+	}
+	defer archive.Close()
+	return archive.info, nil
 }
 
 // ExtractArchive validates and extracts a .sealpack archive to destDir.
 func ExtractArchive(pkgPath, destDir string) (*ArchiveInfo, error) {
-	archiveInfo, err := InspectArchive(pkgPath)
+	return ExtractArchiveContext(context.Background(), pkgPath, destDir)
+}
+
+// ExtractArchiveContext is the cancellable form of ExtractArchive.
+func ExtractArchiveContext(ctx context.Context, pkgPath, destDir string) (*ArchiveInfo, error) {
+	return ExtractArchiveWithProgress(ctx, pkgPath, destDir, nil)
+}
+
+// ExtractArchiveWithProgress extracts an archive and reports bounded-memory progress.
+func ExtractArchiveWithProgress(ctx context.Context, pkgPath, destDir string, progress ExtractProgressFunc) (*ArchiveInfo, error) {
+	archive, err := openArchive(ctx, pkgPath)
 	if err != nil {
 		return nil, err
 	}
-
-	reader, err := zip.OpenReader(pkgPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open extension package: %w", err)
-	}
-	defer reader.Close()
+	defer archive.Close()
 
 	root := filepath.Clean(destDir)
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return nil, err
 	}
 
-	for _, file := range reader.File {
+	buffer := make([]byte, archiveCopyBufferSize)
+	var totalWritten uint64
+	for _, file := range archive.reader.File {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		normalized, isDir, err := normalizeArchiveEntryName(file.Name)
 		if err != nil {
 			return nil, err
@@ -65,54 +119,76 @@ func ExtractArchive(pkgPath, destDir string) (*ArchiveInfo, error) {
 		}
 
 		if isDir {
-			if mkdirErr := os.MkdirAll(targetPath, 0o755); mkdirErr != nil {
-				return nil, mkdirErr
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return nil, err
 			}
 			continue
 		}
-
-		if mkdirErr := os.MkdirAll(filepath.Dir(targetPath), 0o755); mkdirErr != nil {
-			return nil, mkdirErr
-		}
-
-		rc, err := file.Open()
-		if err != nil {
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 			return nil, err
 		}
 
-		mode := file.Mode()
-		if mode.Perm() == 0 {
-			mode = 0o644
-		}
-		out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-		if err != nil {
-			rc.Close()
-			return nil, err
-		}
-		if _, err := io.Copy(out, rc); err != nil {
-			out.Close()
-			rc.Close()
-			return nil, err
-		}
-		if err := out.Close(); err != nil {
-			rc.Close()
-			return nil, err
-		}
-		if err := rc.Close(); err != nil {
+		if err := extractArchiveFile(ctx, file, targetPath, buffer, &totalWritten, archive.info.UncompressedSize, progress); err != nil {
 			return nil, err
 		}
 	}
 
-	return archiveInfo, nil
+	return archive.info, nil
 }
 
-func inspectArchiveFiles(files []*zip.File) (*ArchiveInfo, error) {
+func openArchive(ctx context.Context, pkgPath string) (*openedArchive, error) {
+	file, err := os.Open(pkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open extension package: %w", err)
+	}
+	closeOnError := true
+	defer func() {
+		if closeOnError {
+			_ = file.Close()
+		}
+	}()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("extension package must be a regular file")
+	}
+	if preflightErr := preflightArchiveDirectory(ctx, file, info.Size()); preflightErr != nil {
+		return nil, preflightErr
+	}
+
+	reader, err := zip.NewReader(file, info.Size())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open extension package: %w", err)
+	}
+	archiveInfo, err := inspectArchiveFiles(ctx, reader.File)
+	if err != nil {
+		return nil, err
+	}
+
+	closeOnError = false
+	return &openedArchive{file: file, reader: reader, info: archiveInfo}, nil
+}
+
+func inspectArchiveFiles(ctx context.Context, files []*zip.File) (*ArchiveInfo, error) {
+	if len(files) > maxArchiveEntries {
+		return nil, fmt.Errorf("archive contains too many entries: %d (maximum %d)", len(files), maxArchiveEntries)
+	}
+
 	seen := make(map[string]struct{}, len(files))
 	archiveInfo := &ArchiveInfo{Files: make([]string, 0, len(files))}
 	var manifestData []byte
 	readmePresent := false
 
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if len(file.Name) > maxArchivePathSize {
+			return nil, fmt.Errorf("archive entry path is too long: %d bytes", len(file.Name))
+		}
 		normalized, isDir, err := normalizeArchiveEntryName(file.Name)
 		if err != nil {
 			return nil, err
@@ -125,29 +201,28 @@ func inspectArchiveFiles(files []*zip.File) (*ArchiveInfo, error) {
 		}
 		seen[normalized] = struct{}{}
 
-		if validateErr := validateArchiveTopLevelPath(normalized); validateErr != nil {
-			return nil, validateErr
+		if validationErr := validateArchiveTopLevelPath(normalized); validationErr != nil {
+			return nil, validationErr
 		}
-
 		if normalized == "README.md" {
 			readmePresent = true
 		}
 		if isDir {
 			continue
 		}
+		if math.MaxUint64-archiveInfo.UncompressedSize < file.UncompressedSize64 {
+			return nil, errors.New("archive uncompressed size overflows uint64")
+		}
+		archiveInfo.UncompressedSize += file.UncompressedSize64
 		archiveInfo.Files = append(archiveInfo.Files, normalized)
 
 		if normalized != InfoFile {
 			continue
 		}
-		rc, err := file.Open()
-		if err != nil {
-			return nil, err
+		if file.UncompressedSize64 > uint64(MaxManifestSize) {
+			return nil, fmt.Errorf("package %s exceeds %d MiB", InfoFile, MaxManifestSize/(1024*1024))
 		}
-		manifestData, err = io.ReadAll(rc)
-		if closeErr := rc.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
+		manifestData, err = readArchiveEntryLimited(file, MaxManifestSize)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +231,6 @@ func inspectArchiveFiles(files []*zip.File) (*ArchiveInfo, error) {
 	if manifestData == nil {
 		return nil, fmt.Errorf("package archive is missing %s", InfoFile)
 	}
-
 	manifest, err := ParseManifest(manifestData)
 	if err != nil {
 		return nil, err
@@ -165,8 +239,251 @@ func inspectArchiveFiles(files []*zip.File) (*ArchiveInfo, error) {
 		manifest.Store.Readme = "README.md"
 	}
 	archiveInfo.Manifest = manifest
-
 	return archiveInfo, nil
+}
+
+func readArchiveEntryLimited(file *zip.File, limit int64) ([]byte, error) {
+	rc, err := file.Open()
+	if err != nil {
+		return nil, err
+	}
+	data, readErr := io.ReadAll(io.LimitReader(rc, limit+1))
+	closeErr := rc.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("package %s exceeds %d MiB", InfoFile, limit/(1024*1024))
+	}
+	return data, nil
+}
+
+func extractArchiveFile(ctx context.Context, file *zip.File, targetPath string, buffer []byte, totalWritten *uint64, totalSize uint64, progress ExtractProgressFunc) error {
+	rc, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	mode := file.Mode()
+	if mode.Perm() == 0 {
+		mode = 0o644
+	}
+	out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return err
+	}
+	succeeded := false
+	defer func() {
+		_ = out.Close()
+		if !succeeded {
+			_ = os.Remove(targetPath)
+		}
+	}()
+
+	var entryWritten uint64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		n, readErr := rc.Read(buffer)
+		if n > 0 {
+			chunk := uint64(n)
+			if entryWritten > file.UncompressedSize64 || chunk > file.UncompressedSize64-entryWritten {
+				return fmt.Errorf("archive entry %s exceeds its declared size", file.Name)
+			}
+			if *totalWritten > totalSize || chunk > totalSize-*totalWritten {
+				return errors.New("archive output exceeds its declared total size")
+			}
+			if progress != nil {
+				if err := progress(*totalWritten+chunk, totalSize); err != nil {
+					return err
+				}
+			}
+			written, writeErr := out.Write(buffer[:n])
+			if writeErr != nil {
+				return writeErr
+			}
+			if written != n {
+				return io.ErrShortWrite
+			}
+			entryWritten += chunk
+			*totalWritten += chunk
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return readErr
+		}
+	}
+	if entryWritten != file.UncompressedSize64 {
+		return fmt.Errorf("archive entry %s size mismatch: expected %d, got %d", file.Name, file.UncompressedSize64, entryWritten)
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	succeeded = true
+	return nil
+}
+
+func preflightArchiveDirectory(ctx context.Context, file *os.File, size int64) error {
+	if size < directoryEndLen {
+		return zip.ErrFormat
+	}
+	tailSize := int64(directoryEndLen + math.MaxUint16)
+	if size < tailSize {
+		tailSize = size
+	}
+	tail := make([]byte, tailSize)
+	if _, err := file.ReadAt(tail, size-tailSize); err != nil && err != io.EOF {
+		return err
+	}
+
+	endIndex := -1
+	for i := len(tail) - directoryEndLen; i >= 0; i-- {
+		if binary.LittleEndian.Uint32(tail[i:i+4]) != directoryEndSignature {
+			continue
+		}
+		commentLen := int(binary.LittleEndian.Uint16(tail[i+20 : i+22]))
+		if i+directoryEndLen+commentLen <= len(tail) {
+			endIndex = i
+			break
+		}
+	}
+	if endIndex < 0 {
+		return zip.ErrFormat
+	}
+
+	end := tail[endIndex : endIndex+directoryEndLen]
+	directoryEndOffset := size - tailSize + int64(endIndex)
+	diskNumber := binary.LittleEndian.Uint16(end[4:6])
+	directoryDisk := binary.LittleEndian.Uint16(end[6:8])
+	recordsOnDisk := uint64(binary.LittleEndian.Uint16(end[8:10]))
+	records := uint64(binary.LittleEndian.Uint16(end[10:12]))
+	directorySize := uint64(binary.LittleEndian.Uint32(end[12:16]))
+	directoryOffset := uint64(binary.LittleEndian.Uint32(end[16:20]))
+
+	// archive/zip also treats 0xffff as a ZIP64 directory-size marker for
+	// compatibility, so the preflight must follow the same interpretation.
+	if records == math.MaxUint16 || directorySize == math.MaxUint16 || directorySize == math.MaxUint32 || directoryOffset == math.MaxUint32 {
+		locatorOffset := directoryEndOffset - directory64LocatorLen
+		if locatorOffset < 0 {
+			return zip.ErrFormat
+		}
+		locator := make([]byte, directory64LocatorLen)
+		if _, err := file.ReadAt(locator, locatorOffset); err != nil {
+			return err
+		}
+		if binary.LittleEndian.Uint32(locator[:4]) != directory64LocatorSignature ||
+			binary.LittleEndian.Uint32(locator[4:8]) != 0 || binary.LittleEndian.Uint32(locator[16:20]) != 1 {
+			return zip.ErrFormat
+		}
+		zip64Offset := binary.LittleEndian.Uint64(locator[8:16])
+		if zip64Offset > math.MaxInt64 {
+			return zip.ErrFormat
+		}
+		zip64End := make([]byte, directory64EndLen)
+		if _, err := file.ReadAt(zip64End, int64(zip64Offset)); err != nil {
+			return err
+		}
+		if binary.LittleEndian.Uint32(zip64End[:4]) != directory64EndSignature {
+			return zip.ErrFormat
+		}
+		if binary.LittleEndian.Uint32(zip64End[16:20]) != 0 || binary.LittleEndian.Uint32(zip64End[20:24]) != 0 {
+			return errors.New("multi-disk ZIP archives are not supported")
+		}
+		recordsOnDisk = binary.LittleEndian.Uint64(zip64End[24:32])
+		records = binary.LittleEndian.Uint64(zip64End[32:40])
+		directorySize = binary.LittleEndian.Uint64(zip64End[40:48])
+		directoryOffset = binary.LittleEndian.Uint64(zip64End[48:56])
+		directoryEndOffset = int64(zip64Offset)
+	} else if diskNumber != 0 || directoryDisk != 0 {
+		return errors.New("multi-disk ZIP archives are not supported")
+	}
+
+	if recordsOnDisk != records {
+		return errors.New("multi-disk ZIP archives are not supported")
+	}
+	if records > maxArchiveEntries {
+		return fmt.Errorf("archive contains too many entries: %d (maximum %d)", records, maxArchiveEntries)
+	}
+	if directorySize > maxArchiveDirectorySize {
+		return fmt.Errorf("archive central directory exceeds %d MiB", maxArchiveDirectorySize/(1024*1024))
+	}
+	if directorySize > math.MaxInt64 || directoryOffset > math.MaxInt64 {
+		return zip.ErrFormat
+	}
+
+	baseOffset := directoryEndOffset - int64(directorySize) - int64(directoryOffset)
+	if baseOffset < 0 {
+		return zip.ErrFormat
+	}
+	directoryStart := baseOffset + int64(directoryOffset)
+	if baseOffset > 0 {
+		var signature [4]byte
+		if _, err := file.ReadAt(signature[:], int64(directoryOffset)); err == nil && binary.LittleEndian.Uint32(signature[:]) == directoryHeaderSignature {
+			directoryStart = int64(directoryOffset)
+		}
+	}
+	return scanCentralDirectory(ctx, file, directoryStart, directorySize, records)
+}
+
+func scanCentralDirectory(ctx context.Context, file *os.File, start int64, size, expectedRecords uint64) error {
+	var offset uint64
+	var records uint64
+	header := make([]byte, directoryHeaderLen)
+	for offset < size {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if size-offset < 4 {
+			return zip.ErrFormat
+		}
+		if _, err := file.ReadAt(header[:4], start+int64(offset)); err != nil {
+			return err
+		}
+		signature := binary.LittleEndian.Uint32(header[:4])
+		if signature == directoryDigitalSignature {
+			var lengthBytes [2]byte
+			if size-offset < 6 {
+				return zip.ErrFormat
+			}
+			if _, err := file.ReadAt(lengthBytes[:], start+int64(offset)+4); err != nil {
+				return err
+			}
+			offset += 6 + uint64(binary.LittleEndian.Uint16(lengthBytes[:]))
+			break
+		}
+		if signature != directoryHeaderSignature || size-offset < directoryHeaderLen {
+			return zip.ErrFormat
+		}
+		if _, err := file.ReadAt(header, start+int64(offset)); err != nil {
+			return err
+		}
+		nameLen := uint64(binary.LittleEndian.Uint16(header[28:30]))
+		extraLen := uint64(binary.LittleEndian.Uint16(header[30:32]))
+		commentLen := uint64(binary.LittleEndian.Uint16(header[32:34]))
+		if nameLen > maxArchivePathSize {
+			return fmt.Errorf("archive entry path is too long: %d bytes", nameLen)
+		}
+		recordSize := uint64(directoryHeaderLen) + nameLen + extraLen + commentLen
+		if recordSize > size-offset {
+			return zip.ErrFormat
+		}
+		offset += recordSize
+		records++
+		if records > maxArchiveEntries {
+			return fmt.Errorf("archive contains too many entries: %d (maximum %d)", records, maxArchiveEntries)
+		}
+	}
+	if offset != size || records != expectedRecords {
+		return zip.ErrFormat
+	}
+	return nil
 }
 
 func normalizeArchiveEntryName(name string) (string, bool, error) {

--- a/dice/sealpack/archive_test.go
+++ b/dice/sealpack/archive_test.go
@@ -2,8 +2,13 @@ package sealpack //nolint:testpackage
 
 import (
 	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -78,6 +83,121 @@ func TestInspectArchiveFallsBackToReadmeFile(t *testing.T) {
 	}
 	if archiveInfo.Manifest.Store.Readme != "README.md" {
 		t.Fatalf("Manifest.Store.Readme = %q, want README.md", archiveInfo.Manifest.Store.Readme)
+	}
+}
+
+func TestInspectArchiveReportsUncompressedSize(t *testing.T) {
+	manifest := minimalManifestForArchiveTest("alice/demo", "1.0.0")
+	archivePath := createArchiveForTest(t, map[string]string{
+		"info.toml":       manifest,
+		"scripts/a.js":    "console.log('x')",
+		"assets/icon.png": "image-data",
+	})
+	info, err := InspectArchive(archivePath)
+	if err != nil {
+		t.Fatalf("InspectArchive() error = %v", err)
+	}
+	want := uint64(len(manifest) + len("console.log('x')") + len("image-data"))
+	if info.UncompressedSize != want {
+		t.Fatalf("UncompressedSize = %d, want %d", info.UncompressedSize, want)
+	}
+}
+
+func TestInspectArchiveRejectsOversizedManifest(t *testing.T) {
+	archivePath := createArchiveForTest(t, map[string]string{
+		"info.toml": strings.Repeat("x", int(MaxManifestSize)+1),
+	})
+	if _, err := InspectArchive(archivePath); err == nil || !strings.Contains(err.Error(), "info.toml") {
+		t.Fatalf("InspectArchive() error = %v, want manifest size rejection", err)
+	}
+}
+
+func TestInspectArchiveRejectsTooManyDeclaredEntriesBeforeZipParsing(t *testing.T) {
+	archivePath := createArchiveForTest(t, map[string]string{
+		"info.toml": minimalManifestForArchiveTest("alice/demo", "1.0.0"),
+	})
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	index := bytes.LastIndex(data, []byte{'P', 'K', 0x05, 0x06})
+	if index < 0 {
+		t.Fatal("EOCD not found")
+	}
+	binary.LittleEndian.PutUint16(data[index+8:index+10], maxArchiveEntries+1)
+	binary.LittleEndian.PutUint16(data[index+10:index+12], maxArchiveEntries+1)
+	if err := os.WriteFile(archivePath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	if _, err := InspectArchive(archivePath); err == nil || !strings.Contains(err.Error(), "too many entries") {
+		t.Fatalf("InspectArchive() error = %v, want entry count rejection", err)
+	}
+}
+
+func TestInspectArchivePreflightMatchesZip64DirectorySizeCompatibility(t *testing.T) {
+	archivePath := createArchiveForTest(t, map[string]string{
+		"info.toml": minimalManifestForArchiveTest("alice/demo", "1.0.0"),
+	})
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	endIndex := bytes.LastIndex(data, []byte{'P', 'K', 0x05, 0x06})
+	if endIndex < 0 {
+		t.Fatal("EOCD not found")
+	}
+
+	end := append([]byte(nil), data[endIndex:]...)
+	directorySize := binary.LittleEndian.Uint32(end[12:16])
+	directoryOffset := binary.LittleEndian.Uint32(end[16:20])
+	binary.LittleEndian.PutUint32(end[12:16], math.MaxUint16)
+
+	zip64EndOffset := uint64(endIndex)
+	zip64End := make([]byte, directory64EndLen)
+	binary.LittleEndian.PutUint32(zip64End[0:4], directory64EndSignature)
+	binary.LittleEndian.PutUint64(zip64End[4:12], directory64EndLen-12)
+	binary.LittleEndian.PutUint16(zip64End[12:14], 45)
+	binary.LittleEndian.PutUint16(zip64End[14:16], 45)
+	binary.LittleEndian.PutUint64(zip64End[24:32], maxArchiveEntries+1)
+	binary.LittleEndian.PutUint64(zip64End[32:40], maxArchiveEntries+1)
+	binary.LittleEndian.PutUint64(zip64End[40:48], uint64(directorySize))
+	binary.LittleEndian.PutUint64(zip64End[48:56], uint64(directoryOffset))
+
+	locator := make([]byte, directory64LocatorLen)
+	binary.LittleEndian.PutUint32(locator[0:4], directory64LocatorSignature)
+	binary.LittleEndian.PutUint64(locator[8:16], zip64EndOffset)
+	binary.LittleEndian.PutUint32(locator[16:20], 1)
+
+	data = append(data[:endIndex], zip64End...)
+	data = append(data, locator...)
+	data = append(data, end...)
+	if err := os.WriteFile(archivePath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if _, err := InspectArchive(archivePath); err == nil || !strings.Contains(err.Error(), "too many entries") {
+		t.Fatalf("InspectArchive() error = %v, want ZIP64 entry count rejection", err)
+	}
+}
+
+func TestInspectArchiveRejectsLongEntryPath(t *testing.T) {
+	archivePath := createArchiveForTest(t, map[string]string{
+		"info.toml": minimalManifestForArchiveTest("alice/demo", "1.0.0"),
+		"assets/" + strings.Repeat("x", maxArchivePathSize): "x",
+	})
+	if _, err := InspectArchive(archivePath); err == nil || !strings.Contains(err.Error(), "path is too long") {
+		t.Fatalf("InspectArchive() error = %v, want path length rejection", err)
+	}
+}
+
+func TestInspectArchiveHonorsCancellation(t *testing.T) {
+	archivePath := createArchiveForTest(t, map[string]string{
+		"info.toml": minimalManifestForArchiveTest("alice/demo", "1.0.0"),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := InspectArchiveContext(ctx, archivePath); err == nil || !strings.Contains(err.Error(), "canceled") {
+		t.Fatalf("InspectArchiveContext() error = %v, want cancellation", err)
 	}
 }
 

--- a/dice/sealpack/manifest.go
+++ b/dice/sealpack/manifest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,9 +17,17 @@ import (
 
 // ParseManifestFile parses an info.toml file from disk.
 func ParseManifestFile(path string) (*Manifest, error) {
-	data, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, MaxManifestSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > MaxManifestSize {
+		return nil, fmt.Errorf("package %s exceeds %d MiB", InfoFile, MaxManifestSize/(1024*1024))
 	}
 	return ParseManifest(data)
 }

--- a/dice/sealpack/types.go
+++ b/dice/sealpack/types.go
@@ -160,8 +160,9 @@ type InstancePersist struct {
 
 // ArchiveInfo describes a validated .sealpack archive.
 type ArchiveInfo struct {
-	Manifest *Manifest `json:"manifest"`
-	Files    []string  `json:"files"`
+	Manifest         *Manifest `json:"manifest"`
+	Files            []string  `json:"files"`
+	UncompressedSize uint64    `json:"-"`
 }
 
 // OperationResult 包操作结果

--- a/dice/store.go
+++ b/dice/store.go
@@ -38,7 +38,18 @@ const (
 )
 
 const storeBackendInfoCacheTTL = 5 * time.Minute
-const maxStoreManifestSize int64 = 1 << 20
+
+const (
+	maxStoreManifestSize     int64 = sealpack.MaxManifestSize
+	maxStoreJSONResponseSize int64 = 16 << 20
+	maxStorePageSize               = 100
+	maxStorePackageFiles           = 10_000
+	maxStorePackageCache           = 4_096
+)
+
+var storeHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+var errStoreResponseTooLarge = errors.New("store response too large")
 
 type StoreBackend struct {
 	Url string `json:"url"`
@@ -134,12 +145,13 @@ type StorePackageFileEntry struct {
 }
 
 type StoreManager struct {
-	lock             *sync.RWMutex
-	parent           *Dice
-	backend          *StoreBackend
-	backendCacheKey  string
-	backendFetchedAt time.Time
-	packageCache     map[string]*StorePackage
+	lock              *sync.RWMutex
+	parent            *Dice
+	backend           *StoreBackend
+	backendCacheKey   string
+	backendFetchedAt  time.Time
+	packageCache      map[string]*StorePackage
+	packageCacheOrder []string
 
 	InstalledPlugins map[string]bool `json:"-" yaml:"-"`
 	InstalledDecks   map[string]bool `json:"-" yaml:"-"`
@@ -192,7 +204,11 @@ func ParseStorePackageFullID(fullID string) (string, string, error) {
 }
 
 func decodeJSONCompatible(data []byte, target interface{}) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
+	return decodeJSONCompatibleReader(bytes.NewReader(data), target)
+}
+
+func decodeJSONCompatibleReader(reader io.Reader, target interface{}) error {
+	decoder := json.NewDecoder(reader)
 	if err := decoder.Decode(target); err != nil {
 		return err
 	}
@@ -205,24 +221,48 @@ func decodeJSONCompatible(data []byte, target interface{}) error {
 	return nil
 }
 
+func decodeStoreJSONResponse(reader io.Reader, limit int64, target interface{}) error {
+	limited := &io.LimitedReader{R: reader, N: limit + 1}
+	if err := decodeJSONCompatibleReader(limited, target); err != nil {
+		if limited.N == 0 {
+			return errStoreResponseTooLarge
+		}
+		return err
+	}
+	if limited.N == 0 {
+		return errStoreResponseTooLarge
+	}
+	return nil
+}
+
 func fetchStoreJSON[T any](requestURL string) (*T, error) {
+	return fetchStoreJSONContext[T](context.Background(), requestURL)
+}
+
+func fetchStoreJSONContext[T any](ctx context.Context, requestURL string) (*T, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
 	// #nosec G107 -- store backend URLs are user/admin-configured extension repository endpoints.
-	resp, err := http.Get(requestURL)
+	resp, err := storeHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	respData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", string(respData))
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if len(message) == 0 {
+			message = []byte(http.StatusText(resp.StatusCode))
+		}
+		return nil, fmt.Errorf("%s", strings.TrimSpace(string(message)))
 	}
 
 	var result T
-	if err := decodeJSONCompatible(respData, &result); err != nil {
+	if err := decodeStoreJSONResponse(resp.Body, maxStoreJSONResponseSize, &result); err != nil {
+		if errors.Is(err, errStoreResponseTooLarge) {
+			return nil, fmt.Errorf("商店响应超过 %d MiB", maxStoreJSONResponseSize/(1024*1024))
+		}
 		return nil, fmt.Errorf("decode store response from %s: %w", requestURL, err)
 	}
 	return &result, nil
@@ -384,6 +424,8 @@ func (m *StoreManager) invalidateStoreBackendLocked() {
 	m.backend = nil
 	m.backendCacheKey = ""
 	m.backendFetchedAt = time.Time{}
+	clear(m.packageCache)
+	m.packageCacheOrder = nil
 }
 
 func (m *StoreManager) storeConfigSnapshot() (enabledUrls []string, disabledUrls []string) {
@@ -416,7 +458,7 @@ func (m *StoreManager) buildBackend(rawURL, id, name string, backendType StoreBa
 		return backend
 	}
 
-	info, err := fetchStoreJSON[storeBackendInfoResponse](backend.Url + "/info")
+	info, err := fetchStoreJSONContext[storeBackendInfoResponse](context.Background(), backend.Url+"/info")
 	if err != nil {
 		backend.Health = false
 		return backend
@@ -501,6 +543,10 @@ func (m *StoreManager) loadStoreBackend(force bool) (*StoreBackend, error) {
 	backend := m.buildBackend(target.rawURL, target.id, target.name, target.backendType, true)
 	fetchedAt := time.Now()
 	m.lock.Lock()
+	if m.backendCacheKey != "" && m.backendCacheKey != target.cacheKey {
+		clear(m.packageCache)
+		m.packageCacheOrder = nil
+	}
 	m.backend = backend
 	m.backendCacheKey = target.cacheKey
 	m.backendFetchedAt = fetchedAt
@@ -542,6 +588,11 @@ func NewStoreManager(parent *Dice) *StoreManager {
 }
 
 func (m *StoreManager) StoreQueryRecommend() ([]*StorePackage, error) {
+	return m.StoreQueryRecommendContext(context.Background())
+}
+
+// StoreQueryRecommendContext queries recommendations with cancellation support.
+func (m *StoreManager) StoreQueryRecommendContext(ctx context.Context) ([]*StorePackage, error) {
 	backend, err := m.currentBackend()
 	if err != nil {
 		return nil, err
@@ -557,7 +608,7 @@ func (m *StoreManager) StoreQueryRecommend() ([]*StorePackage, error) {
 		}
 	}
 
-	respResult, err := fetchStoreJSON[storeRecommendResponse](backend.Url + "/recommend")
+	respResult, err := fetchStoreJSONContext[storeRecommendResponse](ctx, backend.Url+"/recommend")
 	if err != nil {
 		m.refreshStoreBackend()
 		return nil, err
@@ -719,6 +770,17 @@ func (m *StoreManager) resolveStoreBackendActionURL(id, rawURL string, enabledUr
 }
 
 func (m *StoreManager) StoreQueryPage(params StoreQueryPageParams) (*StorePackagePage, error) {
+	return m.StoreQueryPageContext(context.Background(), params)
+}
+
+// StoreQueryPageContext queries a store page with cancellation support.
+func (m *StoreManager) StoreQueryPageContext(ctx context.Context, params StoreQueryPageParams) (*StorePackagePage, error) {
+	if params.PageNum < 0 {
+		return nil, errors.New("pageNum 不能小于 0")
+	}
+	if params.PageSize < 0 || params.PageSize > maxStorePageSize {
+		return nil, fmt.Errorf("pageSize 必须在 1 到 %d 之间，或为 0 使用默认值", maxStorePageSize)
+	}
 	backend, err := m.currentBackend()
 	if err != nil {
 		return nil, err
@@ -766,7 +828,7 @@ func (m *StoreManager) StoreQueryPage(params StoreQueryPageParams) (*StorePackag
 	}
 	requestURL.RawQuery = reqParams.Encode()
 
-	respResult, err := fetchStoreJSON[storePageResponse](requestURL.String())
+	respResult, err := fetchStoreJSONContext[storePageResponse](ctx, requestURL.String())
 	if err != nil {
 		m.refreshStoreBackend()
 		return nil, err
@@ -787,6 +849,11 @@ func (m *StoreManager) StoreQueryPage(params StoreQueryPageParams) (*StorePackag
 }
 
 func (m *StoreManager) StoreQueryPackageFiles(namespace, packageName, version string) ([]StorePackageFileEntry, error) {
+	return m.StoreQueryPackageFilesContext(context.Background(), namespace, packageName, version)
+}
+
+// StoreQueryPackageFilesContext queries package files with cancellation support.
+func (m *StoreManager) StoreQueryPackageFilesContext(ctx context.Context, namespace, packageName, version string) ([]StorePackageFileEntry, error) {
 	backend, err := m.currentBackend()
 	if err != nil {
 		return nil, err
@@ -811,13 +878,16 @@ func (m *StoreManager) StoreQueryPackageFiles(namespace, packageName, version st
 		return nil, err
 	}
 
-	respResult, err := fetchStoreJSON[storePackageFilesResponse](requestURL)
+	respResult, err := fetchStoreJSONContext[storePackageFilesResponse](ctx, requestURL)
 	if err != nil {
 		m.refreshStoreBackend()
 		return nil, err
 	}
 	if !respResult.Result {
 		return nil, fmt.Errorf("%s", respResult.Err)
+	}
+	if len(respResult.Data) > maxStorePackageFiles {
+		return nil, fmt.Errorf("扩展包文件列表不能超过 %d 项", maxStorePackageFiles)
 	}
 	return sanitizeStorePackageFileEntries(respResult.Data)
 }
@@ -943,9 +1013,23 @@ func (m *StoreManager) RefreshInstalled(packages []*StorePackage) {
 			pkg.FullID = BuildStorePackageFullID(pkg.ID, pkg.Version)
 		}
 		if pkg.FullID != "" {
-			m.packageCache[pkg.FullID] = pkg
+			m.cachePackageLocked(pkg.FullID, pkg)
 		}
 	}
+}
+
+func (m *StoreManager) cachePackageLocked(fullID string, pkg *StorePackage) {
+	if _, exists := m.packageCache[fullID]; exists {
+		m.packageCache[fullID] = pkg
+		return
+	}
+	for len(m.packageCacheOrder) >= maxStorePackageCache {
+		oldest := m.packageCacheOrder[0]
+		m.packageCacheOrder = m.packageCacheOrder[1:]
+		delete(m.packageCache, oldest)
+	}
+	m.packageCache[fullID] = pkg
+	m.packageCacheOrder = append(m.packageCacheOrder, fullID)
 }
 
 func (m *StoreManager) FindPackage(id, version string) (*StorePackage, bool) {
@@ -1046,7 +1130,7 @@ func (m *StoreManager) StoreQueryUploadInfo() (StoreUploadInfo, error) {
 			return StoreUploadInfo{}, fmt.Errorf("当前扩展商店后端不可用: %s", backend.Url)
 		}
 	}
-	result, err := fetchStoreJSON[StoreUploadInfo](backend.Url + "/upload/info")
+	result, err := fetchStoreJSONContext[StoreUploadInfo](context.Background(), backend.Url+"/upload/info")
 	if err != nil {
 		m.refreshStoreBackend()
 		return StoreUploadInfo{}, err

--- a/dice/store_test.go
+++ b/dice/store_test.go
@@ -243,6 +243,36 @@ func TestStoreQueryPageUsesSingleResolvedBackend(t *testing.T) {
 	}
 }
 
+func TestStoreQueryPageOmitsDefaultPaginationParameters(t *testing.T) {
+	pageQuery := make(chan map[string][]string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dice/api/store/info":
+			_, _ = w.Write([]byte(`{"formatVersion":"2.0","name":"Official Store","protocolVersions":["2.0"]}`))
+		case "/dice/api/store/page":
+			pageQuery <- r.URL.Query()
+			_, _ = w.Write([]byte(`{"formatVersion":"2.0","result":true,"data":{"formatVersion":"2.0","data":[],"pageNum":1,"pageSize":20,"next":false},"err":""}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	withOfficialStoreBackendBaseURL(t, server.URL)
+	manager := NewStoreManager(&Dice{})
+	if _, err := manager.StoreQueryPage(StoreQueryPageParams{}); err != nil {
+		t.Fatalf("StoreQueryPage() error = %v", err)
+	}
+
+	query := <-pageQuery
+	if _, exists := query["pageNum"]; exists {
+		t.Fatalf("pageNum query = %q, want omitted default", query["pageNum"])
+	}
+	if _, exists := query["pageSize"]; exists {
+		t.Fatalf("pageSize query = %q, want omitted default", query["pageSize"])
+	}
+}
+
 func TestStoreManagerFindPackageMatchesByIDAndVersionAfterRefreshInstalled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/dice/store_test.go
+++ b/dice/store_test.go
@@ -3,6 +3,8 @@ package dice //nolint:testpackage
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -703,5 +705,60 @@ func TestSanitizeStorePackageMarksCanonicalFields(t *testing.T) {
 	}
 	if pkg.StoreAssets.Screenshots == nil {
 		t.Fatal("expected StoreAssets.Screenshots to be initialized")
+	}
+}
+
+func TestStoreQueryPageRejectsOversizedPageBeforeBackendRequest(t *testing.T) {
+	manager := &StoreManager{}
+	_, err := manager.StoreQueryPageContext(context.Background(), StoreQueryPageParams{PageSize: maxStorePageSize + 1})
+	if err == nil || !strings.Contains(err.Error(), "pageSize") {
+		t.Fatalf("StoreQueryPageContext() error = %v, want page size rejection", err)
+	}
+}
+
+func TestStorePackageCacheIsBounded(t *testing.T) {
+	manager := &StoreManager{
+		lock:         new(sync.RWMutex),
+		packageCache: make(map[string]*StorePackage),
+	}
+	packages := make([]*StorePackage, 0, maxStorePackageCache+1)
+	for i := 0; i <= maxStorePackageCache; i++ {
+		packages = append(packages, &StorePackage{ID: "alice/demo", Version: fmt.Sprintf("1.0.%d", i)})
+	}
+	manager.RefreshInstalled(packages)
+	if len(manager.packageCache) != maxStorePackageCache {
+		t.Fatalf("package cache size = %d, want %d", len(manager.packageCache), maxStorePackageCache)
+	}
+	if _, ok := manager.FindPackage("alice/demo", "1.0.0"); ok {
+		t.Fatal("oldest package remained in bounded cache")
+	}
+	if _, ok := manager.FindPackage("alice/demo", fmt.Sprintf("1.0.%d", maxStorePackageCache)); !ok {
+		t.Fatal("newest package missing from bounded cache")
+	}
+}
+
+func TestInvalidateStoreBackendClearsPackageCache(t *testing.T) {
+	manager := &StoreManager{
+		lock:              new(sync.RWMutex),
+		packageCache:      map[string]*StorePackage{"alice/demo@1.0.0": {ID: "alice/demo", Version: "1.0.0"}},
+		packageCacheOrder: []string{"alice/demo@1.0.0"},
+	}
+	manager.invalidateStoreBackendLocked()
+	if len(manager.packageCache) != 0 || len(manager.packageCacheOrder) != 0 {
+		t.Fatalf("cache not cleared: packages=%d order=%d", len(manager.packageCache), len(manager.packageCacheOrder))
+	}
+}
+
+func TestDecodeStoreJSONResponseEnforcesLimit(t *testing.T) {
+	body := `{"name":"Official Store"}`
+	var result storeBackendInfoResponse
+	if err := decodeStoreJSONResponse(strings.NewReader(body), int64(len(body)), &result); err != nil {
+		t.Fatalf("decodeStoreJSONResponse() error = %v", err)
+	}
+	if result.Name != "Official Store" {
+		t.Fatalf("Name = %q", result.Name)
+	}
+	if err := decodeStoreJSONResponse(strings.NewReader(body), int64(len(body)-1), &result); !errors.Is(err, errStoreResponseTooLarge) {
+		t.Fatalf("decodeStoreJSONResponse() error = %v, want size rejection", err)
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

通过在磁盘上对扩展包上传和下载进行流式处理，实现受控的内存和磁盘使用；新增支持取消的存储和包操作，并收紧清单和存储响应的大小限制。

New Features:
- 支持从流和 URL 上下文感知地安装和预览扩展包，包括空闲下载超时和单操作并发控制。
- 暴露基于上下文的商店 API，用于推荐、分页查询和包文件列表，并通过 HTTP 处理程序进行接线集成。

Bug Fixes:
- 防止加载过大的清单、归档或存储响应，以避免过度的内存消耗和潜在的数据损坏。
- 确保在长时间运行的包操作和存储请求中遵守取消和空闲超时设置，避免卡死或资源泄漏。

Enhancements:
- 引入磁盘空间探测和受保护写入，用于包的预处理和解压缩，在每个卷上强制执行空间需求并留出少量安全余量。
- 以流式方式处理包数据，而不是将整个归档缓冲在内存中，包括支持进度的归档解压，以及具有适当超时设置的共享 HTTP 客户端。
- 跟踪未压缩归档大小，并对清单、中央目录、路径长度、存储 JSON 响应大小、页大小和包文件列表长度进行限制。
- 为内存中的商店包缓存设置上限，通过驱逐最旧条目来控制内存占用。
- 清理并复用专用的包预处理目录以存放临时构件，确保在安装和预览后不留下残留文件。

Tests:
- 添加覆盖流式拷贝行为、磁盘空间保护、有界缓存、存储响应限制、归档检查限制以及跨包和存储流程的上下文取消的全面测试和基准。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stream extension package uploads and downloads to disk with bounded memory and disk usage, add cancellation-aware store and package operations, and tighten manifest and store response size limits.

New Features:
- Support context-aware installation and preview of extension packages from streams and URLs, including idle download timeouts and single-operation concurrency control.
- Expose context-based store APIs for recommendations, paged queries, and package file listings, and wire them through HTTP handlers.

Bug Fixes:
- Prevent oversized manifests, archives, or store responses from being loaded to avoid excessive memory consumption and potential corruption.
- Ensure cancellation and idle timeouts are honored during long-running package operations and store requests to avoid hangs or resource leaks.

Enhancements:
- Introduce disk space probing and guarded writes for package staging and extraction, enforcing per-volume space requirements with a small safety reserve.
- Stream package data instead of buffering whole archives in memory, including progress-aware archive extraction and shared HTTP clients with appropriate timeouts.
- Track uncompressed archive size and enforce limits on manifest, central directory, path length, store JSON response sizes, page sizes, and package file list lengths.
- Bound the in-memory store package cache with eviction of the oldest entries to cap memory usage.
- Clean up and reuse a dedicated package staging directory for temporary artifacts, ensuring no leftovers after installs and previews.

Tests:
- Add extensive tests and benchmarks covering streaming copy behavior, disk space guards, bounded caches, store response limiting, archive inspection limits, and context cancellation across package and store flows.

</details>