### PR TITLE
fix: 修复 SaveText 文案备份与原子写入

### DIFF
--- a/dice/config.go
+++ b/dice/config.go
@@ -2457,8 +2457,9 @@ func saveTextTemplateFile(filename string, data []byte) error {
 
 	current, err := os.ReadFile(filename)
 	if err == nil {
-		if err := writeFileAtomically(filename+".bak", current, 0o644); err != nil {
-			return fmt.Errorf("备份文案文件失败: %w", err)
+		backupErr := writeFileAtomically(filename+".bak", current, 0o644)
+		if backupErr != nil {
+			return fmt.Errorf("备份文案文件失败: %w", backupErr)
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("读取现有文案文件失败: %w", err)
@@ -2494,7 +2495,6 @@ func writeFileAtomically(filename string, data []byte, perm os.FileMode) error {
 		return err
 	}
 
-	// 临时文件和目标文件位于同一目录，替换不会跨文件系统。
 	return os.Rename(tmpName, filename)
 }
 

--- a/dice/config.go
+++ b/dice/config.go
@@ -2416,20 +2416,86 @@ func (d *Dice) loadAdvanced() {
 }
 
 func (d *Dice) SaveText() {
-	buf, err := yaml.Marshal(d.TextMapRaw)
+	buf, err := marshalTextTemplate(d.TextMapRaw)
 	if err != nil {
 		d.Logger.Error("Dice.SaveText", err)
-	} else {
-		newFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml")
-		bakFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml.bak")
-		// ioutil.WriteFile(filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml"), buf, 0644)
-		current, err := os.ReadFile(newFn)
-		if err != nil {
-			_ = os.WriteFile(bakFn, current, 0o644) //nolint:gosec
-		}
-
-		_ = os.WriteFile(newFn, buf, 0o644)
+		return
 	}
+
+	newFn := filepath.Join(d.BaseConfig.DataDir, "configs/text-template.yaml")
+	if err := saveTextTemplateFile(newFn, buf); err != nil {
+		d.Logger.Error("Dice.SaveText", err)
+	}
+}
+
+func marshalTextTemplate(texts TextTemplateWithWeightDict) (buf []byte, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			buf = nil
+			err = fmt.Errorf("序列化文案失败: %v", recovered)
+		}
+	}()
+
+	buf, err = yaml.Marshal(texts)
+	if err != nil {
+		return nil, fmt.Errorf("序列化文案失败: %w", err)
+	}
+
+	// 再次解析序列化结果，避免异常数据覆盖掉现有文案文件。
+	var parsed TextTemplateWithWeightDict
+	if err := yaml.Unmarshal(buf, &parsed); err != nil {
+		return nil, fmt.Errorf("校验生成的文案 YAML 失败: %w", err)
+	}
+	return buf, nil
+}
+
+func saveTextTemplateFile(filename string, data []byte) error {
+	dir := filepath.Dir(filename)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("创建文案目录失败: %w", err)
+	}
+
+	current, err := os.ReadFile(filename)
+	if err == nil {
+		if err := writeFileAtomically(filename+".bak", current, 0o644); err != nil {
+			return fmt.Errorf("备份文案文件失败: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("读取现有文案文件失败: %w", err)
+	}
+
+	if err := writeFileAtomically(filename, data, 0o644); err != nil {
+		return fmt.Errorf("写入文案文件失败: %w", err)
+	}
+	return nil
+}
+
+func writeFileAtomically(filename string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(filename), "."+filepath.Base(filename)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName) //nolint:gosec
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	// 临时文件和目标文件位于同一目录，替换不会跨文件系统。
+	return os.Rename(tmpName, filename)
 }
 
 // ApplyExtDefaultSettings 应用扩展默认配置，同时处理插件的启用和禁用


### PR DESCRIPTION
## 变更说明

- 修正 SaveText 备份条件，已有文案文件会先备份到 text-template.yaml.bak。
- 使用同目录临时文件写入并替换目标，避免直接覆盖造成半截 YAML。
- YAML 序列化或现有文件读取失败时保留原文件并记录错误。
- 首次创建文案文件时不生成空备份。

Fixes #1702 

## Summary by Sourcery

提高保存文本模板配置文件的健壮性和原子性。

Bug 修复：
- 通过在目标目录中使用临时文件进行原子写入，防止出现部分写入或损坏的 `text-template.yaml` 文件。
- 在 YAML 序列化或验证失败时，避免覆盖已有的 `text-template.yaml`，从而保留当前文件内容。
- 确保仅在已有 `text-template.yaml` 文件存在时，才正确备份为 `text-template.yaml.bak`，并在读取这些文件出错时进行处理。

增强：
- 将文本模板的 YAML 编组和验证提取到一个专用的辅助工具中，通过重新解析生成的 YAML 来防止无效数据。
- 引入可复用的原子文件写入辅助工具，以统一并规范与文本模板相关文件的安全写入操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and atomicity of saving text-template configuration files.

Bug Fixes:
- Prevent partial or corrupted text-template.yaml writes by using atomic writes via temporary files in the target directory.
- Avoid overwriting existing text-template.yaml when YAML serialization or validation fails, preserving the current file contents.
- Ensure existing text-template.yaml files are correctly backed up to text-template.yaml.bak only when they exist, and handle errors when reading them.

Enhancements:
- Extract text template YAML marshaling and validation into a dedicated helper that re-parses the generated YAML to guard against invalid data.
- Introduce reusable atomic file write helper to standardize safe writes for text-template-related files.

</details>