### PR TITLE
fix: 修复群权限检查读取过期角色（暂不保熟，目前只有lagrange.milky被确认）

### DIFF
--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -142,6 +142,9 @@ func checkBotGroupRole(ctx *MsgContext, groupID string) (detail string, ok bool)
 		return "context invalid", false
 	}
 
+	// Permission changes must be visible immediately; cached member data can retain a stale role.
+	const bypassCache = true
+
 	switch pa := ctx.EndPoint.Adapter.(type) {
 	case *PlatformAdapterOnebot:
 		if pa.sendEmitter == nil {
@@ -151,7 +154,7 @@ func checkBotGroupRole(ctx *MsgContext, groupID string) (detail string, ok bool)
 		if !ok {
 			return "cannot resolve bot qq id", false
 		}
-		memberInfo, err := pa.sendEmitter.GetGroupMemberInfo(pa.ctx, ExtractQQEmitterGroupID(groupID), botID, false)
+		memberInfo, err := pa.sendEmitter.GetGroupMemberInfo(pa.ctx, ExtractQQEmitterGroupID(groupID), botID, bypassCache)
 		if err != nil || memberInfo == nil {
 			if err != nil {
 				return fmt.Sprintf("get_group_member_info failed: %v", err), false
@@ -169,7 +172,7 @@ func checkBotGroupRole(ctx *MsgContext, groupID string) (detail string, ok bool)
 		if botIDRaw == "" || groupIDRaw == "" {
 			return "cannot resolve bot/group id", false
 		}
-		memberInfo := pa.GetGroupMemberInfo(groupIDRaw, botIDRaw)
+		memberInfo := pa.getGroupMemberInfo(groupIDRaw, botIDRaw, bypassCache)
 		if memberInfo == nil {
 			return errGetGroupMemberInfoNil, false
 		}
@@ -179,7 +182,7 @@ func checkBotGroupRole(ctx *MsgContext, groupID string) (detail string, ok bool)
 		}
 		return role, true
 	case *PlatformAdapterMilky:
-		memberInfo, err := pa.GetGroupMemberInfo(groupID, ctx.EndPoint.UserID)
+		memberInfo, err := pa.getGroupMemberInfo(groupID, ctx.EndPoint.UserID, bypassCache)
 		if err != nil {
 			return fmt.Sprintf("get_group_member_info failed: %v", err), false
 		}

--- a/dice/builtin_commands_test.go
+++ b/dice/builtin_commands_test.go
@@ -84,7 +84,7 @@ func (h *milkyRESTHarness) handle(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			h.t.Fatalf("failed to decode get_group_member_info payload: %v", err)
 		}
-		if payload.GroupID != h.expectedGroupID || payload.UserID != h.expectedUserID || payload.NoCache {
+		if payload.GroupID != h.expectedGroupID || payload.UserID != h.expectedUserID || !payload.NoCache {
 			h.t.Fatalf("unexpected get_group_member_info payload: %#v", payload)
 		}
 		if h.apiError != "" {

--- a/dice/platform_adapter_gocq_actions.go
+++ b/dice/platform_adapter_gocq_actions.go
@@ -584,6 +584,10 @@ func (pa *PlatformAdapterGocq) waitEcho2(echo any, value interface{}, beforeWait
 
 // GetGroupMemberInfo 获取群成员信息
 func (pa *PlatformAdapterGocq) GetGroupMemberInfo(groupID string, userID string) *OnebotUserInfo {
+	return pa.getGroupMemberInfo(groupID, userID, false)
+}
+
+func (pa *PlatformAdapterGocq) getGroupMemberInfo(groupID string, userID string, noCache bool) *OnebotUserInfo {
 	type DetailParams struct {
 		GroupID string `json:"group_id"`
 		UserID  string `json:"user_id"`
@@ -597,7 +601,7 @@ func (pa *PlatformAdapterGocq) GetGroupMemberInfo(groupID string, userID string)
 		Params: DetailParams{
 			GroupID: groupID,
 			UserID:  userID,
-			NoCache: false,
+			NoCache: noCache,
 		},
 		Echo: echo,
 	})

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -983,6 +983,10 @@ func (pa *PlatformAdapterMilky) QuitGroup(ctx *MsgContext, groupID string) {
 }
 
 func (pa *PlatformAdapterMilky) GetGroupMemberInfo(groupID string, userID string) (*milky.GroupMemberInfo, error) {
+	return pa.getGroupMemberInfo(groupID, userID, false)
+}
+
+func (pa *PlatformAdapterMilky) getGroupMemberInfo(groupID string, userID string, noCache bool) (*milky.GroupMemberInfo, error) {
 	if pa == nil || pa.IntentSession == nil {
 		return nil, errors.New("milky session unavailable")
 	}
@@ -1001,7 +1005,7 @@ func (pa *PlatformAdapterMilky) GetGroupMemberInfo(groupID string, userID string
 	if err != nil {
 		return nil, fmt.Errorf("invalid milky user id %q: %w", userID, err)
 	}
-	return pa.IntentSession.GetGroupMemberInfo(groupIDInt, userIDInt, false)
+	return pa.IntentSession.GetGroupMemberInfo(groupIDInt, userIDInt, noCache)
 }
 
 func (pa *PlatformAdapterMilky) SetGroupCardName(ctx *MsgContext, cardName string) {

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -21,14 +21,17 @@ import (
 )
 
 type onebotTestEmitter struct {
-	friendReqCalls []friendReqCall
-	groupReqCalls  []groupReqCall
-	groupInfo      *emitterTypes.GroupInfo
-	groupInfoErr   error
-	groupReqCh     chan struct{}
-	loginInfo      *emitterTypes.LoginInfo
-	loginInfoErr   error
-	sendPvtCh      chan time.Time
+	friendReqCalls       []friendReqCall
+	groupReqCalls        []groupReqCall
+	groupInfo            *emitterTypes.GroupInfo
+	groupInfoErr         error
+	groupMemberInfo      *emitterTypes.GroupMemberInfo
+	groupMemberInfoErr   error
+	groupMemberInfoCalls []groupMemberInfoCall
+	groupReqCh           chan struct{}
+	loginInfo            *emitterTypes.LoginInfo
+	loginInfoErr         error
+	sendPvtCh            chan time.Time
 }
 
 type friendReqCall struct {
@@ -41,6 +44,12 @@ type groupReqCall struct {
 	Flag    string
 	Approve bool
 	Reason  string
+}
+
+type groupMemberInfoCall struct {
+	GroupID int64
+	UserID  int64
+	NoCache bool
 }
 
 var _ emitter.Emitter = (*onebotTestEmitter)(nil)
@@ -133,7 +142,18 @@ func (m *onebotTestEmitter) GetGroupInfo(context.Context, int64, bool) (*emitter
 	return m.groupInfo, nil
 }
 
-func (m *onebotTestEmitter) GetGroupMemberInfo(context.Context, int64, int64, bool) (*emitterTypes.GroupMemberInfo, error) {
+func (m *onebotTestEmitter) GetGroupMemberInfo(_ context.Context, groupID int64, userID int64, noCache bool) (*emitterTypes.GroupMemberInfo, error) {
+	m.groupMemberInfoCalls = append(m.groupMemberInfoCalls, groupMemberInfoCall{
+		GroupID: groupID,
+		UserID:  userID,
+		NoCache: noCache,
+	})
+	if m.groupMemberInfoErr != nil {
+		return nil, m.groupMemberInfoErr
+	}
+	if m.groupMemberInfo != nil {
+		return m.groupMemberInfo, nil
+	}
 	return &emitterTypes.GroupMemberInfo{}, nil
 }
 
@@ -144,6 +164,34 @@ func (m *onebotTestEmitter) Raw(context.Context, emitter.Action, any) ([]byte, e
 func (m *onebotTestEmitter) HandleEcho(emitter.Response[sonic.NoCopyRawMessage]) {}
 
 func (m *onebotTestEmitter) GetDroppedEchoCount() uint64 { return 0 }
+
+func TestCheckBotGroupRoleOnebotBypassesCache(t *testing.T) {
+	em := &onebotTestEmitter{
+		groupMemberInfo: &emitterTypes.GroupMemberInfo{Role: "admin"},
+	}
+	pa := &PlatformAdapterOnebot{
+		ctx:         t.Context(),
+		sendEmitter: em,
+	}
+	ctx := &MsgContext{
+		EndPoint: &EndPointInfo{
+			EndPointInfoBase: EndPointInfoBase{UserID: "QQ:10010"},
+			Adapter:          pa,
+		},
+	}
+
+	role, ok := checkBotGroupRole(ctx, "QQ-Group:2010")
+	if !ok || role != "admin" {
+		t.Fatalf("checkBotGroupRole() = (%q, %v), want (%q, true)", role, ok, "admin")
+	}
+	if len(em.groupMemberInfoCalls) != 1 {
+		t.Fatalf("GetGroupMemberInfo call count = %d, want 1", len(em.groupMemberInfoCalls))
+	}
+	call := em.groupMemberInfoCalls[0]
+	if call.GroupID != 2010 || call.UserID != 10010 || !call.NoCache {
+		t.Fatalf("unexpected GetGroupMemberInfo call: %#v", call)
+	}
+}
 
 func newPureOnebotTestAdapter(t *testing.T) (*Dice, *PlatformAdapterOnebot, *onebotTestEmitter, func()) {
 	t.Helper()


### PR DESCRIPTION
## Summary by Sourcery

确保群权限检查使用未缓存的成员数据，以便角色变更能立即生效。

Bug Fixes:
- 修复 OneBot、GoCQ 和 Milky 适配器中的群角色检测问题，在权限检查时绕过已过期的缓存群成员信息。

Enhancements:
- 在 GoCQ 和 Milky 适配器中新增内部辅助方法，以在获取群成员信息时控制缓存使用。
- 扩展 OneBot 测试发射器，并新增测试用例，验证在权限检查时获取群成员信息的请求会绕过缓存。

Tests:
- 为 OneBot 和 Milky 流程新增单元测试，断言 `get_group_member_info` 在调用时会绕过缓存并使用正确的参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure group permission checks use uncached member data so role changes take effect immediately.

Bug Fixes:
- Fix group role detection across OneBot, GoCQ, and Milky adapters by bypassing stale cached group member info during permission checks.

Enhancements:
- Add internal helper methods in GoCQ and Milky adapters to control cache usage when fetching group member info.
- Extend OneBot test emitter and add tests to verify group member info requests bypass cache for permission checks.

Tests:
- Add unit tests for OneBot and Milky flows to assert get_group_member_info is called with cache bypass and correct parameters.

</details>