### PR TITLE
fix(officialqq): 修复群聊 @ 用户格式及 ID 解析

### DIFF
--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -85,10 +85,8 @@ func (i *AtInfo) CopyCtx(ctx *MsgContext) (*MsgContext, bool) {
 			if mctx.Player.Name == "" && strings.HasPrefix(i.UserID, "OpenQQCH:") {
 				mctx.Player.Name = "<@!" + strings.TrimPrefix(i.UserID, "OpenQQCH:") + ">"
 			} else if mctx.Player.Name == "" && strings.HasPrefix(i.UserID, "OpenQQ:") {
-				mentionTarget := strings.TrimPrefix(i.UserID, "OpenQQ:")
-				// 若调用方已经传入规范 ID，回复 QQ 时仍只能发送 MemberOpenID。
-				mentionTarget = strings.TrimPrefix(mentionTarget, officialQQUIN+"-")
-				mctx.Player.Name = "<@" + mentionTarget + ">"
+				mentionTarget := normalizeOfficialQQGroupAtTarget(officialQQUIN, i.UserID)
+				mctx.Player.Name = formatOfficialQQAtUser(mentionTarget)
 			}
 		}
 		return mctx, p != nil
@@ -772,7 +770,7 @@ func AtParse(cmd string, prefix string) (string, []*AtInfo) {
 	case "QQ":
 		re = regexp.MustCompile(`\[CQ:at,qq=(\d+)(?:,name=(?:.*?))?\]`)
 	case "OpenQQ":
-		re = regexp.MustCompile(`<@!?(\S+?)>`)
+		re = officialQQAtRegex
 	case "OpenQQCH":
 		re = regexp.MustCompile(`<@!?(\S+?)>`)
 	case "DISCORD":
@@ -792,11 +790,17 @@ func AtParse(cmd string, prefix string) (string, []*AtInfo) {
 	m := re.FindAllStringSubmatch(cmd, -1)
 
 	for _, i := range m {
-		if len(i) == 2 {
-			at := new(AtInfo)
-			at.UserID = prefix + ":" + i[1]
-			at.IsRobot = prefix == "QQ" && isQQBotUserID(at.UserID)
-			ret = append(ret, at)
+		if len(i) >= 2 {
+			target := i[1]
+			if prefix == "OpenQQ" {
+				target = officialQQMentionTarget(i)
+			}
+			if target != "" {
+				at := new(AtInfo)
+				at.UserID = prefix + ":" + target
+				at.IsRobot = prefix == "QQ" && isQQBotUserID(at.UserID)
+				ret = append(ret, at)
+			}
 		}
 	}
 
@@ -808,7 +812,7 @@ func AtBuild(uid string) string {
 	if uid == "" {
 		return ""
 	}
-	re := regexp.MustCompile("(QQ|DISCORD|KOOK|TG|DODO).*?:(.*)")
+	re := regexp.MustCompile("^(OpenQQ|QQ|DISCORD|KOOK|TG|DODO).*?:(.*)")
 	m := re.FindStringSubmatch(uid)
 	var text string
 	if len(m) == 3 {

--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -86,7 +86,7 @@ func (i *AtInfo) CopyCtx(ctx *MsgContext) (*MsgContext, bool) {
 				mctx.Player.Name = "<@!" + strings.TrimPrefix(i.UserID, "OpenQQCH:") + ">"
 			} else if mctx.Player.Name == "" && strings.HasPrefix(i.UserID, "OpenQQ:") {
 				mentionTarget := normalizeOfficialQQGroupAtTarget(officialQQUIN, i.UserID)
-				mctx.Player.Name = formatOfficialQQAtUser(mentionTarget)
+				mctx.Player.Name = "<@" + mentionTarget + ">"
 			}
 		}
 		return mctx, p != nil

--- a/dice/cmd_parse.go
+++ b/dice/cmd_parse.go
@@ -86,7 +86,7 @@ func (i *AtInfo) CopyCtx(ctx *MsgContext) (*MsgContext, bool) {
 				mctx.Player.Name = "<@!" + strings.TrimPrefix(i.UserID, "OpenQQCH:") + ">"
 			} else if mctx.Player.Name == "" && strings.HasPrefix(i.UserID, "OpenQQ:") {
 				mentionTarget := normalizeOfficialQQGroupAtTarget(officialQQUIN, i.UserID)
-				mctx.Player.Name = "<@" + mentionTarget + ">"
+				mctx.Player.Name = formatOfficialQQAtUser(mentionTarget)
 			}
 		}
 		return mctx, p != nil

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -39,7 +39,42 @@ import (
 	"sealdice-core/utils"
 )
 
-var officialQQAtRegex = regexp.MustCompile(`<@!?(\S+?)>`)
+// Official QQ 当前使用 qqbot-at-user 标签表示提及；解析端继续兼容旧的
+// <@userID> 格式，以便平滑处理旧事件和已持久化消息。
+var officialQQAtRegex = regexp.MustCompile(`(?:<qqbot-at-user\s+id="([^"]+)"\s*/>|<@!?(\S+?)>)`)
+
+func officialQQMentionTarget(match []string) string {
+	if len(match) < 2 {
+		return ""
+	}
+	for _, target := range match[1:] {
+		if target != "" {
+			return target
+		}
+	}
+	return ""
+}
+
+func formatOfficialQQAtUser(target string) string {
+	return fmt.Sprintf(`<qqbot-at-user id="%s" />`, target)
+}
+
+func renderOfficialQQGroupAtTarget(target string) string {
+	if target == "all" {
+		return ""
+	}
+	return formatOfficialQQAtUser(target)
+}
+
+func rewriteOfficialQQGroupAtTags(text string, normalizeTarget func(string) string) string {
+	return officialQQAtRegex.ReplaceAllStringFunc(text, func(tag string) string {
+		target := officialQQMentionTarget(officialQQAtRegex.FindStringSubmatch(tag))
+		if target == "" {
+			return tag
+		}
+		return renderOfficialQQGroupAtTarget(normalizeTarget(target))
+	})
+}
 
 type PaginationItem struct {
 	Pages     []string
@@ -879,8 +914,8 @@ func (pa *PlatformAdapterOfficialQQ) groupMsgToStdMsg(event *dto.WSPayload, msgQ
 	}
 
 	m := officialQQAtRegex.FindStringSubmatch(msgQQ.Content)
-	if len(m) == 2 {
-		msg.TmpUID = "OpenQQ:" + m[1]
+	if target := officialQQMentionTarget(m); target != "" {
+		msg.TmpUID = officialQQUserIDPrefix + target
 	} else if botSelfOpenID != "" {
 		msg.TmpUID = "OpenQQ:" + botSelfOpenID
 	}
@@ -931,8 +966,8 @@ func (pa *PlatformAdapterOfficialQQ) groupNormalMsgToStdMsg(event *dto.WSPayload
 	}
 
 	for _, match := range officialQQAtRegex.FindAllStringSubmatch(msgQQ.Content, -1) {
-		if len(match) == 2 && match[1] == botSelfOpenID {
-			msg.TmpUID = "OpenQQ:" + match[1]
+		if target := officialQQMentionTarget(match); target == botSelfOpenID {
+			msg.TmpUID = officialQQUserIDPrefix + target
 			break
 		}
 	}
@@ -1996,7 +2031,9 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw(ctx *MsgContext, rowMsgID
 	for _, element := range elems {
 		switch elem := element.(type) {
 		case *message.TextElement:
-			content += textLinkStrip(elem.Content)
+			content += rewriteOfficialQQGroupAtTags(textLinkStrip(elem.Content), func(target string) string {
+				return normalizeOfficialQQGroupAtTarget(pa.UIN, target)
+			})
 		case *message.ReplyElement:
 			msgRef = &dto.MessageReference{
 				MessageID:             elem.ReplySeq,
@@ -2004,11 +2041,8 @@ func (pa *PlatformAdapterOfficialQQ) sendQQGroupMsgRaw(ctx *MsgContext, rowMsgID
 			}
 			toCreate.MessageReference = msgRef
 		case *message.AtElement:
-			target := strings.TrimPrefix(elem.Target, "OpenQQ:")
-			target = strings.TrimPrefix(target, "QQ:")
-			if target != "all" {
-				content += fmt.Sprintf("<qqbot-at-user id=\"%s\" />", target)
-			}
+			target := normalizeOfficialQQGroupAtTarget(pa.UIN, elem.Target)
+			content += renderOfficialQQGroupAtTarget(target)
 		case *message.ImageElement:
 			media, err := pa.uploadGroupMedia(qctx, groupID, elem.File, 1)
 			if err != nil {
@@ -2128,6 +2162,16 @@ func formatDiceIDOfficialQQGroupOpenID(uin, groupOpenID string) string {
 func formatDiceIDOfficialQQMemberOpenID(uin, _ string, memberOpenID string) string {
 	// 官方QQ群成员ID格式
 	return fmt.Sprintf("%s%s-%s", officialQQUserIDPrefix, uin, memberOpenID)
+}
+
+func normalizeOfficialQQGroupAtTarget(uin, target string) string {
+	target = strings.TrimSpace(target)
+	target = strings.TrimPrefix(target, officialQQUserIDPrefix)
+	target = strings.TrimPrefix(target, "QQ:")
+	if uin != "" {
+		target = strings.TrimPrefix(target, uin+"-")
+	}
+	return target
 }
 
 func (pa *PlatformAdapterOfficialQQ) populateGroupMentionedInfo(msg *Message, mentions []*dto.User) {

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -297,8 +297,8 @@ func TestOfficialQQDelegatedContextKeepsRawMentionTarget(t *testing.T) {
 	if delegatedCtx.Player.UserID != canonicalUserID {
 		t.Fatalf("delegated user ID = %q, want %q", delegatedCtx.Player.UserID, canonicalUserID)
 	}
-	if delegatedCtx.Player.Name != "<@"+memberOpenID+">" {
-		t.Fatalf("delegated mention name = %q, want raw MemberOpenID", delegatedCtx.Player.Name)
+	if delegatedCtx.Player.Name != formatOfficialQQAtUser(memberOpenID) {
+		t.Fatalf("delegated mention name = %q, want qqbot-at-user with raw MemberOpenID", delegatedCtx.Player.Name)
 	}
 }
 


### PR DESCRIPTION
<img width="1162" height="219" alt="image" src="https://github.com/user-attachments/assets/a389e7e9-684a-488e-ba16-d396e846b839" />
如图，且换新格式并兼容一下海豹 id 格式

## Summary by Sourcery

更新 Official QQ 提及（mention）的解析与渲染，以支持新的 qqbot-at-user 格式，同时保持向下兼容，并在解析与消息构造过程中统一（规范化）OpenQQ 用户 ID。

New Features:
- 为 Official QQ 群消息添加对新的 `<qqbot-at-user id="..." />` 提及格式的支持。

Bug Fixes:
- 修复在 Official QQ 群消息中同时使用旧版 `<@userID>` 与新版 qqbot-at-user 格式时，对 @ 提及的检测问题。
- 确保回复和发出的 Official QQ 消息中使用正确规范化的成员 OpenID，而不是带有不一致前缀的 ID。
- 修正 OpenQQ @ 提及解析逻辑，保证在多群正则匹配中能够一致地抽取用户 ID。

Enhancements:
- 引入辅助函数，用于规范化 Official QQ 群的 @ 目标，并将提及 ID 的提取与格式化逻辑集中管理。
- 扩展通用的 AtBuild/AtParse 处理逻辑，使其能够识别带有 OpenQQ 前缀的用户 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Official QQ mention parsing and rendering to support the new qqbot-at-user format while maintaining backward compatibility, and normalize OpenQQ user IDs across parsing and message construction.

New Features:
- Support the new <qqbot-at-user id="..." /> mention format for Official QQ group messages.

Bug Fixes:
- Fix detection of @-mentions in Official QQ group messages when using both legacy <@userID> and new qqbot-at-user formats.
- Ensure replies and outgoing Official QQ messages use correctly normalized member OpenID IDs instead of inconsistent prefixes.
- Correct OpenQQ @-mention parsing so that user IDs are consistently extracted from multi-group regex matches.

Enhancements:
- Introduce helpers to normalize Official QQ group @ targets and centralize mention ID extraction and formatting.
- Extend generic AtBuild/AtParse handling to recognize OpenQQ-prefixed user IDs.

</details>