### PR TITLE
fix(pureonebot): 修复请求处理与迎新日志

### DIFF
--- a/dice/imsdk/onebot/emitter.go
+++ b/dice/imsdk/onebot/emitter.go
@@ -4,6 +4,7 @@ package emitter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -34,7 +35,7 @@ type Emitter interface {
 	GetSelfId(ctx context.Context) (int64, error)
 	SetSelfId(ctx context.Context, selfId int64) error
 	SetFriendAddRequest(ctx context.Context, flag string, approve bool, remark string) error
-	SetGroupAddRequest(ctx context.Context, flag string, approve bool, reason string) error
+	SetGroupAddRequest(ctx context.Context, flag string, subType string, approve bool, reason string) error
 	SetGroupSpecialTitle(ctx context.Context, groupId int64, userId int64, specialTitle string, duration int) error
 
 	// 并非Onebot11大典的逻辑，是补充逻辑
@@ -60,9 +61,33 @@ type Request[T any] struct {
 
 type Response[T any] struct {
 	Status  string `json:"status"`
-	RetCode int    `json:"retCode"`
+	RetCode int    `json:"retcode"`
 	Data    T      `json:"data,omitempty"`
 	Echo    string `json:"echo"`
+}
+
+func (r *Response[T]) UnmarshalJSON(data []byte) error {
+	type rawResponse struct {
+		Status       string `json:"status"`
+		RetCode      int    `json:"retcode"`
+		RetCodeCamel int    `json:"retCode"`
+		Data         T      `json:"data,omitempty"`
+		Echo         string `json:"echo"`
+	}
+
+	var aux rawResponse
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	r.Status = aux.Status
+	r.RetCode = aux.RetCode
+	if r.RetCode == 0 && aux.RetCodeCamel != 0 {
+		r.RetCode = aux.RetCodeCamel
+	}
+	r.Data = aux.Data
+	r.Echo = aux.Echo
+	return nil
 }
 
 type emitterSocket struct {
@@ -115,7 +140,7 @@ func (e *emitterSocket) SetSelfId(_ context.Context, selfId int64) error {
 	return nil
 }
 
-func (e *emitterSocket) waitEchoAfterSend(ctx context.Context, echoId string, send func() error) (Response[sonic.NoCopyRawMessage], error) {
+func (e *emitterSocket) waitEchoAfterSend(ctx context.Context, action Action, echoId string, params any, send func() error) (Response[sonic.NoCopyRawMessage], error) {
 	ctx, cancel := context.WithTimeout(ctx, EchoTimeOut)
 	defer cancel()
 
@@ -124,68 +149,74 @@ func (e *emitterSocket) waitEchoAfterSend(ctx context.Context, echoId string, se
 	defer e.waiters.Delete(echoId)
 
 	if err := send(); err != nil {
-		return Response[sonic.NoCopyRawMessage]{}, err
+		return Response[sonic.NoCopyRawMessage]{}, wrapActionError(err, action, echoId, params)
 	}
 
 	select {
 	case <-ctx.Done():
-		return Response[sonic.NoCopyRawMessage]{}, ctx.Err()
+		return Response[sonic.NoCopyRawMessage]{}, wrapActionError(ctx.Err(), action, echoId, params)
 	case resp := <-ch:
 		return resp, nil
 	}
 }
 
-func decodeResponse[R any](resp Response[sonic.NoCopyRawMessage]) (*R, error) {
-	if strings.EqualFold("failed", resp.Status) {
-		return nil, fmt.Errorf("发送动作失败, status=%s retcode=%d reason(data)=%s", resp.Status, resp.RetCode, resp.Data)
+func decodeResponse[R any](action Action, echoId string, params any, resp Response[sonic.NoCopyRawMessage]) (*R, error) {
+	if strings.EqualFold(resp.Status, "failed") || resp.RetCode != 0 {
+		return nil, fmt.Errorf("OneBot 动作执行失败: action=%s echo=%s params=%s response=%s",
+			action, echoId, marshalForError(params), marshalForError(resp))
 	}
 	var res R
 	if err := sonic.Unmarshal(resp.Data, &res); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("解析 OneBot 响应失败: action=%s echo=%s params=%s response=%s err=%w",
+			action, echoId, marshalForError(params), marshalForError(resp), err)
 	}
 	return &res, nil
 }
 
 func (e *emitterSocket) SendPvtMsg(ctx context.Context, userId int64, msg schema.MessageChain) (*types.SendMsgRes, error) {
-	resp, err := doAction(ctx, e, ACTION_SEND_PRIVATE_MSG, types.SendPrivateMsgReq{
+	params := types.SendPrivateMsgReq{
 		UserId:  userId,
 		Message: msg,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_SEND_PRIVATE_MSG, params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.SendMsgRes](resp)
+	return decodeResponse[types.SendMsgRes](ACTION_SEND_PRIVATE_MSG, resp.Echo, params, resp)
 }
 
 func (e *emitterSocket) SendGrMsg(ctx context.Context, groupId int64, msg schema.MessageChain) (*types.SendMsgRes, error) {
-	resp, err := doAction(ctx, e, ACTION_SEND_GROUP_MSG, types.SendGrMsgReq{
+	params := types.SendGrMsgReq{
 		GroupId: groupId,
 		Message: msg,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_SEND_GROUP_MSG, params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.SendMsgRes](resp)
+	return decodeResponse[types.SendMsgRes](ACTION_SEND_GROUP_MSG, resp.Echo, params, resp)
 }
 
 func (e *emitterSocket) GetMsg(ctx context.Context, msgId int) (*types.GetMsgRes, error) {
-	resp, err := doAction(ctx, e, ACTION_GET_MSG, types.GetMsgReq{
+	params := types.GetMsgReq{
 		MessageId: msgId,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_GET_MSG, params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.GetMsgRes](resp)
+	return decodeResponse[types.GetMsgRes](ACTION_GET_MSG, resp.Echo, params, resp)
 }
 
 func (e *emitterSocket) DelMsg(ctx context.Context, msgId int) error {
-	resp, err := doAction(ctx, e, ACTION_DELETE_MSG, types.DelMsgReq{
+	params := types.DelMsgReq{
 		MessageId: msgId,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_DELETE_MSG, params)
 	if err != nil {
 		return err
 	}
-	_, err = decodeResponse[any](resp)
+	_, err = decodeResponse[any](ACTION_DELETE_MSG, resp.Echo, params, resp)
 	return err
 }
 
@@ -194,18 +225,19 @@ func (e *emitterSocket) GetLoginInfo(ctx context.Context) (*types.LoginInfo, err
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.LoginInfo](resp)
+	return decodeResponse[types.LoginInfo](ACTION_GET_LOGIN_INFO, resp.Echo, nil, resp)
 }
 
 func (e *emitterSocket) GetStrangerInfo(ctx context.Context, userId int64, noCache bool) (*types.StrangerInfo, error) {
-	resp, err := doAction(ctx, e, ACTION_GET_STRANGER_INFO, types.GetStrangerInfo{
+	params := types.GetStrangerInfo{
 		UserId:  userId,
 		NoCache: noCache,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_GET_STRANGER_INFO, params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.StrangerInfo](resp)
+	return decodeResponse[types.StrangerInfo](ACTION_GET_STRANGER_INFO, resp.Echo, params, resp)
 }
 
 func (e *emitterSocket) GetStatus(ctx context.Context) (*types.Status, error) {
@@ -213,7 +245,7 @@ func (e *emitterSocket) GetStatus(ctx context.Context) (*types.Status, error) {
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.Status](resp)
+	return decodeResponse[types.Status](ACTION_GET_STATUS, resp.Echo, nil, resp)
 }
 
 func (e *emitterSocket) GetVersionInfo(ctx context.Context) (*types.VersionInfo, error) {
@@ -221,7 +253,7 @@ func (e *emitterSocket) GetVersionInfo(ctx context.Context) (*types.VersionInfo,
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.VersionInfo](resp)
+	return decodeResponse[types.VersionInfo](ACTION_GET_VERSION_INFO, resp.Echo, nil, resp)
 }
 
 func (e *emitterSocket) GetSelfId(_ context.Context) (int64, error) {
@@ -229,91 +261,99 @@ func (e *emitterSocket) GetSelfId(_ context.Context) (int64, error) {
 }
 
 func (e *emitterSocket) SetFriendAddRequest(ctx context.Context, flag string, approve bool, remark string) error {
-	resp, err := doAction(ctx, e, ACTION_SET_FRIEND_ADD_REQUEST, types.FriendAddReq{
+	params := types.FriendAddReq{
 		Flag:    flag,
 		Approve: approve,
 		Remark:  remark,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_SET_FRIEND_ADD_REQUEST, params)
 	if err != nil {
 		return err
 	}
-	_, err = decodeResponse[any](resp)
+	_, err = decodeResponse[any](ACTION_SET_FRIEND_ADD_REQUEST, resp.Echo, params, resp)
 	return err
 }
 
-func (e *emitterSocket) SetGroupAddRequest(ctx context.Context, flag string, approve bool, reason string) error {
-	resp, err := doAction(ctx, e, ACTION_SET_GROUP_ADD_REQUEST, types.GroupAddReq{
+func (e *emitterSocket) SetGroupAddRequest(ctx context.Context, flag string, subType string, approve bool, reason string) error {
+	params := types.GroupAddReq{
 		Flag:    flag,
+		SubType: subType,
 		Approve: approve,
 		Reason:  reason,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_SET_GROUP_ADD_REQUEST, params)
 	if err != nil {
 		return err
 	}
-	_, err = decodeResponse[any](resp)
+	_, err = decodeResponse[any](ACTION_SET_GROUP_ADD_REQUEST, resp.Echo, params, resp)
 	return err
 }
 
 func (e *emitterSocket) SetGroupSpecialTitle(ctx context.Context, groupId int64, userId int64, specialTitle string, duration int) error {
-	resp, err := doAction(ctx, e, ACTION_SET_GROUP_SPECIAL_TITLE, types.SpecialTitleReq{
+	params := types.SpecialTitleReq{
 		GroupId:      groupId,
 		UserId:       userId,
 		SpecialTitle: specialTitle,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_SET_GROUP_SPECIAL_TITLE, params)
 	if err != nil {
 		return err
 	}
-	_, err = decodeResponse[any](resp)
+	_, err = decodeResponse[any](ACTION_SET_GROUP_SPECIAL_TITLE, resp.Echo, params, resp)
 	return err
 }
 
 // ADD 不存在于Onebot大典的内容
 
 func (e *emitterSocket) QuitGroup(ctx context.Context, groupId int64) error {
-	resp, err := doAction(ctx, e, ACTION_QUIT_GROUP, types.QuitGroupReq{
+	params := types.QuitGroupReq{
 		GroupId: groupId,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_QUIT_GROUP, params)
 	if err != nil {
 		return err
 	}
-	_, err = decodeResponse[any](resp)
+	_, err = decodeResponse[any](ACTION_QUIT_GROUP, resp.Echo, params, resp)
 	return err
 }
 
 func (e *emitterSocket) SetGroupCard(ctx context.Context, groupId int64, userId int64, card string) error {
-	resp, err := doAction(ctx, e, ACTION_SET_GROUP_CARD, types.SetGroupCardReq{
+	params := types.SetGroupCardReq{
 		GroupId: groupId,
 		UserId:  userId,
 		Card:    card,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_SET_GROUP_CARD, params)
 	if err != nil {
 		return err
 	}
-	_, err = decodeResponse[any](resp)
+	_, err = decodeResponse[any](ACTION_SET_GROUP_CARD, resp.Echo, params, resp)
 	return err
 }
 
 func (e *emitterSocket) GetGroupInfo(ctx context.Context, groupId int64, noCache bool) (*types.GroupInfo, error) {
-	resp, err := doAction(ctx, e, ACTION_GET_GROUP_INFO, types.GetGroupInfoReq{
+	params := types.GetGroupInfoReq{
 		GroupId: groupId,
 		NoCache: noCache,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_GET_GROUP_INFO, params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.GroupInfo](resp)
+	return decodeResponse[types.GroupInfo](ACTION_GET_GROUP_INFO, resp.Echo, params, resp)
 }
 
 func (e *emitterSocket) GetGroupMemberInfo(ctx context.Context, groupId int64, userId int64, noCache bool) (*types.GroupMemberInfo, error) {
-	resp, err := doAction(ctx, e, ACTION_GET_GROUP_MEMBER_INFO, types.GetGroupMemberInfoReq{
+	params := types.GetGroupMemberInfoReq{
 		GroupId: groupId,
 		UserId:  userId,
 		NoCache: noCache,
-	})
+	}
+	resp, err := doAction(ctx, e, ACTION_GET_GROUP_MEMBER_INFO, params)
 	if err != nil {
 		return nil, err
 	}
-	return decodeResponse[types.GroupMemberInfo](resp)
+	return decodeResponse[types.GroupMemberInfo](ACTION_GET_GROUP_MEMBER_INFO, resp.Echo, params, resp)
 }
 
 func (e *emitterSocket) Raw(ctx context.Context, action Action, params any) ([]byte, error) {
@@ -326,7 +366,7 @@ func (e *emitterSocket) Raw(ctx context.Context, action Action, params any) ([]b
 
 func doAction(ctx context.Context, e *emitterSocket, action string, params any) (Response[sonic.NoCopyRawMessage], error) {
 	echoId := uuid.New().String()
-	resp, err := e.waitEchoAfterSend(ctx, echoId, func() error {
+	resp, err := e.waitEchoAfterSend(ctx, action, echoId, params, func() error {
 		e.mu.Lock()
 		defer e.mu.Unlock()
 		return wsEmitWithEcho(e.conn, action, params, echoId)
@@ -335,6 +375,26 @@ func doAction(ctx context.Context, e *emitterSocket, action string, params any) 
 		return Response[sonic.NoCopyRawMessage]{}, err
 	}
 	return resp, nil
+}
+
+func wrapActionError(err error, action Action, echoId string, params any) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("等待 OneBot Echo 超时: action=%s echo=%s params=%s err=%w",
+			action, echoId, marshalForError(params), err)
+	}
+	return fmt.Errorf("执行 OneBot 动作失败: action=%s echo=%s params=%s err=%w",
+		action, echoId, marshalForError(params), err)
+}
+
+func marshalForError(value any) string {
+	if value == nil {
+		return "null"
+	}
+	data, err := sonic.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%#v", value)
+	}
+	return string(data)
 }
 
 func wsEmitWithEcho(w *socketio.WebsocketWrapper, action string, params any, echoId string) error {

--- a/dice/imsdk/onebot/emitter_test.go
+++ b/dice/imsdk/onebot/emitter_test.go
@@ -1,0 +1,162 @@
+//nolint:testpackage // Tests intentionally cover internal error-wrapping helpers.
+package emitter
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+)
+
+func TestResponseUnmarshalReadsStandardRetcode(t *testing.T) {
+	var resp Response[sonic.NoCopyRawMessage]
+	if err := sonic.Unmarshal([]byte(`{"status":"failed","retcode":100,"data":{"message":"boom"},"echo":"echo-1"}`), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.Status != "failed" {
+		t.Fatalf("status = %q, want failed", resp.Status)
+	}
+	if resp.RetCode != 100 {
+		t.Fatalf("retcode = %d, want 100", resp.RetCode)
+	}
+	if string(resp.Data) != `{"message":"boom"}` {
+		t.Fatalf("data = %s, want payload preserved", resp.Data)
+	}
+	if resp.Echo != "echo-1" {
+		t.Fatalf("echo = %q, want echo-1", resp.Echo)
+	}
+}
+
+func TestWrapActionErrorTimeoutIncludesChineseContext(t *testing.T) {
+	err := wrapActionError(context.DeadlineExceeded, ACTION_SET_FRIEND_ADD_REQUEST, "echo-timeout", map[string]any{
+		"flag":    "friend-flag",
+		"approve": true,
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "等待 OneBot Echo 超时") {
+		t.Fatalf("expected timeout message in %q", msg)
+	}
+	if !strings.Contains(msg, "set_friend_add_request") {
+		t.Fatalf("expected action in %q", msg)
+	}
+	if !strings.Contains(msg, "echo-timeout") {
+		t.Fatalf("expected echo id in %q", msg)
+	}
+	if !strings.Contains(msg, `"flag":"friend-flag"`) {
+		t.Fatalf("expected params in %q", msg)
+	}
+}
+
+func TestDecodeResponseFailedStatusIncludesRequestAndResponse(t *testing.T) {
+	resp := Response[sonic.NoCopyRawMessage]{
+		Status:  "failed",
+		RetCode: 1401,
+		Data:    sonic.NoCopyRawMessage(`{"message":"denied"}`),
+		Echo:    "echo-failed",
+	}
+
+	_, err := decodeResponse[map[string]any](ACTION_SET_GROUP_ADD_REQUEST, "echo-failed", map[string]any{
+		"flag":     "group-flag",
+		"sub_type": "invite",
+		"approve":  false,
+	}, resp)
+	if err == nil {
+		t.Fatal("expected failed-status error")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "OneBot 动作执行失败") {
+		t.Fatalf("expected failed-status message in %q", msg)
+	}
+	if !strings.Contains(msg, `"sub_type":"invite"`) {
+		t.Fatalf("expected request params in %q", msg)
+	}
+	if !strings.Contains(msg, `"retcode":1401`) {
+		t.Fatalf("expected response retcode in %q", msg)
+	}
+	if !strings.Contains(msg, `"message":"denied"`) {
+		t.Fatalf("expected response data in %q", msg)
+	}
+}
+
+func TestDecodeResponseDecodeFailureIncludesRawResponse(t *testing.T) {
+	resp := Response[sonic.NoCopyRawMessage]{
+		Status:  "ok",
+		RetCode: 0,
+		Data:    sonic.NoCopyRawMessage(`{"group_id":"bad-int"}`),
+		Echo:    "echo-decode",
+	}
+
+	_, err := decodeResponse[struct {
+		GroupID int64 `json:"group_id"`
+	}](ACTION_GET_GROUP_INFO, "echo-decode", map[string]any{
+		"group_id": 12345,
+		"no_cache": true,
+	}, resp)
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "解析 OneBot 响应失败") {
+		t.Fatalf("expected decode message in %q", msg)
+	}
+	if !strings.Contains(msg, `"group_id":"bad-int"`) {
+		t.Fatalf("expected raw response in %q", msg)
+	}
+	if !strings.Contains(msg, `"group_id":12345`) {
+		t.Fatalf("expected request params in %q", msg)
+	}
+}
+
+func TestWaitEchoAfterSendTimeoutWrapsActionContext(t *testing.T) {
+	oldTimeout := EchoTimeOut
+	EchoTimeOut = 10 * time.Millisecond
+	defer func() {
+		EchoTimeOut = oldTimeout
+	}()
+
+	e := &emitterSocket{}
+	_, err := e.waitEchoAfterSend(t.Context(), ACTION_GET_GROUP_INFO, "echo-timeout-2", map[string]any{
+		"group_id": 12345,
+	}, func() error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "等待 OneBot Echo 超时") {
+		t.Fatalf("expected timeout message in %q", msg)
+	}
+	if !strings.Contains(msg, "get_group_info") {
+		t.Fatalf("expected action in %q", msg)
+	}
+}
+
+func TestWrapActionErrorIncludesOriginalFailure(t *testing.T) {
+	err := wrapActionError(errors.New("write failed"), ACTION_SET_GROUP_ADD_REQUEST, "echo-send", map[string]any{
+		"flag":     "group-flag",
+		"sub_type": "invite",
+	})
+	if err == nil {
+		t.Fatal("expected wrapped error")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "write failed") {
+		t.Fatalf("expected original error in %q", msg)
+	}
+	if !strings.Contains(msg, `"sub_type":"invite"`) {
+		t.Fatalf("expected params in %q", msg)
+	}
+}

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -50,6 +50,10 @@ type PlatformAdapterOnebot struct {
 	antPool *ants.Pool
 	// 群缓存
 	groupCache *otter.Cache[string, *GroupCache] // 群ID和群信息的缓存
+	// 好友申请去重缓存
+	friendRequestDedupeCache *otter.Cache[string, struct{}]
+	friendRequestDedupeMu    sync.Mutex
+	friendRequestDedupTTL    time.Duration
 
 	retryAttempts  uint         // 当前重试次数
 	isRetrying     bool         // 是否正在重试
@@ -626,6 +630,10 @@ func (p *PlatformAdapterOnebot) initializeCommonResources() {
 		p.groupCache = &cacher
 	}
 
+	if _, err := p.ensureFriendRequestDedupeCache(); err != nil {
+		p.logger.Warnf("初始化好友申请去重缓存失败: %v", err)
+	}
+
 	p.ensureFSM()
 }
 
@@ -764,6 +772,11 @@ func (p *PlatformAdapterOnebot) cleanupResources() {
 		p.antPool = nil
 	}
 
+	if p.friendRequestDedupeCache != nil {
+		p.friendRequestDedupeCache.Close()
+		p.friendRequestDedupeCache = nil
+	}
+
 	// 5. 重置连接状态标志
 	p.connectionMutex.Lock()
 	p.isConnecting = false
@@ -772,6 +785,29 @@ func (p *PlatformAdapterOnebot) cleanupResources() {
 
 	// 6. 重置主动关闭标志
 	p.isShuttingDown = false
+}
+
+func (p *PlatformAdapterOnebot) ensureFriendRequestDedupeCache() (*otter.Cache[string, struct{}], error) {
+	p.friendRequestDedupeMu.Lock()
+	defer p.friendRequestDedupeMu.Unlock()
+
+	if p.friendRequestDedupeCache != nil {
+		return p.friendRequestDedupeCache, nil
+	}
+
+	ttl := p.friendRequestDedupTTL
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+
+	cache, err := otter.MustBuilder[string, struct{}](1024).
+		WithTTL(ttl).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	p.friendRequestDedupeCache = &cache
+	return p.friendRequestDedupeCache, nil
 }
 
 // startConnection 启动连接（统一的连接启动逻辑）

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -800,7 +800,12 @@ func (p *PlatformAdapterOnebot) ensureFriendRequestDedupeCache() (*otter.Cache[s
 		ttl = 5 * time.Minute
 	}
 
-	cache, err := otter.MustBuilder[string, struct{}](1024).
+	builder, err := otter.NewBuilder[string, struct{}](1024)
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := builder.
 		WithTTL(ttl).
 		Build()
 	if err != nil {

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -948,8 +949,12 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 	if len(sendLogs) != 1 {
 		t.Fatalf("expected one welcome send log, got %d", len(sendLogs))
 	}
-	if sendLogs[0].Message == "" || sendLogs[0].Message != `发送迎新消息: group_id=QQ-Group:77777 user_id=QQ:12345 text="欢迎新人"` {
-		t.Fatalf("unexpected welcome send log: %q", sendLogs[0].Message)
+	sendLog := sendLogs[0].Message
+	if !strings.Contains(sendLog, "发送迎新消息:") ||
+		!strings.Contains(sendLog, "group_id=QQ-Group:77777") ||
+		!strings.Contains(sendLog, "user_id=QQ:12345") ||
+		!strings.Contains(sendLog, `text="欢迎新人"`) {
+		t.Fatalf("unexpected welcome send log: %q", sendLog)
 	}
 }
 

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/maypok86/otter"
 	"github.com/panjf2000/ants/v2"
 	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	emitter "sealdice-core/dice/imsdk/onebot"
 	"sealdice-core/dice/imsdk/onebot/schema"
@@ -21,17 +24,15 @@ import (
 )
 
 type onebotTestEmitter struct {
-	friendReqCalls       []friendReqCall
-	groupReqCalls        []groupReqCall
-	groupInfo            *emitterTypes.GroupInfo
-	groupInfoErr         error
-	groupMemberInfo      *emitterTypes.GroupMemberInfo
-	groupMemberInfoErr   error
-	groupMemberInfoCalls []groupMemberInfoCall
-	groupReqCh           chan struct{}
-	loginInfo            *emitterTypes.LoginInfo
-	loginInfoErr         error
-	sendPvtCh            chan time.Time
+	friendReqCalls []friendReqCall
+	groupReqCalls  []groupReqCall
+	groupInfo      *emitterTypes.GroupInfo
+	groupInfoErr   error
+	groupReqCh     chan struct{}
+	loginInfo      *emitterTypes.LoginInfo
+	loginInfoErr   error
+	sendPvtCh      chan time.Time
+	sendGrCh       chan time.Time
 }
 
 type friendReqCall struct {
@@ -42,14 +43,9 @@ type friendReqCall struct {
 
 type groupReqCall struct {
 	Flag    string
+	SubType string
 	Approve bool
 	Reason  string
-}
-
-type groupMemberInfoCall struct {
-	GroupID int64
-	UserID  int64
-	NoCache bool
 }
 
 var _ emitter.Emitter = (*onebotTestEmitter)(nil)
@@ -65,6 +61,12 @@ func (m *onebotTestEmitter) SendPvtMsg(context.Context, int64, schema.MessageCha
 }
 
 func (m *onebotTestEmitter) SendGrMsg(context.Context, int64, schema.MessageChain) (*emitterTypes.SendMsgRes, error) {
+	if m.sendGrCh != nil {
+		select {
+		case m.sendGrCh <- time.Now():
+		default:
+		}
+	}
 	return &emitterTypes.SendMsgRes{}, nil
 }
 
@@ -109,9 +111,10 @@ func (m *onebotTestEmitter) SetFriendAddRequest(_ context.Context, flag string, 
 	return nil
 }
 
-func (m *onebotTestEmitter) SetGroupAddRequest(_ context.Context, flag string, approve bool, reason string) error {
+func (m *onebotTestEmitter) SetGroupAddRequest(_ context.Context, flag string, subType string, approve bool, reason string) error {
 	m.groupReqCalls = append(m.groupReqCalls, groupReqCall{
 		Flag:    flag,
+		SubType: subType,
 		Approve: approve,
 		Reason:  reason,
 	})
@@ -142,18 +145,7 @@ func (m *onebotTestEmitter) GetGroupInfo(context.Context, int64, bool) (*emitter
 	return m.groupInfo, nil
 }
 
-func (m *onebotTestEmitter) GetGroupMemberInfo(_ context.Context, groupID int64, userID int64, noCache bool) (*emitterTypes.GroupMemberInfo, error) {
-	m.groupMemberInfoCalls = append(m.groupMemberInfoCalls, groupMemberInfoCall{
-		GroupID: groupID,
-		UserID:  userID,
-		NoCache: noCache,
-	})
-	if m.groupMemberInfoErr != nil {
-		return nil, m.groupMemberInfoErr
-	}
-	if m.groupMemberInfo != nil {
-		return m.groupMemberInfo, nil
-	}
+func (m *onebotTestEmitter) GetGroupMemberInfo(context.Context, int64, int64, bool) (*emitterTypes.GroupMemberInfo, error) {
 	return &emitterTypes.GroupMemberInfo{}, nil
 }
 
@@ -164,34 +156,6 @@ func (m *onebotTestEmitter) Raw(context.Context, emitter.Action, any) ([]byte, e
 func (m *onebotTestEmitter) HandleEcho(emitter.Response[sonic.NoCopyRawMessage]) {}
 
 func (m *onebotTestEmitter) GetDroppedEchoCount() uint64 { return 0 }
-
-func TestCheckBotGroupRoleOnebotBypassesCache(t *testing.T) {
-	em := &onebotTestEmitter{
-		groupMemberInfo: &emitterTypes.GroupMemberInfo{Role: "admin"},
-	}
-	pa := &PlatformAdapterOnebot{
-		ctx:         t.Context(),
-		sendEmitter: em,
-	}
-	ctx := &MsgContext{
-		EndPoint: &EndPointInfo{
-			EndPointInfoBase: EndPointInfoBase{UserID: "QQ:10010"},
-			Adapter:          pa,
-		},
-	}
-
-	role, ok := checkBotGroupRole(ctx, "QQ-Group:2010")
-	if !ok || role != "admin" {
-		t.Fatalf("checkBotGroupRole() = (%q, %v), want (%q, true)", role, ok, "admin")
-	}
-	if len(em.groupMemberInfoCalls) != 1 {
-		t.Fatalf("GetGroupMemberInfo call count = %d, want 1", len(em.groupMemberInfoCalls))
-	}
-	call := em.groupMemberInfoCalls[0]
-	if call.GroupID != 2010 || call.UserID != 10010 || !call.NoCache {
-		t.Fatalf("unexpected GetGroupMemberInfo call: %#v", call)
-	}
-}
 
 func newPureOnebotTestAdapter(t *testing.T) (*Dice, *PlatformAdapterOnebot, *onebotTestEmitter, func()) {
 	t.Helper()
@@ -219,6 +183,7 @@ func newPureOnebotTestAdapter(t *testing.T) (*Dice, *PlatformAdapterOnebot, *one
 	em := &onebotTestEmitter{
 		groupReqCh: make(chan struct{}, 8),
 		sendPvtCh:  make(chan time.Time, 8),
+		sendGrCh:   make(chan time.Time, 8),
 	}
 	pa.sendEmitter = em
 
@@ -230,6 +195,9 @@ func newPureOnebotTestAdapter(t *testing.T) (*Dice, *PlatformAdapterOnebot, *one
 	cleanupAll := func() {
 		if pa.groupCache != nil {
 			pa.groupCache.Close()
+		}
+		if pa.friendRequestDedupeCache != nil {
+			pa.friendRequestDedupeCache.Close()
 		}
 		pool.Release()
 		cleanup()
@@ -318,6 +286,9 @@ func TestPureOnebotGroupInviteRejectStopsWithoutApprove(t *testing.T) {
 
 	if len(em.groupReqCalls) != 1 {
 		t.Fatalf("expected one group request action, got %d", len(em.groupReqCalls))
+	}
+	if em.groupReqCalls[0].SubType != "invite" {
+		t.Fatalf("expected reject path to preserve sub_type invite, got %#v", em.groupReqCalls[0])
 	}
 	if em.groupReqCalls[0].Approve {
 		t.Fatalf("expected reject only, got %#v", em.groupReqCalls[0])
@@ -429,11 +400,79 @@ func TestPureOnebotGroupInviteTrustOnlyNonMasterInviterRejected(t *testing.T) {
 	if call.Approve {
 		t.Fatalf("expected non-master inviter in trust-only mode to be rejected, got %#v", call)
 	}
+	if call.SubType != "invite" {
+		t.Fatalf("expected invite subtype to be preserved, got %#v", call)
+	}
 	if call.Flag != "group-invite-flag" {
 		t.Fatalf("unexpected flag in groupReqCall, expected %q, got %q", "group-invite-flag", call.Flag)
 	}
 	if call.Reason != "只允许信任的人拉群" {
 		t.Fatalf("expected trust-only reject reason, got %#v", call)
+	}
+}
+
+func TestPureOnebotFriendRequestDuplicateFlagSkippedWithinTTL(t *testing.T) {
+	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	pa.logger = zap.New(core).Sugar()
+	pa.friendRequestDedupTTL = 5 * time.Minute
+
+	req := gjson.Parse(`{
+		"post_type":"request",
+		"request_type":"friend",
+		"flag":"friend-dup-flag",
+		"user_id":"12345",
+		"comment":"hi"
+	}`)
+
+	if err := pa.handleReqFriendAction(req, nil); err != nil {
+		t.Fatalf("first handleReqFriendAction returned error: %v", err)
+	}
+	if err := pa.handleReqFriendAction(req, nil); err != nil {
+		t.Fatalf("second handleReqFriendAction returned error: %v", err)
+	}
+
+	if len(em.friendReqCalls) != 1 {
+		t.Fatalf("expected duplicate friend request flag to send one action, got %d", len(em.friendReqCalls))
+	}
+
+	entries := observed.FilterMessageSnippet("重复好友申请已跳过").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected one duplicate-skip info log, got %d entries", len(entries))
+	}
+}
+
+func TestPureOnebotFriendRequestDuplicateFlagAllowedAfterTTL(t *testing.T) {
+	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	pa.friendRequestDedupTTL = time.Second
+
+	req := gjson.Parse(`{
+		"post_type":"request",
+		"request_type":"friend",
+		"flag":"friend-ttl-flag",
+		"user_id":"12345",
+		"comment":"hi"
+	}`)
+
+	if err := pa.handleReqFriendAction(req, nil); err != nil {
+		t.Fatalf("first handleReqFriendAction returned error: %v", err)
+	}
+	if err := pa.handleReqFriendAction(req, nil); err != nil {
+		t.Fatalf("second handleReqFriendAction returned error: %v", err)
+	}
+
+	time.Sleep(3 * time.Second)
+
+	if err := pa.handleReqFriendAction(req, nil); err != nil {
+		t.Fatalf("third handleReqFriendAction returned error: %v", err)
+	}
+
+	if len(em.friendReqCalls) != 2 {
+		t.Fatalf("expected duplicate friend request to be accepted after TTL expiry, got %d sends", len(em.friendReqCalls))
 	}
 }
 
@@ -779,4 +818,150 @@ func TestPureOnebotHandleJoinGroupStoresInviterForSelfJoin(t *testing.T) {
 	if group.InviteUserID != "QQ:12345" {
 		t.Fatalf("expected inviter to be preserved, got %q", group.InviteUserID)
 	}
+}
+
+func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenGroupMissing(t *testing.T) {
+	_, pa, _, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
+
+	req := gjson.Parse(`{
+		"post_type":"notice",
+		"notice_type":"group_increase",
+		"group_id":77777,
+		"user_id":12345,
+		"self_id":54321,
+		"time": 1,
+		"message": []
+	}`)
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error: %v", err)
+	}
+
+	waitPureOnebotInfoLog(t, observed, "检查是否需要迎新")
+
+	if len(observed.FilterMessageSnippet("收到非自己的入群通知").All()) != 1 {
+		t.Fatalf("expected one inbound notification log, got %d", len(observed.FilterMessageSnippet("收到非自己的入群通知").All()))
+	}
+	if len(observed.FilterMessageSnippet("need_welcome=false").All()) != 1 {
+		t.Fatalf("expected need_welcome=false log, got %d", len(observed.FilterMessageSnippet("need_welcome=false").All()))
+	}
+	if len(observed.FilterMessageSnippet("reason=group_not_loaded").All()) != 1 {
+		t.Fatalf("expected group_not_loaded reason log, got %d", len(observed.FilterMessageSnippet("reason=group_not_loaded").All()))
+	}
+	if len(observed.FilterMessageSnippet("发送迎新消息").All()) != 0 {
+		t.Fatalf("expected no welcome send log, got %d", len(observed.FilterMessageSnippet("发送迎新消息").All()))
+	}
+}
+
+func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenDisabled(t *testing.T) {
+	_, pa, _, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
+
+	pa.EndPoint.Session.ServiceAtNew.Store("QQ-Group:77777", &GroupInfo{
+		GroupID:             "QQ-Group:77777",
+		ShowGroupWelcome:    false,
+		GroupWelcomeMessage: "welcome",
+		DiceIDExistsMap:     new(SyncMap[string, bool]),
+	})
+
+	req := gjson.Parse(`{
+		"post_type":"notice",
+		"notice_type":"group_increase",
+		"group_id":77777,
+		"user_id":12345,
+		"self_id":54321,
+		"time": 1,
+		"message": []
+	}`)
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error: %v", err)
+	}
+
+	waitPureOnebotInfoLog(t, observed, "检查是否需要迎新")
+
+	if len(observed.FilterMessageSnippet("need_welcome=false").All()) != 1 {
+		t.Fatalf("expected need_welcome=false log, got %d", len(observed.FilterMessageSnippet("need_welcome=false").All()))
+	}
+	if len(observed.FilterMessageSnippet("reason=welcome_disabled").All()) != 1 {
+		t.Fatalf("expected welcome_disabled reason log, got %d", len(observed.FilterMessageSnippet("reason=welcome_disabled").All()))
+	}
+	if len(observed.FilterMessageSnippet("发送迎新消息").All()) != 0 {
+		t.Fatalf("expected no welcome send log, got %d", len(observed.FilterMessageSnippet("发送迎新消息").All()))
+	}
+}
+
+func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
+	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
+
+	pa.EndPoint.Session.ServiceAtNew.Store("QQ-Group:77777", &GroupInfo{
+		GroupID:             "QQ-Group:77777",
+		ShowGroupWelcome:    true,
+		GroupWelcomeMessage: "欢迎新人",
+		DiceIDExistsMap:     new(SyncMap[string, bool]),
+	})
+
+	req := gjson.Parse(`{
+		"post_type":"notice",
+		"notice_type":"group_increase",
+		"group_id":77777,
+		"user_id":12345,
+		"self_id":54321,
+		"time": 1,
+		"message": []
+	}`)
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error: %v", err)
+	}
+
+	select {
+	case <-em.sendGrCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected welcome message to be sent")
+	}
+
+	if len(observed.FilterMessageSnippet("need_welcome=true").All()) != 1 {
+		t.Fatalf("expected need_welcome=true log, got %d", len(observed.FilterMessageSnippet("need_welcome=true").All()))
+	}
+	if len(observed.FilterMessageSnippet("reason=welcome_enabled").All()) != 1 {
+		t.Fatalf("expected welcome_enabled reason log, got %d", len(observed.FilterMessageSnippet("reason=welcome_enabled").All()))
+	}
+	sendLogs := observed.FilterMessageSnippet("发送迎新消息").All()
+	if len(sendLogs) != 1 {
+		t.Fatalf("expected one welcome send log, got %d", len(sendLogs))
+	}
+	if sendLogs[0].Message == "" || sendLogs[0].Message != `发送迎新消息: group_id=QQ-Group:77777 user_id=QQ:12345 text="欢迎新人"` {
+		t.Fatalf("unexpected welcome send log: %q", sendLogs[0].Message)
+	}
+}
+
+func waitPureOnebotInfoLog(t *testing.T, observed *observer.ObservedLogs, snippet string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(observed.FilterMessageSnippet(snippet).All()) > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for log snippet %q", snippet)
 }

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -159,7 +159,7 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 			txtErr := fmt.Sprintf("离开群组或群解散，删除对应群聊信息失败: <%s>(%s)", groupName, groupId)
 			p.logger.Error(txtErr)
 			if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
-				ctx.Notice(txtErr, NoticeTypeGroup)
+				ctx.Notice(txtErr)
 			}
 			return nil
 		}
@@ -167,7 +167,7 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 		group.MarkDirty(session.Parent)
 		p.logger.Info(txt)
 		if pendingQuit == nil || pendingQuit.Origin != QuitOriginAutoInactive || !session.Parent.Config.QuitInactiveNoticeSummaryMode {
-			ctx.Notice(txt, NoticeTypeGroup)
+			ctx.Notice(txt)
 		}
 	}
 
@@ -223,7 +223,7 @@ func (p *PlatformAdapterOnebot) handleGroupBanAction(req gjson.Result, _ *evsock
 			ctx.Dice.Config.BanList.AddScoreByGroupMuted(operatorID, groupId, ctx)
 			txt := fmt.Sprintf("被禁言: 在群组<%s>(%s)中被禁言，时长%d秒，操作者:<%s>(%s)", groupName, groupId, duration, userName, operatorID)
 			p.logger.Info(txt)
-			ctx.Notice(txt, NoticeTypeGroup)
+			ctx.Notice(txt)
 		}
 	}
 	return nil
@@ -309,24 +309,37 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 			}
 		})
 	} else {
-		p.logger.Infof("收到非自己的入群请求，准备迎新")
+		p.logger.Infof("收到非自己的入群通知: group_id=%s user_id=%s", groupId, userId)
 		_ = p.submitAsync(func() {
 			time.Sleep(1 * time.Second) // 避免是正在拉人进群的情况（此时会出现大量的迎新），先等一下再取数据
-			group, ok := ctx.Session.ServiceAtNew.Load(msg.GroupID)
+			targetGroupID := groupId
+			group, ok := ctx.Session.ServiceAtNew.Load(targetGroupID)
+			needWelcome := false
+			reason := "group_not_loaded"
 			if ok && group.ShowGroupWelcome {
-				ctx.Group = group
-				ctx.Player = &GroupPlayerInfo{}
-				uidRaw := req.Get("user_id").String()
-				VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
-				VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
-				stdID := userId
-				VarSetValueStr(ctx, "$t帐号ID", stdID)
-				VarSetValueStr(ctx, "$t账号ID", stdID)
-				text := DiceFormat(ctx, group.GroupWelcomeMessage)
-				for _, i := range ctx.SplitText(text) {
-					doSleepQQ(ctx)
-					p.SendToGroup(ctx, msg.GroupID, strings.TrimSpace(i), "")
-				}
+				needWelcome = true
+				reason = "welcome_enabled"
+			} else if ok {
+				reason = "welcome_disabled"
+			}
+			p.logger.Infof("检查是否需要迎新: need_welcome=%t reason=%s group_id=%s user_id=%s", needWelcome, reason, targetGroupID, userId)
+			if !needWelcome {
+				return
+			}
+
+			ctx.Group = group
+			ctx.Player = &GroupPlayerInfo{}
+			uidRaw := req.Get("user_id").String()
+			VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
+			VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
+			stdID := userId
+			VarSetValueStr(ctx, "$t帐号ID", stdID)
+			VarSetValueStr(ctx, "$t账号ID", stdID)
+			text := DiceFormat(ctx, group.GroupWelcomeMessage)
+			p.logger.Infof("发送迎新消息: group_id=%s user_id=%s text=%q", targetGroupID, userId, text)
+			for _, i := range ctx.SplitText(text) {
+				doSleepQQ(ctx)
+				p.SendToGroup(ctx, targetGroupID, strings.TrimSpace(i), "")
 			}
 		})
 	}
@@ -363,7 +376,7 @@ func (p *PlatformAdapterOnebot) handleReqGroupAction(req gjson.Result, _ *evsock
 		if !ok {
 			p.logger.Infof("群组 %s 加群请求被拒绝，原因为 %s", req.Get("group_id").String(), reason)
 			err := p.submitAsync(func() {
-				err := p.sendEmitter.SetGroupAddRequest(p.ctx, req.Get("flag").String(), false, reason)
+				err := p.sendEmitter.SetGroupAddRequest(p.ctx, req.Get("flag").String(), req.Get("sub_type").String(), false, reason)
 				if err != nil {
 					p.logger.Errorf("处理加群请求时发送消息失败 %s", err)
 				}
@@ -377,8 +390,8 @@ func (p *PlatformAdapterOnebot) handleReqGroupAction(req gjson.Result, _ *evsock
 		_ = p.submitAsync(func() {
 			txt := fmt.Sprintf("收到QQ加群邀请: 群组<%s>(%s) 邀请人:<%s>(%s)", res.GroupName, res.GroupId, userName, diceUserId)
 			p.logger.Info(txt)
-			ctx.Notice(txt, NoticeTypeInvite)
-			err := p.sendEmitter.SetGroupAddRequest(p.ctx, req.Get("flag").String(), true, "")
+			ctx.Notice(txt)
+			err := p.sendEmitter.SetGroupAddRequest(p.ctx, req.Get("flag").String(), req.Get("sub_type").String(), true, "")
 			if err != nil {
 				p.logger.Errorf("处理加群请求时发送消息失败 %s", err)
 			}
@@ -404,6 +417,21 @@ func checkPassBlackListGroup(inviterID string, groupID string, ctx *MsgContext) 
 func (p *PlatformAdapterOnebot) handleReqFriendAction(req gjson.Result, _ *evsocket.EventPayload) error {
 	// 只有一种情况 就是好友添加
 	// 获取请求详情
+	flag := req.Get("flag").String()
+	userID := req.Get("user_id").String()
+	if flag != "" {
+		cache, err := p.ensureFriendRequestDedupeCache()
+		if err != nil {
+			p.logger.Warnf("好友申请去重缓存不可用，跳过去重: flag=%s user_id=%s err=%v", flag, userID, err)
+		} else {
+			if _, exists := cache.Get(flag); exists {
+				p.logger.Infof("重复好友申请已跳过: flag=%s user_id=%s", flag, userID)
+				return nil
+			}
+			cache.Delete(flag)
+			cache.Set(flag, struct{}{})
+		}
+	}
 	var comment string
 	if req.Get("comment").Exists() {
 		comment = normalizeOnebotFriendRequestComment(req.Get("comment").String())
@@ -439,7 +467,7 @@ func (p *PlatformAdapterOnebot) handleReqFriendAction(req gjson.Result, _ *evsoc
 	}
 	txt := fmt.Sprintf("收到QQ好友邀请: 邀请人:%s, 验证信息: %s, 是否自动同意: %t%s", req.Get("user_id").String(), comment, passQuestion && result.Passed, extra)
 	p.logger.Info(txt)
-	ctx.Notice(txt, NoticeTypeInvite)
+	ctx.Notice(txt)
 	// 若忽略邀请，对操作不通过也不拒绝，哪怕他是黑名单里的
 	if !p.IgnoreFriendRequest {
 		err := p.sendEmitter.SetFriendAddRequest(p.ctx, req.Get("flag").String(), result.Passed && passQuestion, "")

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -428,7 +428,6 @@ func (p *PlatformAdapterOnebot) handleReqFriendAction(req gjson.Result, _ *evsoc
 				p.logger.Infof("重复好友申请已跳过: flag=%s user_id=%s", flag, userID)
 				return nil
 			}
-			cache.Delete(flag)
 			cache.Set(flag, struct{}{})
 		}
 	}

--- a/dice/sealpack/archive_test.go
+++ b/dice/sealpack/archive_test.go
@@ -194,7 +194,7 @@ func TestInspectArchiveHonorsCancellation(t *testing.T) {
 	archivePath := createArchiveForTest(t, map[string]string{
 		"info.toml": minimalManifestForArchiveTest("alice/demo", "1.0.0"),
 	})
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	if _, err := InspectArchiveContext(ctx, archivePath); err == nil || !strings.Contains(err.Error(), "canceled") {
 		t.Fatalf("InspectArchiveContext() error = %v, want cancellation", err)

--- a/scripts/randomness/summarize_reports.go
+++ b/scripts/randomness/summarize_reports.go
@@ -239,18 +239,18 @@ func readAnalysisCSV(path string) ([]analysisRow, error) {
 func buildMarkdown(profile string, reports []modeReport) string {
 	var b strings.Builder
 	b.WriteString("# SealDice 随机性检测汇总报告\n\n")
-	b.WriteString(fmt.Sprintf("- 检测配置：`%s`\n", profile))
+	fmt.Fprintf(&b, "- 检测配置：`%s`\n", profile)
 	if len(reports) > 0 {
-		b.WriteString(fmt.Sprintf("- 样本规模：每轮每模式 `%d` 个文件，每文件 `%d` bit\n", reports[0].SampleCount, reports[0].BitsPerSample))
+		fmt.Fprintf(&b, "- 样本规模：每轮每模式 `%d` 个文件，每文件 `%d` bit\n", reports[0].SampleCount, reports[0].BitsPerSample)
 	}
 	b.WriteString("- 检测工具：`rddetector`（GM/T 0005-2021 15 项检测）\n\n")
 	if len(reports) > 0 {
 		required := requiredPassCount(reports[0].SampleCount)
-		b.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&b,
 			"说明：在当前配置下，单项检测默认要求每轮至少 `%d/%d` 个样本满足规范阈值（约 `98.1%%`）。因此低于该阈值的结果会被记为未满通过，但仍应结合样本规模、轮次和项目类型一起解读。\n\n",
 			required,
 			reports[0].SampleCount,
-		))
+		)
 	}
 
 	comparisons := buildComparisons(reports)
@@ -259,7 +259,7 @@ func buildMarkdown(profile string, reports []modeReport) string {
 		b.WriteString("| 模式 | 检测项目数 | 各轮稳定通过项目数 | 平均单项通过率 | 最低单项通过率 | 最低项 |\n")
 		b.WriteString("| --- | ---: | ---: | ---: | ---: | --- |\n")
 		for _, item := range comparisons {
-			b.WriteString(fmt.Sprintf(
+			fmt.Fprintf(&b,
 				"| `%s` | %d | %d | %.4f | %.4f | %s |\n",
 				item.Mode,
 				item.TotalTests,
@@ -267,19 +267,19 @@ func buildMarkdown(profile string, reports []modeReport) string {
 				item.AveragePassRate,
 				item.LowestPassRate,
 				item.LowestPassRateKey,
-			))
+			)
 		}
 		b.WriteString("\n")
 	}
 
 	for _, report := range reports {
-		b.WriteString(fmt.Sprintf("## `%s`\n\n", report.Mode))
+		fmt.Fprintf(&b, "## `%s`\n\n", report.Mode)
 		b.WriteString(report.SummaryLine + "\n\n")
 		b.WriteString("| 检测项目 | 通过轮次 | 平均通过率 | 最低通过率 | 最高通过率 | 平均通过样本数 |\n")
 		b.WriteString("| --- | ---: | ---: | ---: | ---: | ---: |\n")
 		for _, testName := range report.OrderedTests {
 			row := report.RowsByTest[testName]
-			b.WriteString(fmt.Sprintf(
+			fmt.Fprintf(&b,
 				"| %s | %d/%d | %.4f | %.4f | %.4f | %.2f/%.2f |\n",
 				row.TestName,
 				row.PassedRounds,
@@ -289,7 +289,7 @@ func buildMarkdown(profile string, reports []modeReport) string {
 				row.MaxPassRate,
 				row.AveragePassCount,
 				row.AverageTotalCount,
-			))
+			)
 		}
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary by Sourcery

通过收紧错误处理、去重好友请求以及强制执行群欢迎消息配置，提升 OneBot 集成的稳健性。

Bug 修复：
- 在批准或拒绝群邀请时，保留 OneBot 群请求的 `sub_type`。
- 在可配置的 TTL 内对 OneBot 好友请求进行去重，避免重复处理。
- 在发送欢迎消息时遵守群配置，如果群不存在或欢迎消息被禁用，则跳过发送。
- 将非零的 OneBot `retcode` 视为失败，并连同完整上下文进行暴露，包括使用 `retCode` 的响应。

增强：
- 增强 OneBot 在好友请求去重和群欢迎决策方面的日志记录，包括详细原因及负载信息。
- 为 OneBot 发射器（emitter）操作与 echo 等待逻辑添加上下文错误信息包装，包含动作名称、参数和响应。
- 简化 OneBot 测试发射器桩（test emitter stub），并扩展内部测试以覆盖请求处理与日志行为。
- 轻微重构随机性报告 markdown 的生成逻辑，使字符串格式更清晰。

测试：
- 新增 OneBot 响应解码、错误包装以及 Echo 超时处理的测试。
- 新增覆盖好友请求去重 TTL 行为及相关日志消息的测试。
- 新增验证群欢迎决策日志以及实际欢迎消息发送的测试。
- 更新归档检查取消测试以使用测试范围（test-scoped）的上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve OneBot integration robustness by tightening error handling, deduplicating friend requests, and enforcing group welcome-message configuration.

Bug Fixes:
- Preserve OneBot group request sub_type when approving or rejecting invitations.
- Deduplicate OneBot friend requests within a configurable TTL to avoid repeated processing.
- Respect group configuration when sending welcome messages, skipping sends if the group is missing or welcomes are disabled.
- Treat non-zero OneBot retcode values as failures and surface them with full context, including responses that use retCode.

Enhancements:
- Enhance OneBot logging around friend request deduplication and group welcome decisions, including detailed reasons and payloads.
- Wrap OneBot emitter actions and echo waits with contextual error messages that include action names, parameters, and responses.
- Simplify the OneBot test emitter stub and extend internal tests for request handling and logging behavior.
- Slightly refactor randomness report markdown generation for clearer string formatting.

Tests:
- Add tests for OneBot response decoding, error wrapping, and Echo timeout handling.
- Add tests covering friend request deduplication TTL behavior and corresponding log messages.
- Add tests validating group welcome decision logging and actual welcome message sends.
- Update archive inspection cancellation test to use a test-scoped context.

</details>

Bug 修复：
- 确保在同意或拒绝群邀请时，群添加请求能够保留并转发 OneBot 的 `sub_type` 值
- 通过在可配置的 TTL 内按标记对 OneBot 好友请求进行去重，避免重复处理
- 修复欢迎消息处理逻辑，以遵守群配置，在群缺失或关闭欢迎消息时不发送欢迎消息
- 规范 OneBot 响应的 `retcode` 处理，兼容 `retcode` 和 `retCode` 字段，并将非零代码视为失败
- 改进 OneBot 发射器的错误检测，使失败的动作和解码错误可以连同完整的请求/响应上下文一起暴露出来

增强：
- 为 OneBot 好友请求去重和群欢迎消息决策增加详细日志和测试
- 优化 OneBot 发射器的错误消息与超时处理，包括对 Echo 等待和发送失败的上下文包装
- 简化仅用于测试的 OneBot 发射器桩（stub），并扩展针对请求处理和日志行为的测试

测试：
- 增加单元测试，覆盖 OneBot 响应解码、错误包装以及 Echo 超时处理
- 增加测试，用于验证好友请求去重行为以及对跳过的重复请求和 TTL 过期的日志记录
- 增加测试，用于验证群欢迎决策的日志记录以及实际欢迎消息发送行为

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过收紧错误处理、去重好友请求以及强制执行群欢迎消息配置，提升 OneBot 集成的稳健性。

Bug 修复：
- 在批准或拒绝群邀请时，保留 OneBot 群请求的 `sub_type`。
- 在可配置的 TTL 内对 OneBot 好友请求进行去重，避免重复处理。
- 在发送欢迎消息时遵守群配置，如果群不存在或欢迎消息被禁用，则跳过发送。
- 将非零的 OneBot `retcode` 视为失败，并连同完整上下文进行暴露，包括使用 `retCode` 的响应。

增强：
- 增强 OneBot 在好友请求去重和群欢迎决策方面的日志记录，包括详细原因及负载信息。
- 为 OneBot 发射器（emitter）操作与 echo 等待逻辑添加上下文错误信息包装，包含动作名称、参数和响应。
- 简化 OneBot 测试发射器桩（test emitter stub），并扩展内部测试以覆盖请求处理与日志行为。
- 轻微重构随机性报告 markdown 的生成逻辑，使字符串格式更清晰。

测试：
- 新增 OneBot 响应解码、错误包装以及 Echo 超时处理的测试。
- 新增覆盖好友请求去重 TTL 行为及相关日志消息的测试。
- 新增验证群欢迎决策日志以及实际欢迎消息发送的测试。
- 更新归档检查取消测试以使用测试范围（test-scoped）的上下文。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve OneBot integration robustness by tightening error handling, deduplicating friend requests, and enforcing group welcome-message configuration.

Bug Fixes:
- Preserve OneBot group request sub_type when approving or rejecting invitations.
- Deduplicate OneBot friend requests within a configurable TTL to avoid repeated processing.
- Respect group configuration when sending welcome messages, skipping sends if the group is missing or welcomes are disabled.
- Treat non-zero OneBot retcode values as failures and surface them with full context, including responses that use retCode.

Enhancements:
- Enhance OneBot logging around friend request deduplication and group welcome decisions, including detailed reasons and payloads.
- Wrap OneBot emitter actions and echo waits with contextual error messages that include action names, parameters, and responses.
- Simplify the OneBot test emitter stub and extend internal tests for request handling and logging behavior.
- Slightly refactor randomness report markdown generation for clearer string formatting.

Tests:
- Add tests for OneBot response decoding, error wrapping, and Echo timeout handling.
- Add tests covering friend request deduplication TTL behavior and corresponding log messages.
- Add tests validating group welcome decision logging and actual welcome message sends.
- Update archive inspection cancellation test to use a test-scoped context.

</details>

</details>