### PR TITLE
feat(team): 新增团队列表命令

### DIFF
--- a/dice/ext_core_team.go
+++ b/dice/ext_core_team.go
@@ -7,10 +7,15 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/samber/lo"
 	ds "github.com/sealdice/dicescript"
+
+	"sealdice-core/utils"
 )
+
+const teamListPageMaxLength = 14000
 
 type attributeContainer struct {
 	UserID string
@@ -19,8 +24,9 @@ type attributeContainer struct {
 
 var cmdTeam = &CmdItemInfo{
 	Name:      "team",
-	ShortHelp: ".team <团队名> add/del/clear/call/st/ra/rc [attr-expr]",
+	ShortHelp: ".team list 或 .team <团队名> add/del/clear/call/st/ra/rc [attr-expr]",
 	Help: `队伍管理指令:
+.team list // 列出当前群的所有团队及成员
 .team <团队名> add/del <@成员...> // 增减队伍列表，若无团队会自动新建
 .team <团队名> clear // 清空队伍
 .team <团队名> call // 艾特队伍
@@ -47,6 +53,10 @@ var cmdTeam = &CmdItemInfo{
 		group := context.Group
 		if group.PlayerGroups == nil {
 			group.PlayerGroups = new(SyncMap[string, []string])
+		}
+		if teamIsListRequest(arguments) {
+			teamReplyList(context, message, group)
+			return execResult
 		}
 		playerGroup, groupExists := group.PlayerGroups.Load(groupName)
 
@@ -227,6 +237,77 @@ var cmdTeam = &CmdItemInfo{
 
 		return execResult
 	},
+}
+
+func teamIsListRequest(arguments *CmdArgs) bool {
+	return arguments.GetArgN(1) == "list" && arguments.GetArgN(2) == ""
+}
+
+func teamReplyList(context *MsgContext, message *Message, group *GroupInfo) {
+	text := teamListText(context, group)
+	for _, page := range teamListPages(text) {
+		ReplyToSender(context, message, page)
+	}
+}
+
+func teamListPages(text string) []string {
+	return utils.SplitLongText(text, teamListPageMaxLength, "团队列表（%d/%d）\n")
+}
+
+func teamListText(context *MsgContext, group *GroupInfo) string {
+	teamNames := make([]string, 0, group.PlayerGroups.Len())
+	group.PlayerGroups.Range(func(teamName string, _ []string) bool {
+		teamNames = append(teamNames, teamName)
+		return true
+	})
+	slices.Sort(teamNames)
+
+	if len(teamNames) == 0 {
+		return "当前群尚未创建团队"
+	}
+
+	lines := make([]string, 0, len(teamNames)+1)
+	lines = append(lines, fmt.Sprintf("当前群共有%d个团队：", len(teamNames)))
+	for _, teamName := range teamNames {
+		members, _ := group.PlayerGroups.Load(teamName)
+		formattedMembers := make([]string, 0, len(members))
+		for _, userID := range members {
+			formattedMembers = append(formattedMembers, teamMemberDisplayName(context, group, userID))
+		}
+
+		memberText := "无成员"
+		if len(formattedMembers) > 0 {
+			memberText = strings.Join(formattedMembers, "、")
+		}
+		lines = append(lines, fmt.Sprintf("%s（%d人）：%s", teamSanitizeDisplayName(teamName), len(members), memberText))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func teamMemberDisplayName(context *MsgContext, group *GroupInfo, userID string) string {
+	name := ""
+	player := group.PlayerGet(context.Dice.DBOperator, userID)
+	if player != nil {
+		name = teamSanitizeDisplayName(player.Name)
+	}
+
+	if name == "" || name == "%未知用户%" {
+		name = teamSanitizeDisplayName(context.Dice.Parent.TryGetUserName(userID))
+	}
+	if name == "" || name == "%未知用户%" {
+		return userID
+	}
+	return fmt.Sprintf("%s（%s）", name, userID)
+}
+
+func teamSanitizeDisplayName(name string) string {
+	name = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, name)
+	return strings.Join(strings.Fields(name), " ")
 }
 
 func teamStripPlatformPrefix(userID string) string {

--- a/dice/ext_core_team_test.go
+++ b/dice/ext_core_team_test.go
@@ -1,0 +1,74 @@
+//nolint:testpackage
+package dice
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTeamListUsesStoredNamesCacheAndIDFallback(t *testing.T) {
+	dm := &DiceManager{}
+	d := &Dice{Parent: dm}
+	ctx := &MsgContext{Dice: d}
+	group := &GroupInfo{
+		Players:      new(SyncMap[string, *GroupPlayerInfo]),
+		PlayerGroups: new(SyncMap[string, []string]),
+	}
+	group.PlayerGroups.Store("B组", []string{})
+	group.PlayerGroups.Store("A组", []string{"QQ:1", "QQ:2", "QQ:3"})
+	group.Players.Store("QQ:1", &GroupPlayerInfo{Name: "  海\n豹\t名  ", UserID: "QQ:1"})
+	group.Players.Store("QQ:2", nil)
+	group.Players.Store("QQ:3", nil)
+	dm.UserNameCache.Store("QQ:1", &GroupNameCacheItem{Name: "不应使用的缓存名"})
+	dm.UserNameCache.Store("QQ:2", &GroupNameCacheItem{Name: "缓存名"})
+
+	got := teamListText(ctx, group)
+	want := "当前群共有2个团队：\n" +
+		"A组（3人）：海 豹 名（QQ:1）、缓存名（QQ:2）、QQ:3\n" +
+		"B组（0人）：无成员"
+	if got != want {
+		t.Fatalf("team list reply = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "[CQ:at") {
+		t.Fatalf("team list unexpectedly mentions members: %q", got)
+	}
+}
+
+func TestTeamListReportsNoTeams(t *testing.T) {
+	group := &GroupInfo{PlayerGroups: new(SyncMap[string, []string])}
+	if got := teamListText(nil, group); got != "当前群尚未创建团队" {
+		t.Fatalf("team list reply = %q, want empty-team hint", got)
+	}
+}
+
+func TestTeamNamedListCanStillBeCalledExplicitly(t *testing.T) {
+	if !teamIsListRequest(&CmdArgs{Args: []string{"list"}}) {
+		t.Fatal(".team list was not recognized as a list request")
+	}
+	if teamIsListRequest(&CmdArgs{Args: []string{"list", "call"}}) {
+		t.Fatal(".team list call must remain an explicit call for the team named list")
+	}
+}
+
+func TestTeamListPagesOnlyWhenTextIsLong(t *testing.T) {
+	shortText := "当前群共有1个团队：\n调查组（1人）：Alice（QQ:1）"
+	shortPages := teamListPages(shortText)
+	if len(shortPages) != 1 || shortPages[0] != shortText {
+		t.Fatalf("short pages = %#v, want unchanged text", shortPages)
+	}
+
+	longText := strings.Repeat("x", teamListPageMaxLength+100)
+	longPages := teamListPages(longText)
+	if len(longPages) < 2 {
+		t.Fatalf("long page count = %d, want at least two", len(longPages))
+	}
+	for index, page := range longPages {
+		wantPrefix := "团队列表（"
+		if !strings.HasPrefix(page, wantPrefix) {
+			t.Fatalf("page %d = %q, want pagination prefix", index+1, page)
+		}
+		if len(page) >= 15000 {
+			t.Fatalf("page %d length = %d, want below reply hard limit", index+1, len(page))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- 新增 .team list，按名称稳定列出当前群的所有团队及成员
- 优先显示海豹记录名，其次使用现有用户名缓存，并始终附带平台用户 ID
- 不发送 at；仅在输出确实过长时自动分页
- 保留对名为 list 的团队执行 .team list call 的兼容行为

## Testing

- go test -race ./dice -run ^TestTeam -count=1
- go vet ./...

Implement #1777

## Summary by Sourcery

在群组中添加一个 `.team list` 命令，用于显示所有团队及其成员，并提供稳定的排序和安全的显示名称，对较长的输出自动进行分页。

**新功能：**
- 引入 `.team list`，用于列出当前群组中的所有团队及其成员及人数。

**增强：**
- 确保团队和成员的显示名称经过清理（sanitized），并包含平台用户 ID；在必要时回退到缓存的名称或原始 ID。
- 为较长的团队列表输出添加自动分页功能，以确保回复内容长度不超限。

**测试：**
- 添加测试，用于覆盖团队列表的名称解析与回退逻辑、空团队行为、对名为 `list` 的团队进行显式调用的行为，以及长输出的分页行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a .team list command to display all teams and members in a group, with stable ordering and safe display names, including automatic pagination for long outputs.

New Features:
- Introduce .team list to list all teams in the current group along with their members and counts.

Enhancements:
- Ensure team and member display names are sanitized and include platform user IDs, falling back to cached names or raw IDs when necessary.
- Add automatic pagination of long team list outputs to stay within reply length limits.

Tests:
- Add tests covering team list name resolution and fallbacks, empty-team behavior, explicit calls to a team named list, and pagination behavior for long outputs.

</details>