### PR TITLE
fix(js): 统一兼容性版本比较逻辑

### DIFF
--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -1025,6 +1025,26 @@ type JsScriptDepends struct {
 	RawKey string `json:"rawKey"`
 }
 
+func isJSAPIVersionCompatible(
+	constraint *semver.Constraints,
+	rawConstraint string,
+	currentVersion *semver.Version,
+	compatibleVersions []*semver.Version,
+) bool {
+	// 有特殊符号时，进行严格的版本检查（只检查当前版本）。
+	if strings.ContainsAny(rawConstraint, "~*^<=>|") || strings.Contains(rawConstraint, " - ") {
+		// SealPack 的最低/最高版本检查按 SemVer 优先级比较，预发行版本也参与排序。
+		strictConstraint := *constraint
+		strictConstraint.IncludePrerelease = true
+		return strictConstraint.Check(currentVersion)
+	}
+
+	_, ok := lo.Find(compatibleVersions, func(version *semver.Version) bool {
+		return constraint.Check(version)
+	})
+	return ok
+}
+
 func (d *Dice) JsParseMeta(s string, installTime time.Time, rawData []byte, builtin bool) (*JsScriptInfo, error) {
 	// 读取文件内容填空，类似油猴脚本那种形式
 	jsInfo := &JsScriptInfo{
@@ -1117,17 +1137,7 @@ func (d *Dice) JsParseMeta(s string, installTime time.Time, rawData []byte, buil
 					continue
 				}
 
-				var verOK bool
-				// 有特殊符号时，进行严格的版本检查(只检查当前版本)
-				if strings.ContainsAny(v, "~*^<=>|") || strings.Contains(v, " - ") {
-					verOK = vc.Check(VERSION)
-				} else {
-					_, verOK = lo.Find(VERSION_JSAPI_COMPATIBLE, func(v *semver.Version) bool {
-						return vc.Check(v)
-					})
-				}
-
-				if !verOK {
+				if !isJSAPIVersionCompatible(vc, v, VERSION, VERSION_JSAPI_COMPATIBLE) {
 					errMsg = append(errMsg, fmt.Sprintf("插件「%s」依赖的海豹版本限制在 %s，与海豹版本(%s)的JSAPI不兼容", jsInfo.Name, v, VERSION.String()))
 				}
 			case "needCompiled":

--- a/dice/dice_jsvm_internal_test.go
+++ b/dice/dice_jsvm_internal_test.go
@@ -4,7 +4,54 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/Masterminds/semver/v3"
 )
+
+func TestIsJSAPIVersionCompatible(t *testing.T) {
+	compatibleVersions := []*semver.Version{
+		semver.MustParse("1.6.1-dev"),
+		semver.MustParse("1.6.0"),
+		semver.MustParse("1.5.0"),
+	}
+	tests := []struct {
+		name           string
+		currentVersion string
+		constraint     string
+		want           bool
+	}{
+		{name: "prerelease satisfies older stable minimum", currentVersion: "1.6.1-dev", constraint: ">=1.6.0", want: true},
+		{name: "prerelease does not satisfy its stable minimum", currentVersion: "1.6.1-dev", constraint: ">=1.6.1", want: false},
+		{name: "prerelease satisfies its stable maximum", currentVersion: "1.6.1-dev", constraint: "<=1.6.1", want: true},
+		{name: "prerelease exceeds older stable maximum", currentVersion: "1.6.1-dev", constraint: "<=1.6.0", want: false},
+		{name: "prerelease satisfies bounded range", currentVersion: "1.6.1-dev", constraint: ">=1.6.0, <1.6.1", want: true},
+		{name: "prerelease satisfies caret range", currentVersion: "1.6.1-dev", constraint: "^1.6.0", want: true},
+		{name: "strict equality does not use compatibility list", currentVersion: "1.6.1-dev", constraint: "=1.6.0", want: false},
+		{name: "prerelease satisfies exact prerelease", currentVersion: "1.6.1-dev", constraint: "=1.6.1-dev", want: true},
+		{name: "plain version uses compatibility list", currentVersion: "1.6.1-dev", constraint: "1.6.0", want: true},
+		{name: "unknown plain version is rejected", currentVersion: "1.6.1-dev", constraint: "1.6.2", want: false},
+		{name: "stable version behavior is unchanged", currentVersion: "1.6.1", constraint: ">=1.6.1", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			constraint, err := semver.NewConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("NewConstraint(%q) error = %v", tt.constraint, err)
+			}
+
+			got := isJSAPIVersionCompatible(
+				constraint,
+				tt.constraint,
+				semver.MustParse(tt.currentVersion),
+				compatibleVersions,
+			)
+			if got != tt.want {
+				t.Errorf("isJSAPIVersionCompatible(%q, %q) = %v, want %v", tt.currentVersion, tt.constraint, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestSortJsScripts(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
修改 JSAPI 的兼容性版本比较逻辑，使带运算符的 sealVersion 约束包含预发行版本，并按 SemVer 优先级处理，和 SealPack 一致

## Summary by Sourcery

将 JSAPI 兼容性版本检查与 SealPack 语义统一：让基于运算符的约束使用完整的 SemVer 优先级（包括预发布版本），而普通版本约束继续依赖预定义的兼容性列表。

Bug Fixes:
- 修复 JSAPI 版本兼容性检查，使预发布版本能正确根据基于运算符的 SemVer 约束进行评估。

Enhancements:
- 抽取 JSAPI 版本兼容性逻辑为可复用的辅助函数，并在元数据解析中共享使用。
- 通过显式包含预发布版本到基于运算符的约束中，使 JSAPI 版本约束处理与 SemVer 规则保持一致。

Tests:
- 添加单元测试，覆盖在各种 SemVer 约束模式下，JSAPI 版本兼容性在预发布版本和稳定版本上的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify JSAPI compatibility version checking with SealPack semantics so that operator-based constraints use full SemVer precedence including prereleases while plain version constraints continue to rely on the predefined compatibility list.

Bug Fixes:
- Fix JSAPI version compatibility checks so that prerelease versions are correctly evaluated against operator-based SemVer constraints.

Enhancements:
- Extract JSAPI version compatibility logic into a reusable helper function shared by metadata parsing.
- Align JSAPI version constraint handling with SemVer rules by explicitly including prerelease versions for operator-based constraints.

Tests:
- Add unit tests covering JSAPI version compatibility behavior for prerelease and stable versions across various SemVer constraint patterns.

</details>