### PR TITLE
refactor(endpoint): 引入全局状态机重构所有Adapter节点

### DIFF
--- a/dice/endpoint_lifecycle.go
+++ b/dice/endpoint_lifecycle.go
@@ -1,0 +1,559 @@
+package dice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	loopfsm "github.com/looplab/fsm"
+)
+
+// EndpointLifecycleState is the adapter-independent runtime state used by the
+// endpoint lifecycle supervisor. It intentionally mirrors pureonebot's FSM
+// shape so migrated adapters share the same enable/disable/retry semantics.
+type EndpointLifecycleState string
+
+const (
+	// LifecycleDisconnected means no active run is owned by the supervisor.
+	LifecycleDisconnected EndpointLifecycleState = "disconnected"
+	// LifecycleConnecting means a driver Start call is in progress or waiting
+	// for its asynchronous connected callback.
+	LifecycleConnecting EndpointLifecycleState = "connecting"
+	// LifecycleConnected means the current generation has reported a successful
+	// connection and may receive traffic.
+	LifecycleConnected EndpointLifecycleState = "connected"
+	// LifecycleFailed means the current generation failed to start. The
+	// supervisor may retry if the endpoint is still desired-enabled.
+	LifecycleFailed EndpointLifecycleState = "failed"
+)
+
+// EndpointLifecycleEvent names every transition that can move the shared FSM.
+// Keeping these values centralized avoids spreading string literals and magic
+// numeric endpoint states across adapter implementations.
+type EndpointLifecycleEvent string
+
+const (
+	// LifecycleEventEnable requests a transition from disconnected/failed to
+	// connecting.
+	LifecycleEventEnable EndpointLifecycleEvent = "enable"
+	// LifecycleEventDisable requests a transition to disconnected and stops the
+	// active generation.
+	LifecycleEventDisable EndpointLifecycleEvent = "disable"
+	// LifecycleEventConnectOK is reported by the current generation once the
+	// protocol connection is usable.
+	LifecycleEventConnectOK EndpointLifecycleEvent = "connect_ok"
+	// LifecycleEventConnectFail is reported by the current generation when start
+	// fails before a usable connection is established.
+	LifecycleEventConnectFail EndpointLifecycleEvent = "connect_fail"
+	// LifecycleEventConnectionLost is reported by the current generation when an
+	// established connection is lost unexpectedly.
+	LifecycleEventConnectionLost EndpointLifecycleEvent = "connection_lost"
+	// LifecycleEventRelogin is represented by the public Relogin method. It is
+	// kept as an enum so logs/tests can refer to the operation without inventing
+	// another literal.
+	LifecycleEventRelogin EndpointLifecycleEvent = "relogin"
+)
+
+// EndpointLifecycleFailurePolicy tells the supervisor whether a failed
+// generation should be retried. The default is retryable so existing adapters
+// can report ordinary network failures with run.Failed(err).
+type EndpointLifecycleFailurePolicy int
+
+const (
+	// LifecycleFailureRetry means the endpoint remains desired-enabled and the
+	// supervisor should retry according to its backoff policy.
+	LifecycleFailureRetry EndpointLifecycleFailurePolicy = iota
+	// LifecycleFailureStop means the failure is not useful to retry immediately,
+	// for example invalid configuration, container-mode restriction, or device
+	// lock/login rejection.
+	LifecycleFailureStop
+)
+
+// EndpointLifecycleFailure wraps a driver error with retry policy metadata
+// without forcing the reporter interface to grow more methods.
+type EndpointLifecycleFailure struct {
+	err    error
+	policy EndpointLifecycleFailurePolicy
+}
+
+// NewEndpointLifecycleFailure marks err with a retry policy for supervisor
+// decisions. A nil err is normalized so callers can still express the policy.
+func NewEndpointLifecycleFailure(err error, policy EndpointLifecycleFailurePolicy) error {
+	if err == nil {
+		err = errors.New("endpoint lifecycle failure")
+	}
+	return &EndpointLifecycleFailure{err: err, policy: policy}
+}
+
+// Error implements error while preserving the wrapped protocol error text.
+func (e *EndpointLifecycleFailure) Error() string {
+	if e == nil || e.err == nil {
+		return "endpoint lifecycle failure"
+	}
+	return e.err.Error()
+}
+
+// Unwrap exposes the protocol error to errors.Is/errors.As callers.
+func (e *EndpointLifecycleFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+// Policy returns the supervisor retry policy carried by this error.
+func (e *EndpointLifecycleFailure) Policy() EndpointLifecycleFailurePolicy {
+	if e == nil {
+		return LifecycleFailureRetry
+	}
+	return e.policy
+}
+
+func endpointLifecycleFailurePolicy(err error) EndpointLifecycleFailurePolicy {
+	var lifecycleFailure *EndpointLifecycleFailure
+	if errors.As(err, &lifecycleFailure) {
+		return lifecycleFailure.Policy()
+	}
+	return LifecycleFailureRetry
+}
+
+// EndpointStateFromLifecycle maps the internal lifecycle enum to the legacy
+// endpoint state enum consumed by API/UI clients.
+func EndpointStateFromLifecycle(state EndpointLifecycleState) EndpointState {
+	switch state {
+	case LifecycleDisconnected:
+		return StateDisconnected
+	case LifecycleConnecting:
+		return StateConnecting
+	case LifecycleConnected:
+		return StateConnected
+	case LifecycleFailed:
+		return StateConnectionFailed
+	default:
+		return StateConnectionFailed
+	}
+}
+
+// EndpointLifecycleDriver is the small protocol-specific surface needed by the
+// shared supervisor. Implementations should not start top-level reconnection
+// loops by themselves; they should report lifecycle changes through run.
+type EndpointLifecycleDriver interface {
+	LifecycleStart(ctx context.Context, run EndpointRunReporter) error
+	LifecycleStop(ctx context.Context) error
+}
+
+// EndpointRunReporter is scoped to one supervisor generation. Late reports from
+// an old generation are ignored, which prevents stale websocket sessions from
+// resurrecting endpoint state or scheduling new reconnects.
+type EndpointRunReporter interface {
+	Generation() uint64
+	Started()
+	Failed(error)
+	Closed(error)
+}
+
+// EndpointLifecycleSupervisor serializes lifecycle operations for one endpoint.
+// It owns the FSM, desired-enabled flag, current generation, cancellation, and
+// retry timer so adapters do not need their own ad-hoc "serving" booleans.
+type EndpointLifecycleSupervisor struct {
+	opMu sync.Mutex
+	mu   sync.Mutex
+
+	d      *Dice
+	ep     *EndPointInfo
+	driver EndpointLifecycleDriver
+	fsm    *loopfsm.FSM
+
+	desiredEnabled bool
+	generation     uint64
+	runCtx         context.Context
+	runCancel      context.CancelFunc
+
+	retryTimer        *time.Timer
+	retryAttempt      int
+	retryInitialDelay time.Duration
+	retryMaxDelay     time.Duration
+	retryMaxAttempts  int
+	stopTimeout       time.Duration
+	failurePolicy     EndpointLifecycleFailurePolicy
+}
+
+// NewEndpointLifecycleSupervisor creates a lifecycle supervisor for tests and
+// runtime binding. Runtime code should normally use ensureEndpointLifecycle so
+// the supervisor remains attached to the endpoint.
+func NewEndpointLifecycleSupervisor(d *Dice, ep *EndPointInfo, driver EndpointLifecycleDriver) *EndpointLifecycleSupervisor {
+	s := &EndpointLifecycleSupervisor{
+		d:                 d,
+		ep:                ep,
+		driver:            driver,
+		desiredEnabled:    ep != nil && ep.Enable,
+		retryInitialDelay: 2 * time.Second,
+		retryMaxDelay:     30 * time.Second,
+		retryMaxAttempts:  5,
+		stopTimeout:       5 * time.Second,
+	}
+	s.fsm = loopfsm.NewFSM(
+		string(LifecycleDisconnected),
+		loopfsm.Events{
+			{Name: string(LifecycleEventEnable), Src: []string{string(LifecycleDisconnected), string(LifecycleFailed)}, Dst: string(LifecycleConnecting)},
+			{Name: string(LifecycleEventConnectOK), Src: []string{string(LifecycleConnecting)}, Dst: string(LifecycleConnected)},
+			{Name: string(LifecycleEventConnectFail), Src: []string{string(LifecycleConnecting)}, Dst: string(LifecycleFailed)},
+			{Name: string(LifecycleEventConnectionLost), Src: []string{string(LifecycleConnected)}, Dst: string(LifecycleConnecting)},
+			{Name: string(LifecycleEventDisable), Src: []string{string(LifecycleConnecting), string(LifecycleConnected), string(LifecycleFailed), string(LifecycleDisconnected)}, Dst: string(LifecycleDisconnected)},
+		},
+		loopfsm.Callbacks{
+			"enter_" + string(LifecycleConnecting):   s.onEnterConnecting,
+			"enter_" + string(LifecycleConnected):    s.onEnterConnected,
+			"enter_" + string(LifecycleFailed):       s.onEnterFailed,
+			"enter_" + string(LifecycleDisconnected): s.onEnterDisconnected,
+		},
+	)
+	return s
+}
+
+// Enable records the user's desired state and starts the endpoint unless it is
+// already starting or running.
+func (s *EndpointLifecycleSupervisor) Enable(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.desiredEnabled = true
+	if s.ep != nil {
+		s.ep.Enable = true
+	}
+
+	switch EndpointLifecycleState(s.fsm.Current()) {
+	case LifecycleConnecting, LifecycleConnected:
+		s.updateAndSaveLocked()
+		return nil
+	default:
+		return s.eventLocked(ctx, LifecycleEventEnable)
+	}
+}
+
+// Disable records the user's desired state, cancels retry/start work, and asks
+// the driver to close the current protocol resources.
+func (s *EndpointLifecycleSupervisor) Disable(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
+	cancel := s.prepareStopLocked(ctx, false)
+	if cancel != nil {
+		cancel()
+	}
+	return s.stopDriver(ctx)
+}
+
+// Relogin replaces the active generation with a fresh one. Stopping the old
+// generation before starting the new one is the core guard against split
+// websocket connections.
+func (s *EndpointLifecycleSupervisor) Relogin(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
+	cancel := s.prepareStopLocked(ctx, true)
+	if cancel != nil {
+		cancel()
+	}
+	if err := s.stopDriver(ctx); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.desiredEnabled = true
+	if s.ep != nil {
+		s.ep.Enable = true
+	}
+	return s.eventLocked(ctx, LifecycleEventEnable)
+}
+
+func (s *EndpointLifecycleSupervisor) prepareStopLocked(ctx context.Context, keepDesiredEnabled bool) context.CancelFunc {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.desiredEnabled = keepDesiredEnabled
+	if s.ep != nil {
+		s.ep.Enable = keepDesiredEnabled
+	}
+	s.stopRetryLocked()
+
+	cancel := s.runCancel
+	s.runCancel = nil
+	s.runCtx = nil
+	_ = s.eventLocked(ctx, LifecycleEventDisable)
+	return cancel
+}
+
+func (s *EndpointLifecycleSupervisor) stopDriver(parent context.Context) error {
+	if s.driver == nil {
+		return nil
+	}
+	timeout := s.stopTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	return s.driver.LifecycleStop(ctx)
+}
+
+func (s *EndpointLifecycleSupervisor) eventLocked(ctx context.Context, event EndpointLifecycleEvent) error {
+	err := s.fsm.Event(ctx, string(event))
+	var noTransition loopfsm.NoTransitionError
+	if errors.As(err, &noTransition) {
+		return nil
+	}
+	var invalid loopfsm.InvalidEventError
+	if errors.As(err, &invalid) {
+		return nil
+	}
+	return err
+}
+
+func (s *EndpointLifecycleSupervisor) onEnterConnecting(_ context.Context, _ *loopfsm.Event) {
+	s.stopRetryLocked()
+	s.failurePolicy = LifecycleFailureRetry
+	s.generation++
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	s.runCtx = runCtx
+	s.runCancel = cancel
+
+	if s.ep != nil {
+		s.ep.State = EndpointStateFromLifecycle(LifecycleConnecting)
+		s.ep.Enable = s.desiredEnabled
+	}
+	s.updateAndSaveLocked()
+
+	generation := s.generation
+	driver := s.driver
+	reporter := &endpointLifecycleRunReporter{supervisor: s, generation: generation}
+	go func() {
+		if driver == nil {
+			reporter.Failed(fmt.Errorf("endpoint lifecycle driver is nil"))
+			return
+		}
+		if err := driver.LifecycleStart(runCtx, reporter); err != nil {
+			reporter.Failed(err)
+		}
+	}()
+}
+
+func (s *EndpointLifecycleSupervisor) onEnterConnected(_ context.Context, _ *loopfsm.Event) {
+	s.retryAttempt = 0
+	if s.ep != nil {
+		s.ep.State = EndpointStateFromLifecycle(LifecycleConnected)
+		s.ep.Enable = true
+	}
+	s.updateAndSaveLocked()
+}
+
+func (s *EndpointLifecycleSupervisor) onEnterFailed(_ context.Context, _ *loopfsm.Event) {
+	if s.ep != nil {
+		s.ep.State = EndpointStateFromLifecycle(LifecycleFailed)
+		s.ep.Enable = s.desiredEnabled
+	}
+	s.updateAndSaveLocked()
+	if s.desiredEnabled && s.failurePolicy == LifecycleFailureRetry {
+		s.scheduleRetryLocked()
+	}
+}
+
+func (s *EndpointLifecycleSupervisor) onEnterDisconnected(_ context.Context, _ *loopfsm.Event) {
+	if s.ep != nil {
+		s.ep.State = EndpointStateFromLifecycle(LifecycleDisconnected)
+		s.ep.Enable = s.desiredEnabled
+	}
+	s.updateAndSaveLocked()
+}
+
+func (s *EndpointLifecycleSupervisor) scheduleRetryLocked() {
+	if s.retryMaxAttempts > 0 && s.retryAttempt >= s.retryMaxAttempts {
+		return
+	}
+
+	s.retryAttempt++
+	delay := s.retryInitialDelay
+	if delay <= 0 {
+		delay = 2 * time.Second
+	}
+	for i := 1; i < s.retryAttempt; i++ {
+		delay *= 2
+	}
+	if s.retryMaxDelay > 0 && delay > s.retryMaxDelay {
+		delay = s.retryMaxDelay
+	}
+
+	generation := s.generation
+	s.stopRetryLocked()
+	s.retryTimer = time.AfterFunc(delay, func() {
+		s.retry(generation)
+	})
+}
+
+func (s *EndpointLifecycleSupervisor) stopRetryLocked() {
+	if s.retryTimer != nil {
+		s.retryTimer.Stop()
+		s.retryTimer = nil
+	}
+}
+
+func (s *EndpointLifecycleSupervisor) retry(generation uint64) {
+	s.opMu.Lock()
+	defer s.opMu.Unlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if generation != s.generation || !s.desiredEnabled || EndpointLifecycleState(s.fsm.Current()) != LifecycleFailed {
+		return
+	}
+	_ = s.eventLocked(context.Background(), LifecycleEventEnable)
+}
+
+func (s *EndpointLifecycleSupervisor) reportStarted(generation uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if generation != s.generation || EndpointLifecycleState(s.fsm.Current()) != LifecycleConnecting {
+		return
+	}
+	_ = s.eventLocked(context.Background(), LifecycleEventConnectOK)
+}
+
+func (s *EndpointLifecycleSupervisor) reportFailed(generation uint64, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if generation != s.generation {
+		return
+	}
+	s.failurePolicy = endpointLifecycleFailurePolicy(err)
+	switch EndpointLifecycleState(s.fsm.Current()) {
+	case LifecycleConnecting:
+		_ = s.eventLocked(context.Background(), LifecycleEventConnectFail)
+	case LifecycleConnected:
+		_ = s.eventLocked(context.Background(), LifecycleEventConnectionLost)
+	}
+}
+
+func (s *EndpointLifecycleSupervisor) reportClosed(generation uint64, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if generation != s.generation || !s.desiredEnabled {
+		return
+	}
+	s.failurePolicy = endpointLifecycleFailurePolicy(err)
+	switch EndpointLifecycleState(s.fsm.Current()) {
+	case LifecycleConnected:
+		_ = s.eventLocked(context.Background(), LifecycleEventConnectionLost)
+	case LifecycleConnecting:
+		_ = s.eventLocked(context.Background(), LifecycleEventConnectFail)
+	}
+}
+
+func (s *EndpointLifecycleSupervisor) updateAndSaveLocked() {
+	if s.d == nil {
+		return
+	}
+	s.d.LastUpdatedTime = time.Now().Unix()
+	s.d.Save(false)
+}
+
+type endpointLifecycleRunReporter struct {
+	supervisor *EndpointLifecycleSupervisor
+	generation uint64
+}
+
+// Generation returns the run generation owned by this reporter.
+func (r *endpointLifecycleRunReporter) Generation() uint64 {
+	return r.generation
+}
+
+// Started marks this generation as connected if it is still current.
+func (r *endpointLifecycleRunReporter) Started() {
+	r.supervisor.reportStarted(r.generation)
+}
+
+// Failed marks this generation as failed if it is still current.
+func (r *endpointLifecycleRunReporter) Failed(err error) {
+	r.supervisor.reportFailed(r.generation, err)
+}
+
+// Closed reports an unexpected close for this generation if it is still current.
+func (r *endpointLifecycleRunReporter) Closed(err error) {
+	r.supervisor.reportClosed(r.generation, err)
+}
+
+func endpointLifecycleDriver(ep *EndPointInfo) (EndpointLifecycleDriver, bool) {
+	if ep == nil || ep.Adapter == nil {
+		return nil, false
+	}
+	driver, ok := ep.Adapter.(EndpointLifecycleDriver)
+	return driver, ok
+}
+
+func endpointDice(d *Dice, ep *EndPointInfo) *Dice {
+	if d != nil {
+		return d
+	}
+	if ep != nil && ep.Session != nil {
+		return ep.Session.Parent
+	}
+	return nil
+}
+
+func ensureEndpointLifecycle(d *Dice, ep *EndPointInfo, driver EndpointLifecycleDriver) *EndpointLifecycleSupervisor {
+	if ep.lifecycle != nil {
+		ep.lifecycle.d = endpointDice(d, ep)
+		ep.lifecycle.driver = driver
+		return ep.lifecycle
+	}
+	ep.lifecycle = NewEndpointLifecycleSupervisor(endpointDice(d, ep), ep, driver)
+	return ep.lifecycle
+}
+
+// StartEndpointLifecycle enables an endpoint through the shared supervisor when
+// the adapter supports it. Legacy adapters fall back to their existing method.
+func StartEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
+	driver, ok := endpointLifecycleDriver(ep)
+	if !ok {
+		return fmt.Errorf("endpoint lifecycle driver is unavailable")
+	}
+	return ensureEndpointLifecycle(d, ep, driver).Enable(context.Background())
+}
+
+// StopEndpointLifecycle disables an endpoint through the shared supervisor when
+// available. Legacy adapters fall back to their existing method.
+func StopEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
+	driver, ok := endpointLifecycleDriver(ep)
+	if !ok {
+		return fmt.Errorf("endpoint lifecycle driver is unavailable")
+	}
+	return ensureEndpointLifecycle(d, ep, driver).Disable(context.Background())
+}
+
+// ReloginEndpointLifecycle restarts an endpoint through the shared supervisor
+// when available. Legacy adapters fall back to their existing relogin method.
+func ReloginEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
+	driver, ok := endpointLifecycleDriver(ep)
+	if !ok {
+		return fmt.Errorf("endpoint lifecycle driver is unavailable")
+	}
+	return ensureEndpointLifecycle(d, ep, driver).Relogin(context.Background())
+}

--- a/dice/endpoint_lifecycle.go
+++ b/dice/endpoint_lifecycle.go
@@ -3,7 +3,6 @@ package dice
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -71,24 +70,24 @@ const (
 	LifecycleFailureStop
 )
 
-// EndpointLifecycleFailure wraps a driver error with retry policy metadata
+// EndpointLifecycleError wraps a driver error with retry policy metadata
 // without forcing the reporter interface to grow more methods.
-type EndpointLifecycleFailure struct {
+type EndpointLifecycleError struct {
 	err    error
 	policy EndpointLifecycleFailurePolicy
 }
 
-// NewEndpointLifecycleFailure marks err with a retry policy for supervisor
+// NewEndpointLifecycleError marks err with a retry policy for supervisor
 // decisions. A nil err is normalized so callers can still express the policy.
-func NewEndpointLifecycleFailure(err error, policy EndpointLifecycleFailurePolicy) error {
+func NewEndpointLifecycleError(err error, policy EndpointLifecycleFailurePolicy) error {
 	if err == nil {
 		err = errors.New("endpoint lifecycle failure")
 	}
-	return &EndpointLifecycleFailure{err: err, policy: policy}
+	return &EndpointLifecycleError{err: err, policy: policy}
 }
 
 // Error implements error while preserving the wrapped protocol error text.
-func (e *EndpointLifecycleFailure) Error() string {
+func (e *EndpointLifecycleError) Error() string {
 	if e == nil || e.err == nil {
 		return "endpoint lifecycle failure"
 	}
@@ -96,7 +95,7 @@ func (e *EndpointLifecycleFailure) Error() string {
 }
 
 // Unwrap exposes the protocol error to errors.Is/errors.As callers.
-func (e *EndpointLifecycleFailure) Unwrap() error {
+func (e *EndpointLifecycleError) Unwrap() error {
 	if e == nil {
 		return nil
 	}
@@ -104,7 +103,7 @@ func (e *EndpointLifecycleFailure) Unwrap() error {
 }
 
 // Policy returns the supervisor retry policy carried by this error.
-func (e *EndpointLifecycleFailure) Policy() EndpointLifecycleFailurePolicy {
+func (e *EndpointLifecycleError) Policy() EndpointLifecycleFailurePolicy {
 	if e == nil {
 		return LifecycleFailureRetry
 	}
@@ -112,7 +111,7 @@ func (e *EndpointLifecycleFailure) Policy() EndpointLifecycleFailurePolicy {
 }
 
 func endpointLifecycleFailurePolicy(err error) EndpointLifecycleFailurePolicy {
-	var lifecycleFailure *EndpointLifecycleFailure
+	var lifecycleFailure *EndpointLifecycleError
 	if errors.As(err, &lifecycleFailure) {
 		return lifecycleFailure.Policy()
 	}
@@ -345,7 +344,7 @@ func (s *EndpointLifecycleSupervisor) onEnterConnecting(_ context.Context, _ *lo
 	reporter := &endpointLifecycleRunReporter{supervisor: s, generation: generation}
 	go func() {
 		if driver == nil {
-			reporter.Failed(fmt.Errorf("endpoint lifecycle driver is nil"))
+			reporter.Failed(errors.New("endpoint lifecycle driver is nil"))
 			return
 		}
 		if err := driver.LifecycleStart(runCtx, reporter); err != nil {
@@ -448,6 +447,8 @@ func (s *EndpointLifecycleSupervisor) reportFailed(generation uint64, err error)
 		_ = s.eventLocked(context.Background(), LifecycleEventConnectFail)
 	case LifecycleConnected:
 		_ = s.eventLocked(context.Background(), LifecycleEventConnectionLost)
+	case LifecycleDisconnected, LifecycleFailed:
+		return
 	}
 }
 
@@ -464,6 +465,8 @@ func (s *EndpointLifecycleSupervisor) reportClosed(generation uint64, err error)
 		_ = s.eventLocked(context.Background(), LifecycleEventConnectionLost)
 	case LifecycleConnecting:
 		_ = s.eventLocked(context.Background(), LifecycleEventConnectFail)
+	case LifecycleDisconnected, LifecycleFailed:
+		return
 	}
 }
 
@@ -533,7 +536,7 @@ func ensureEndpointLifecycle(d *Dice, ep *EndPointInfo, driver EndpointLifecycle
 func StartEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
 	driver, ok := endpointLifecycleDriver(ep)
 	if !ok {
-		return fmt.Errorf("endpoint lifecycle driver is unavailable")
+		return errors.New("endpoint lifecycle driver is unavailable")
 	}
 	return ensureEndpointLifecycle(d, ep, driver).Enable(context.Background())
 }
@@ -543,7 +546,7 @@ func StartEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
 func StopEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
 	driver, ok := endpointLifecycleDriver(ep)
 	if !ok {
-		return fmt.Errorf("endpoint lifecycle driver is unavailable")
+		return errors.New("endpoint lifecycle driver is unavailable")
 	}
 	return ensureEndpointLifecycle(d, ep, driver).Disable(context.Background())
 }
@@ -553,7 +556,7 @@ func StopEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
 func ReloginEndpointLifecycle(d *Dice, ep *EndPointInfo) error {
 	driver, ok := endpointLifecycleDriver(ep)
 	if !ok {
-		return fmt.Errorf("endpoint lifecycle driver is unavailable")
+		return errors.New("endpoint lifecycle driver is unavailable")
 	}
 	return ensureEndpointLifecycle(d, ep, driver).Relogin(context.Background())
 }

--- a/dice/endpoint_lifecycle_test.go
+++ b/dice/endpoint_lifecycle_test.go
@@ -1,3 +1,4 @@
+//nolint:testpackage
 package dice
 
 import (
@@ -96,11 +97,11 @@ func TestEndpointLifecycleConcurrentEnableStartsOnce(t *testing.T) {
 	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := supervisor.Enable(context.Background()); err != nil {
+			if err := supervisor.Enable(t.Context()); err != nil {
 				t.Errorf("Enable returned error: %v", err)
 			}
 		}()
@@ -127,12 +128,12 @@ func TestEndpointLifecycleConcurrentEnableStartsOnce(t *testing.T) {
 func TestEndpointLifecycleDisableIgnoresLateStarted(t *testing.T) {
 	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
 
-	if err := supervisor.Enable(context.Background()); err != nil {
+	if err := supervisor.Enable(t.Context()); err != nil {
 		t.Fatalf("Enable returned error: %v", err)
 	}
 	run := waitLifecycleRun(t, driver)
 
-	if err := supervisor.Disable(context.Background()); err != nil {
+	if err := supervisor.Disable(t.Context()); err != nil {
 		t.Fatalf("Disable returned error: %v", err)
 	}
 	run.run.Started()
@@ -151,13 +152,13 @@ func TestEndpointLifecycleDisableIgnoresLateStarted(t *testing.T) {
 func TestEndpointLifecycleReloginStopsOldGenerationBeforeStartingNew(t *testing.T) {
 	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
 
-	if err := supervisor.Enable(context.Background()); err != nil {
+	if err := supervisor.Enable(t.Context()); err != nil {
 		t.Fatalf("Enable returned error: %v", err)
 	}
 	first := waitLifecycleRun(t, driver)
 	first.run.Started()
 
-	if err := supervisor.Relogin(context.Background()); err != nil {
+	if err := supervisor.Relogin(t.Context()); err != nil {
 		t.Fatalf("Relogin returned error: %v", err)
 	}
 	second := waitLifecycleRun(t, driver)
@@ -186,13 +187,13 @@ func TestEndpointLifecycleReloginStopsOldGenerationBeforeStartingNew(t *testing.
 func TestEndpointLifecycleOldGenerationClosedDoesNotReconnect(t *testing.T) {
 	supervisor, _, driver := newEndpointLifecycleTestSupervisor(t)
 
-	if err := supervisor.Enable(context.Background()); err != nil {
+	if err := supervisor.Enable(t.Context()); err != nil {
 		t.Fatalf("Enable returned error: %v", err)
 	}
 	first := waitLifecycleRun(t, driver)
 	first.run.Started()
 
-	if err := supervisor.Relogin(context.Background()); err != nil {
+	if err := supervisor.Relogin(t.Context()); err != nil {
 		t.Fatalf("Relogin returned error: %v", err)
 	}
 	second := waitLifecycleRun(t, driver)
@@ -209,7 +210,7 @@ func TestEndpointLifecycleOldGenerationClosedDoesNotReconnect(t *testing.T) {
 func TestEndpointLifecycleConnectFailKeepsEnableAndRetries(t *testing.T) {
 	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
 
-	if err := supervisor.Enable(context.Background()); err != nil {
+	if err := supervisor.Enable(t.Context()); err != nil {
 		t.Fatalf("Enable returned error: %v", err)
 	}
 	first := waitLifecycleRun(t, driver)
@@ -233,11 +234,11 @@ func TestEndpointLifecyclePermanentFailureKeepsEnableWithoutRetry(t *testing.T) 
 	supervisor.retryInitialDelay = 10 * time.Millisecond
 	supervisor.retryMaxDelay = 10 * time.Millisecond
 
-	if err := supervisor.Enable(context.Background()); err != nil {
+	if err := supervisor.Enable(t.Context()); err != nil {
 		t.Fatalf("Enable returned error: %v", err)
 	}
 	first := waitLifecycleRun(t, driver)
-	first.run.Failed(NewEndpointLifecycleFailure(errors.New("bad token"), LifecycleFailureStop))
+	first.run.Failed(NewEndpointLifecycleError(errors.New("bad token"), LifecycleFailureStop))
 
 	if !ep.Enable {
 		t.Fatal("expected endpoint desired enable to stay true after permanent failure")
@@ -253,13 +254,13 @@ func TestEndpointLifecycleDisableCancelsPendingRetry(t *testing.T) {
 	supervisor.retryInitialDelay = 80 * time.Millisecond
 	supervisor.retryMaxDelay = 80 * time.Millisecond
 
-	if err := supervisor.Enable(context.Background()); err != nil {
+	if err := supervisor.Enable(t.Context()); err != nil {
 		t.Fatalf("Enable returned error: %v", err)
 	}
 	first := waitLifecycleRun(t, driver)
 	first.run.Failed(errors.New("dial failed"))
 
-	if err := supervisor.Disable(context.Background()); err != nil {
+	if err := supervisor.Disable(t.Context()); err != nil {
 		t.Fatalf("Disable returned error: %v", err)
 	}
 	assertNoLifecycleRun(t, driver, 120*time.Millisecond)

--- a/dice/endpoint_lifecycle_test.go
+++ b/dice/endpoint_lifecycle_test.go
@@ -1,0 +1,330 @@
+package dice
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+var _ EndpointLifecycleDriver = (PlatformAdapter)(nil)
+
+type endpointLifecycleTestDriver struct {
+	mu        sync.Mutex
+	startRuns []endpointLifecycleTestRun
+	stopCalls int
+	startCh   chan endpointLifecycleTestRun
+}
+
+type endpointLifecycleTestRun struct {
+	ctx context.Context
+	run EndpointRunReporter
+}
+
+func newEndpointLifecycleTestDriver() *endpointLifecycleTestDriver {
+	return &endpointLifecycleTestDriver{
+		startCh: make(chan endpointLifecycleTestRun, 16),
+	}
+}
+
+func (d *endpointLifecycleTestDriver) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	item := endpointLifecycleTestRun{ctx: ctx, run: run}
+
+	d.mu.Lock()
+	d.startRuns = append(d.startRuns, item)
+	d.mu.Unlock()
+
+	d.startCh <- item
+	return nil
+}
+
+func (d *endpointLifecycleTestDriver) LifecycleStop(context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.stopCalls++
+	return nil
+}
+
+func (d *endpointLifecycleTestDriver) startCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.startRuns)
+}
+
+func (d *endpointLifecycleTestDriver) stopCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.stopCalls
+}
+
+func newEndpointLifecycleTestSupervisor(t *testing.T) (*EndpointLifecycleSupervisor, *EndPointInfo, *endpointLifecycleTestDriver) {
+	t.Helper()
+
+	ep := &EndPointInfo{}
+	driver := newEndpointLifecycleTestDriver()
+	supervisor := NewEndpointLifecycleSupervisor(nil, ep, driver)
+	supervisor.retryInitialDelay = 10 * time.Millisecond
+	supervisor.retryMaxDelay = 10 * time.Millisecond
+
+	return supervisor, ep, driver
+}
+
+func waitLifecycleRun(t *testing.T, driver *endpointLifecycleTestDriver) endpointLifecycleTestRun {
+	t.Helper()
+
+	select {
+	case run := <-driver.startCh:
+		return run
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle start")
+		return endpointLifecycleTestRun{}
+	}
+}
+
+func assertNoLifecycleRun(t *testing.T, driver *endpointLifecycleTestDriver, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case run := <-driver.startCh:
+		t.Fatalf("unexpected lifecycle start for generation %d", run.run.Generation())
+	case <-time.After(timeout):
+	}
+}
+
+func TestEndpointLifecycleConcurrentEnableStartsOnce(t *testing.T) {
+	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := supervisor.Enable(context.Background()); err != nil {
+				t.Errorf("Enable returned error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	run := waitLifecycleRun(t, driver)
+	if run.run.Generation() == 0 {
+		t.Fatal("expected non-zero generation")
+	}
+	assertNoLifecycleRun(t, driver, 50*time.Millisecond)
+
+	if got := driver.startCount(); got != 1 {
+		t.Fatalf("expected one LifecycleStart call, got %d", got)
+	}
+	if !ep.Enable {
+		t.Fatal("expected endpoint desired enable to remain true")
+	}
+	if ep.State != StateConnecting {
+		t.Fatalf("expected endpoint state %v, got %v", StateConnecting, ep.State)
+	}
+}
+
+func TestEndpointLifecycleDisableIgnoresLateStarted(t *testing.T) {
+	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
+
+	if err := supervisor.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	run := waitLifecycleRun(t, driver)
+
+	if err := supervisor.Disable(context.Background()); err != nil {
+		t.Fatalf("Disable returned error: %v", err)
+	}
+	run.run.Started()
+
+	if got := driver.stopCount(); got != 1 {
+		t.Fatalf("expected one LifecycleStop call, got %d", got)
+	}
+	if ep.Enable {
+		t.Fatal("expected endpoint desired enable to be false")
+	}
+	if ep.State != StateDisconnected {
+		t.Fatalf("expected endpoint state %v, got %v", StateDisconnected, ep.State)
+	}
+}
+
+func TestEndpointLifecycleReloginStopsOldGenerationBeforeStartingNew(t *testing.T) {
+	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
+
+	if err := supervisor.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	first := waitLifecycleRun(t, driver)
+	first.run.Started()
+
+	if err := supervisor.Relogin(context.Background()); err != nil {
+		t.Fatalf("Relogin returned error: %v", err)
+	}
+	second := waitLifecycleRun(t, driver)
+
+	if second.run.Generation() <= first.run.Generation() {
+		t.Fatalf("expected second generation to be newer than first: first=%d second=%d", first.run.Generation(), second.run.Generation())
+	}
+	if got := driver.stopCount(); got != 1 {
+		t.Fatalf("expected relogin to stop the old generation once, got %d stops", got)
+	}
+
+	first.run.Closed(errors.New("old generation closed"))
+	second.run.Started()
+
+	if got := driver.startCount(); got != 2 {
+		t.Fatalf("expected exactly two starts, got %d", got)
+	}
+	if !ep.Enable {
+		t.Fatal("expected endpoint desired enable to remain true")
+	}
+	if ep.State != StateConnected {
+		t.Fatalf("expected endpoint state %v, got %v", StateConnected, ep.State)
+	}
+}
+
+func TestEndpointLifecycleOldGenerationClosedDoesNotReconnect(t *testing.T) {
+	supervisor, _, driver := newEndpointLifecycleTestSupervisor(t)
+
+	if err := supervisor.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	first := waitLifecycleRun(t, driver)
+	first.run.Started()
+
+	if err := supervisor.Relogin(context.Background()); err != nil {
+		t.Fatalf("Relogin returned error: %v", err)
+	}
+	second := waitLifecycleRun(t, driver)
+
+	first.run.Closed(errors.New("old generation closed"))
+	assertNoLifecycleRun(t, driver, 50*time.Millisecond)
+
+	second.run.Started()
+	if got := driver.startCount(); got != 2 {
+		t.Fatalf("expected old generation close to be ignored, got %d starts", got)
+	}
+}
+
+func TestEndpointLifecycleConnectFailKeepsEnableAndRetries(t *testing.T) {
+	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
+
+	if err := supervisor.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	first := waitLifecycleRun(t, driver)
+	first.run.Failed(errors.New("dial failed"))
+
+	if !ep.Enable {
+		t.Fatal("expected endpoint desired enable to stay true after connect failure")
+	}
+	if ep.State != StateConnectionFailed {
+		t.Fatalf("expected endpoint state %v, got %v", StateConnectionFailed, ep.State)
+	}
+
+	second := waitLifecycleRun(t, driver)
+	if second.run.Generation() <= first.run.Generation() {
+		t.Fatalf("expected retry generation to be newer than failed generation")
+	}
+}
+
+func TestEndpointLifecyclePermanentFailureKeepsEnableWithoutRetry(t *testing.T) {
+	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
+	supervisor.retryInitialDelay = 10 * time.Millisecond
+	supervisor.retryMaxDelay = 10 * time.Millisecond
+
+	if err := supervisor.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	first := waitLifecycleRun(t, driver)
+	first.run.Failed(NewEndpointLifecycleFailure(errors.New("bad token"), LifecycleFailureStop))
+
+	if !ep.Enable {
+		t.Fatal("expected endpoint desired enable to stay true after permanent failure")
+	}
+	if ep.State != StateConnectionFailed {
+		t.Fatalf("expected endpoint state %v, got %v", StateConnectionFailed, ep.State)
+	}
+	assertNoLifecycleRun(t, driver, 50*time.Millisecond)
+}
+
+func TestEndpointLifecycleDisableCancelsPendingRetry(t *testing.T) {
+	supervisor, ep, driver := newEndpointLifecycleTestSupervisor(t)
+	supervisor.retryInitialDelay = 80 * time.Millisecond
+	supervisor.retryMaxDelay = 80 * time.Millisecond
+
+	if err := supervisor.Enable(context.Background()); err != nil {
+		t.Fatalf("Enable returned error: %v", err)
+	}
+	first := waitLifecycleRun(t, driver)
+	first.run.Failed(errors.New("dial failed"))
+
+	if err := supervisor.Disable(context.Background()); err != nil {
+		t.Fatalf("Disable returned error: %v", err)
+	}
+	assertNoLifecycleRun(t, driver, 120*time.Millisecond)
+
+	if ep.Enable {
+		t.Fatal("expected endpoint desired enable to be false after disable")
+	}
+	if ep.State != StateDisconnected {
+		t.Fatalf("expected endpoint state %v, got %v", StateDisconnected, ep.State)
+	}
+}
+
+func TestEndpointLifecycleHelpersRejectMissingDriver(t *testing.T) {
+	ep := &EndPointInfo{}
+
+	if err := StartEndpointLifecycle(nil, ep); err == nil {
+		t.Fatal("expected StartEndpointLifecycle to reject endpoint without adapter")
+	}
+	if err := StopEndpointLifecycle(nil, ep); err == nil {
+		t.Fatal("expected StopEndpointLifecycle to reject endpoint without adapter")
+	}
+	if err := ReloginEndpointLifecycle(nil, ep); err == nil {
+		t.Fatal("expected ReloginEndpointLifecycle to reject endpoint without adapter")
+	}
+}
+
+func TestEndpointStateFromLifecycleCoversLifecycleStates(t *testing.T) {
+	tests := []struct {
+		state EndpointLifecycleState
+		want  EndpointState
+	}{
+		{LifecycleDisconnected, StateDisconnected},
+		{LifecycleConnecting, StateConnecting},
+		{LifecycleConnected, StateConnected},
+		{LifecycleFailed, StateConnectionFailed},
+	}
+
+	for _, tt := range tests {
+		if got := EndpointStateFromLifecycle(tt.state); got != tt.want {
+			t.Fatalf("EndpointStateFromLifecycle(%q) = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}
+
+func TestAllAdaptersImplementEndpointLifecycleDriver(t *testing.T) {
+	drivers := []EndpointLifecycleDriver{
+		&PlatformAdapterGocq{},
+		&PlatformAdapterDiscord{},
+		&PlatformAdapterDingTalk{},
+		&PlatformAdapterDodo{},
+		&PlatformAdapterHTTP{},
+		&PlatformAdapterKook{},
+		&PlatformAdapterMilky{},
+		&PlatformAdapterMinecraft{},
+		&PlatformAdapterOfficialQQ{},
+		&PlatformAdapterOnebot{},
+		&PlatformAdapterRed{},
+		&PlatformAdapterSatori{},
+		&PlatformAdapterSealChat{},
+		&PlatformAdapterSlack{},
+		&PlatformAdapterTelegram{},
+		&PlatformAdapterWalleQ{},
+	}
+
+	if len(drivers) != 16 {
+		t.Fatalf("expected all adapters to be lifecycle drivers")
+	}
+}

--- a/dice/execute_new_test.go
+++ b/dice/execute_new_test.go
@@ -91,6 +91,11 @@ func (m *mockPlatformAdapter) SendToPerson(_ *MsgContext, _ string, text string,
 func (m *mockPlatformAdapter) Serve() int       { return 0 }
 func (m *mockPlatformAdapter) DoRelogin() bool  { return true }
 func (m *mockPlatformAdapter) SetEnable(_ bool) {}
+func (m *mockPlatformAdapter) LifecycleStart(_ context.Context, run EndpointRunReporter) error {
+	run.Started()
+	return nil
+}
+func (m *mockPlatformAdapter) LifecycleStop(context.Context) error { return nil }
 func (m *mockPlatformAdapter) QuitGroup(_ *MsgContext, groupID string) {
 	m.mu.Lock()
 	m.quitGroups = append(m.quitGroups, groupID)

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1663,7 +1663,7 @@ func (s *IMSession) OnGroupJoined(ctx *MsgContext, msg *Message) {
 	}
 }
 
-var lastWelcome *LastWelcomeInfo
+var lastGroupMemberWelcome *LastWelcomeInfo
 
 // OnGroupMemberJoined 群成员进群事件处理，除了 bot 自己以外的群成员入群时调用。其他 Adapter 应当尽快迁移至此方法实现
 func (s *IMSession) OnGroupMemberJoined(ctx *MsgContext, msg *Message) {
@@ -1673,44 +1673,61 @@ func (s *IMSession) OnGroupMemberJoined(ctx *MsgContext, msg *Message) {
 	// 进群的是别人，是否迎新？
 	// 这里很诡异，当手机QQ客户端审批进群时，入群后会有一句默认发言
 	// 此时会收到两次完全一样的某用户入群信息，导致发两次欢迎词
-	if ok && groupInfo.ShowGroupWelcome {
-		isDouble := false
-		if lastWelcome != nil {
-			isDouble = msg.GroupID == lastWelcome.GroupID &&
-				msg.Sender.UserID == lastWelcome.UserID &&
-				msg.Time == lastWelcome.Time
-		}
-		lastWelcome = &LastWelcomeInfo{
-			GroupID: msg.GroupID,
-			UserID:  msg.Sender.UserID,
-			Time:    msg.Time,
-		}
+	needWelcome := false
+	reason := "group_not_loaded"
+	if ok {
+		if groupInfo.ShowGroupWelcome {
+			isDouble := false
+			if lastGroupMemberWelcome != nil {
+				isDouble = msg.GroupID == lastGroupMemberWelcome.GroupID &&
+					msg.Sender.UserID == lastGroupMemberWelcome.UserID &&
+					msg.Time == lastGroupMemberWelcome.Time
+			}
+			lastGroupMemberWelcome = &LastWelcomeInfo{
+				GroupID: msg.GroupID,
+				UserID:  msg.Sender.UserID,
+				Time:    msg.Time,
+			}
 
-		if !isDouble {
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("迎新致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
-					}
-				}()
-
-				// Ensure context has group set for formatting and attrs access
-				ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
-				// VarSetValueStr(ctx, "$t新人昵称", "<"+msgQQ.Sender.Nickname+">")
-				uidRaw := UserIDExtract(msg.Sender.UserID)
-				VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
-				VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
-				stdID := msg.Sender.UserID
-				VarSetValueStr(ctx, "$t帐号ID", stdID)
-				VarSetValueStr(ctx, "$t账号ID", stdID)
-				text := DiceFormat(ctx, groupInfo.GroupWelcomeMessage)
-				for _, i := range ctx.SplitText(text) {
-					doSleepQQ(ctx)
-					ReplyGroup(ctx, msg, strings.TrimSpace(i))
-				}
-			}()
+			if isDouble {
+				reason = "duplicate_event"
+			} else {
+				needWelcome = true
+				reason = "welcome_enabled"
+			}
+		} else {
+			reason = "welcome_disabled"
 		}
 	}
+	log.Infof("检查是否需要迎新: need_welcome=%t reason=%s group_id=%s user_id=%s", needWelcome, reason, msg.GroupID, msg.Sender.UserID)
+
+	if !needWelcome {
+		return
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("迎新致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
+			}
+		}()
+
+		// Ensure context has group set for formatting and attrs access
+		ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
+		// VarSetValueStr(ctx, "$t新人昵称", "<"+msgQQ.Sender.Nickname+">")
+		uidRaw := UserIDExtract(msg.Sender.UserID)
+		VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
+		VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
+		stdID := msg.Sender.UserID
+		VarSetValueStr(ctx, "$t帐号ID", stdID)
+		VarSetValueStr(ctx, "$t账号ID", stdID)
+		text := DiceFormat(ctx, groupInfo.GroupWelcomeMessage)
+		log.Infof("发送迎新消息: group_id=%s user_id=%s text=%q", msg.GroupID, msg.Sender.UserID, text)
+		for _, i := range ctx.SplitText(text) {
+			doSleepQQ(ctx)
+			ReplyGroup(ctx, msg, strings.TrimSpace(i))
+		}
+	}()
 }
 
 var platformRE = regexp.MustCompile(`^(.*)-Group:`)

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -441,6 +441,9 @@ type EndPointInfo struct {
 	EndPointInfoBase `jsbind:"baseInfo" yaml:"baseInfo"`
 
 	Adapter PlatformAdapter `json:"adapter" yaml:"adapter"`
+	// lifecycle is runtime-only. It centralizes adapter start/stop/retry state
+	// for adapters that opt in via EndpointLifecycleDriver.
+	lifecycle *EndpointLifecycleSupervisor `json:"-" yaml:"-"`
 }
 
 func (ep *EndPointInfo) UnmarshalYAML(value *yaml.Node) error {
@@ -2376,8 +2379,10 @@ func (s *IMSession) GetEpByPlatform(p string) *EndPointInfo {
 // SetEnable
 /* 如果已连接，将断开连接，如果开着GCQ将自动结束。如果启用的话，则反过来  */
 func (ep *EndPointInfo) SetEnable(_ *Dice, enable bool) {
-	if ep.Enable != enable {
-		ep.Adapter.SetEnable(enable)
+	if enable {
+		_ = StartEndpointLifecycle(nil, ep)
+	} else {
+		_ = StopEndpointLifecycle(nil, ep)
 	}
 }
 
@@ -2417,7 +2422,6 @@ func (ep *EndPointInfo) BindRuntime(session *IMSession) {
 			log := zap.S().Named(logger.LogKeyAdapter)
 			pa.EndPoint = ep
 			pa.logger = log
-			pa.desiredEnabled = ep.Enable
 			// case "LagrangeGo":
 			//	pa := ep.Adapter.(*PlatformAdapterLagrangeGo)
 			//	pa.EndPoint = ep

--- a/dice/platform_adapter.go
+++ b/dice/platform_adapter.go
@@ -3,6 +3,8 @@ package dice
 import "sealdice-core/message"
 
 type PlatformAdapter interface {
+	EndpointLifecycleDriver
+
 	Serve() int
 	DoRelogin() bool
 	SetEnable(enable bool)

--- a/dice/platform_adapter_dingtalk.go
+++ b/dice/platform_adapter_dingtalk.go
@@ -1,6 +1,8 @@
 package dice
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -24,41 +26,45 @@ type PlatformAdapterDingTalk struct {
 }
 
 func (pa *PlatformAdapterDingTalk) DoRelogin() bool {
-	if err := pa.closeSessionLocked(); err != nil {
-		pa.EndPoint.Session.Parent.Logger.Error("Dingtalk 断开连接失败: ", err)
-		return false
-	}
-	pa.EndPoint.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
-	if err := pa.openSessionLocked(); err != nil {
-		pa.EndPoint.Session.Parent.Logger.Errorf("与DingTalk服务进行连接时出错:%s", err.Error())
-		pa.EndPoint.State = 3
-		pa.EndPoint.Enable = false
-		return false
-	}
-	pa.EndPoint.State = 1
-	pa.EndPoint.Enable = true
-	return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterDingTalk) SetEnable(enable bool) {
 	if enable {
-		pa.EndPoint.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
-		if err := pa.openSessionLocked(); err != nil {
-			pa.EndPoint.Session.Parent.Logger.Errorf("与DingTalk服务进行连接时出错:%s", err.Error())
-			pa.EndPoint.State = 3
-			pa.EndPoint.Enable = false
-			return
-		}
-		pa.EndPoint.State = 1
-		pa.EndPoint.Enable = true
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		if err := pa.closeSessionLocked(); err != nil {
-			pa.EndPoint.Session.Parent.Logger.Error("Dingtalk 断开连接失败: ", err)
-			return
-		}
-		pa.EndPoint.State = 0
-		pa.EndPoint.Enable = false
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
 	}
+}
+
+// LifecycleStart opens one DingTalk stream session for the supervisor
+// generation. Reconnect policy is intentionally owned by EndpointLifecycleSupervisor.
+func (pa *PlatformAdapterDingTalk) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("dingtalk endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用DingTalk服务……")
+	if pa.Serve() != 0 {
+		return errors.New("dingtalk serve failed")
+	}
+	run.Started()
+	return nil
+}
+
+// LifecycleStop closes the current DingTalk stream session and leaves endpoint
+// state persistence to the shared lifecycle supervisor.
+func (pa *PlatformAdapterDingTalk) LifecycleStop(context.Context) error {
+	if pa.EndPoint != nil && pa.EndPoint.Session != nil {
+		pa.EndPoint.Session.Parent.Logger.Infof("正在禁用DingTalk服务……")
+	}
+	return pa.closeSessionLocked()
 }
 
 func (pa *PlatformAdapterDingTalk) QuitGroup(ctx *MsgContext, id string) {
@@ -262,7 +268,7 @@ func (pa *PlatformAdapterDingTalk) Serve() int {
 	pa.sessionOpened = true
 
 	logger.Info("Dingtalk 连接成功")
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 	pa.EndPoint.Enable = true
 	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()

--- a/dice/platform_adapter_dingtalk.go
+++ b/dice/platform_adapter_dingtalk.go
@@ -41,7 +41,7 @@ func (pa *PlatformAdapterDingTalk) SetEnable(enable bool) {
 // generation. Reconnect policy is intentionally owned by EndpointLifecycleSupervisor.
 func (pa *PlatformAdapterDingTalk) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("dingtalk endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("dingtalk endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {
@@ -310,26 +310,4 @@ func (pa *PlatformAdapterDingTalk) closeSessionLocked() error {
 		return nil
 	}
 	return session.Close()
-}
-
-func (pa *PlatformAdapterDingTalk) openSessionLocked() error {
-	pa.sessionMu.Lock()
-	defer pa.sessionMu.Unlock()
-	if pa.IntentSession == nil {
-		pa.IntentSession = dingtalk.New(pa.ClientID, pa.Token)
-		pa.IntentSession.AddEventHandler(pa.OnChatReceive)
-		pa.IntentSession.AddEventHandler(pa.OnGroupJoined)
-	}
-	if pa.sessionOpened {
-		return nil
-	}
-	session := pa.IntentSession
-
-	if err := session.Open(); err != nil {
-		pa.sessionOpened = false
-		return err
-	}
-
-	pa.sessionOpened = true
-	return nil
 }

--- a/dice/platform_adapter_dingtalk_helper.go
+++ b/dice/platform_adapter_dingtalk_helper.go
@@ -1,10 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 func NewDingTalkConnItem(clientID string, token string, nickname string, robotCode string) *EndPointInfo {
 	conn := new(EndPointInfo)
@@ -26,15 +22,8 @@ func NewDingTalkConnItem(clientID string, token string, nickname string, robotCo
 func ServeDingTalk(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "DINGTALK" {
-		conn := ep.Adapter.(*PlatformAdapterDingTalk)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Dingtalk 尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Errorf("连接Dingtalk 失败")
-			ep.State = 3
-			ep.Enable = false
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -253,7 +254,7 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 	_ = pa.IntentSession.UpdateGameStatus(0, "SealDice")
 	pa.EndPoint.UserID = FormatDiceIDDiscord(pa.IntentSession.State.User.ID)
 	pa.EndPoint.Nickname = pa.IntentSession.State.User.Username
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 	pa.EndPoint.Enable = true
 	pa.EndPoint.Session.Parent.Logger.Infof("Discord 服务连接成功，账号<%s>(%s)", pa.IntentSession.State.User.Username, FormatDiceIDDiscord(pa.IntentSession.State.User.ID))
 
@@ -265,55 +266,49 @@ func (pa *PlatformAdapterDiscord) Serve() int {
 
 // DoRelogin 重新登录，虽然似乎没什么实现的必要，但还是写一下
 func (pa *PlatformAdapterDiscord) DoRelogin() bool {
-	if pa.IntentSession == nil {
-		success := pa.Serve()
-		return success == 0
-	}
-	_ = pa.IntentSession.Close()
-	err := pa.IntentSession.Open()
-	if err != nil {
-		pa.EndPoint.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
-		pa.EndPoint.State = 0
-		return false
-	}
-	_ = pa.IntentSession.UpdateGameStatus(0, "SealDice")
-	pa.EndPoint.State = 1
-	pa.EndPoint.Enable = true
-	d := pa.EndPoint.Session.Parent
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-	return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 // SetEnable 禁用之后骰子仍然有可能显示在线一段时间，可能是因为没有挥手机制，不过已经不会接收到事件了
 func (pa *PlatformAdapterDiscord) SetEnable(enable bool) {
 	if enable {
-		pa.EndPoint.Session.Parent.Logger.Infof("正在启用Discord服务……")
-		if pa.IntentSession == nil {
-			pa.Serve()
-			return
-		}
-		err := pa.IntentSession.Open()
-		if err != nil {
-			pa.EndPoint.Session.Parent.Logger.Errorf("与Discord服务进行连接时出错:%s", err.Error())
-			pa.EndPoint.State = 3
-			pa.EndPoint.Enable = false
-			return
-		}
-		_ = pa.IntentSession.UpdateGameStatus(0, "SealDice")
-		pa.EndPoint.Session.Parent.Logger.Infof("Discord 服务连接成功，账号<%s>(%s)", pa.IntentSession.State.User.Username, FormatDiceIDDiscord(pa.IntentSession.State.User.ID))
-		pa.EndPoint.State = 1
-		pa.EndPoint.Enable = true
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		pa.EndPoint.State = 0
-		pa.EndPoint.Enable = false
-		if pa.IntentSession != nil {
-			_ = pa.IntentSession.Close()
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
+	}
+}
+
+// LifecycleStart creates one Discord session for the current supervisor
+// generation. Any later reconnect is scheduled by the shared lifecycle FSM.
+func (pa *PlatformAdapterDiscord) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("discord endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
 	}
-	d := pa.EndPoint.Session.Parent
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
+	_ = pa.LifecycleStop(ctx)
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Discord服务……")
+	if pa.Serve() != 0 {
+		return errors.New("discord serve failed")
+	}
+	run.Started()
+	return nil
+}
+
+// LifecycleStop closes Discord resources for the current generation. The
+// supervisor owns endpoint state updates after this method returns.
+func (pa *PlatformAdapterDiscord) LifecycleStop(context.Context) error {
+	if pa.IntentSession == nil {
+		return nil
+	}
+	err := pa.IntentSession.Close()
+	pa.IntentSession = nil
+	return err
 }
 
 func (pa *PlatformAdapterDiscord) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -282,7 +282,7 @@ func (pa *PlatformAdapterDiscord) SetEnable(enable bool) {
 // generation. Any later reconnect is scheduled by the shared lifecycle FSM.
 func (pa *PlatformAdapterDiscord) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("discord endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("discord endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {

--- a/dice/platform_adapter_discord_helper.go
+++ b/dice/platform_adapter_discord_helper.go
@@ -1,8 +1,6 @@
 package dice
 
 import (
-	"time"
-
 	"github.com/bwmarrin/discordgo"
 	"github.com/google/uuid"
 )
@@ -36,16 +34,9 @@ func NewDiscordConnItem(v AddDiscordEcho) *EndPointInfo {
 func ServeDiscord(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "DISCORD" {
-		conn := ep.Adapter.(*PlatformAdapterDiscord)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("DiscordGo 尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Errorf("连接Discord服务失败")
-			ep.State = 3
-			ep.Enable = false
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }
 

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -310,7 +310,7 @@ func (pa *PlatformAdapterDodo) SetEnable(enable bool) {
 // generation. The adapter no longer performs its own retry loop.
 func (pa *PlatformAdapterDodo) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("dodo endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("dodo endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	_ = pa.LifecycleStop(ctx)
 	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Dodo……")

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -57,9 +58,21 @@ func (pa *PlatformAdapterDodo) GetGroupInfoAsync(groupID string) {
 }
 
 func (pa *PlatformAdapterDodo) Serve() int {
+	return pa.serveWithLifecycle(context.Background(), nil)
+}
+
+func (pa *PlatformAdapterDodo) serveWithLifecycle(ctx context.Context, run EndpointRunReporter) int {
 	logger := pa.EndPoint.Session.Parent.Logger
 	clientID := pa.ClientID
 	token := pa.Token
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return 1
+		default:
+		}
+	}
+
 	instance, err := client.New(clientID, token, client.WithTimeout(time.Second*3))
 	pa.Client = instance
 	if err != nil {
@@ -101,51 +114,50 @@ func (pa *PlatformAdapterDodo) Serve() int {
 	msgHandlers.ChannelMessage = channelMessageHandler
 	msgHandlers.PersonalMessage = personalMessageHandler
 
-	ws, _ := websocket.New(instance, websocket.WithMessageHandlers(msgHandlers))
+	ws, err := websocket.New(instance, websocket.WithMessageHandlers(msgHandlers))
+	if err != nil {
+		logger.Errorf("Dodo WebSocket 初始化错误:%s", err.Error())
+		pa.EndPoint.State = StateConnectionFailed
+		d := pa.EndPoint.Session.Parent
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return 1
+	}
 	// 主动连接到 WebSocket 服务器
 	if err = ws.Connect(); err != nil {
 		logger.Errorf("Dodo连接错误:%s", err.Error())
-		for pa.RetryConnectTimes <= 5 {
-			pa.RetryConnectTimes++
-			time.Sleep(time.Second * 5)
-			pa.EndPoint.Session.Parent.Logger.Infof("Dodo 尝试重连, 第 [%d/5] 次", pa.RetryConnectTimes)
-			ws.Close()
-			if err = ws.Connect(); err == nil {
-				pa.RetryConnectTimes = 0
-				pa.EndPoint.State = 1
-				break
-			} else {
-				logger.Errorf("Dodo连接错误:%s", err.Error())
-			}
-		}
-		if err != nil {
-			logger.Errorf("Dodo 短时间内重试次数过多，先行中断")
-			pa.EndPoint.State = 3
-			d := pa.EndPoint.Session.Parent
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-			return 1
-		}
+		pa.EndPoint.State = StateConnectionFailed
+		d := pa.EndPoint.Session.Parent
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return 1
 	}
 	pa.WebSocket = ws
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 	pa.RetryConnectTimes = 0
 	pa.EndPoint.Session.Parent.Logger.Infof("Dodo 连接成功")
 	pa.EndPoint.Enable = true
 	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
+	if run != nil {
+		run.Started()
+	}
 	go func() {
 		err := ws.Listen()
 		if err != nil {
 			logger.Errorf("Dodo监听错误:%s", err.Error())
+			if ctx != nil && ctx.Err() != nil {
+				return
+			}
 			if pa.EndPoint.Enable {
-				pa.EndPoint.State = 3
+				pa.EndPoint.State = StateConnectionFailed
 				d := pa.EndPoint.Session.Parent
 				d.LastUpdatedTime = time.Now().Unix()
 				d.Save(false)
-				logger.Infof("Dodo 连接断开，正在尝试重连……")
-				pa.DoRelogin()
+				if run != nil {
+					run.Closed(err)
+				}
 			}
 		}
 	}()
@@ -283,44 +295,40 @@ func (pa *PlatformAdapterDodo) refreshPermCache(guildID string, userID string) (
 }
 
 func (pa *PlatformAdapterDodo) DoRelogin() bool {
-	defer func() {
-		_ = recover()
-	}()
-	logger := pa.EndPoint.Session.Parent.Logger
-	if pa.WebSocket != nil {
-		pa.WebSocket.Close()
-		pa.Client = nil
-		pa.WebSocket = nil
-		pa.EndPoint.State = 0
-		pa.EndPoint.Enable = false
-	}
-	logger.Infof("正在启用Dodo……")
-	pa.Serve()
-	return false
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterDodo) SetEnable(enable bool) {
-	defer func() {
-		_ = recover()
-	}()
-	logger := pa.EndPoint.Session.Parent.Logger
 	if enable {
-		if pa.Client != nil && pa.WebSocket != nil {
-			pa.WebSocket.Close()
-			pa.Client = nil
-			pa.WebSocket = nil
-			pa.EndPoint.State = 0
-			pa.EndPoint.Enable = false
-		}
-		logger.Infof("正在启用Dodo……")
-		pa.Serve()
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		pa.WebSocket.Close()
-		pa.Client = nil
-		pa.WebSocket = nil
-		pa.EndPoint.State = 0
-		pa.EndPoint.Enable = false
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
 	}
+}
+
+// LifecycleStart opens one Dodo websocket connection for the supervisor
+// generation. The adapter no longer performs its own retry loop.
+func (pa *PlatformAdapterDodo) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("dodo endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	_ = pa.LifecycleStop(ctx)
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Dodo……")
+	if pa.serveWithLifecycle(ctx, run) != 0 {
+		return errors.New("dodo serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop closes the current Dodo websocket. State transitions are
+// written by EndpointLifecycleSupervisor.
+func (pa *PlatformAdapterDodo) LifecycleStop(context.Context) error {
+	if pa.WebSocket != nil {
+		pa.WebSocket.Close()
+	}
+	pa.Client = nil
+	pa.WebSocket = nil
+	return nil
 }
 
 func (pa *PlatformAdapterDodo) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {

--- a/dice/platform_adapter_dodo_helper.go
+++ b/dice/platform_adapter_dodo_helper.go
@@ -1,10 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 func NewDodoConnItem(clientID string, token string) *EndPointInfo {
 	conn := new(EndPointInfo)
@@ -25,15 +21,8 @@ func NewDodoConnItem(clientID string, token string) *EndPointInfo {
 func ServeDodo(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "DODO" {
-		conn := ep.Adapter.(*PlatformAdapterDodo)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Dodo 尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Errorf("连接Dodo失败")
-			ep.State = 3
-			ep.Enable = false
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1239,7 +1239,7 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 // start their external process here; websocket callbacks report Started/Closed.
 func (pa *PlatformAdapterGocq) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("gocq endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("gocq endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -103,6 +105,42 @@ type PlatformAdapterGocq struct {
 	lagrangeRebootTimes  int
 	SignServerVer        string `json:"signServerVer"  yaml:"signServerVer"`  // 用于前端显示
 	SignServerName       string `json:"signServerName" yaml:"signServerName"` // 用于前端显示
+
+	lifecycleMu  sync.Mutex          `json:"-" yaml:"-"`
+	lifecycleRun EndpointRunReporter `json:"-" yaml:"-"`
+}
+
+func (pa *PlatformAdapterGocq) setLifecycleRun(run EndpointRunReporter) {
+	pa.lifecycleMu.Lock()
+	defer pa.lifecycleMu.Unlock()
+	pa.lifecycleRun = run
+}
+
+func (pa *PlatformAdapterGocq) reportLifecycleStarted() {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Started()
+	}
+}
+
+func (pa *PlatformAdapterGocq) reportLifecycleFailed(err error) {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Failed(err)
+	}
+}
+
+func (pa *PlatformAdapterGocq) reportLifecycleClosed(err error) {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Closed(err)
+	}
 }
 
 type Sender struct {
@@ -438,10 +476,10 @@ func (pa *PlatformAdapterGocq) Serve() int {
 	}
 	pa.Socket = &socket
 
-	ep.State = 2
+	ep.State = StateConnecting
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		defer ErrorLogAndContinue(pa.EndPoint.Session.Parent)
-		ep.State = 1
+		ep.State = StateConnected
 		if pa.IsReverse {
 			log.Info("onebot v11 反向ws连接成功")
 		} else {
@@ -451,6 +489,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		pa.lagrangeRebootTimes = 0
 		//  {"data":{"nickname":"闃斧鐗岃�佽檸鏈�","user_id":1001},"retcode":0,"status":"ok"}
 		pa.GetLoginInfo()
+		pa.reportLifecycleStarted()
 	}
 
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
@@ -460,6 +499,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		log.Error("onebot v11 connection error: ", err)
 		log.Info("onebot wss connection addr: ", socket.Url)
 		// }
+		pa.reportLifecycleFailed(err)
 		pa.InPackGoCqhttpDisconnectedCH <- 2
 	}
 
@@ -1105,6 +1145,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 		log.Info("onebot 服务的连接被对方关闭")
 		_ = pa.EndPoint.Session.Parent.SendMail("", MailTypeConnectClose, NoticeTypeSystem)
+		pa.reportLifecycleClosed(err)
 		pa.InPackGoCqhttpDisconnectedCH <- 1
 	}
 
@@ -1136,7 +1177,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				// 注: 只能管一个socket，不过不管了
 				pa.Socket = &socketClone
 
-				pa.EndPoint.State = 1
+				pa.EndPoint.State = StateConnected
 				socketClone.NewClient(ws)
 				return nil
 			})
@@ -1183,115 +1224,88 @@ func (pa *PlatformAdapterGocq) Serve() int {
 }
 
 func (pa *PlatformAdapterGocq) DoRelogin() bool {
-	myDice := pa.EndPoint.Session.Parent
-	ep := pa.EndPoint
-	if pa.Socket != nil {
-		go func() {
-			defer func() {
-				_ = recover()
-			}()
-			pa.Socket.Close()
-			pa.diceServing = false
-		}()
-	}
-
-	if pa.IsReverse {
-		if pa.reverseApp != nil {
-			_ = pa.reverseApp.Close()
-			pa.reverseApp = nil
-		}
-
-		go pa.Serve()
-		return true
-	}
-
-	if pa.UseInPackClient {
-		if pa.InPackGoCqhttpDisconnectedCH != nil {
-			pa.InPackGoCqhttpDisconnectedCH <- -1
-		}
-		if pa.BuiltinMode == "lagrange" {
-			myDice.Logger.Infof("重新启动 lagrange 进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
-			pa.CurLoginIndex++
-			pa.GoCqhttpState = StateCodeInit
-			ep.Enable = false // 拉格朗进程杀死前应先禁用账号，否则拉格朗会自动重启（该行为在LagrangeServe中）
-			go BuiltinQQServeProcessKill(myDice, ep)
-			time.Sleep(10 * time.Second)           // 上面那个清理有概率卡住，具体不懂，改成等5s -> 10s 超过一次重试间隔
-			LagrangeServeRemoveSession(myDice, ep) // 删除 keystore
-			pa.GoCqhttpLastRestrictedTime = 0      // 重置风控时间
-			ep.Enable = true
-			myDice.LastUpdatedTime = time.Now().Unix()
-			myDice.Save(false)
-			LagrangeServe(myDice, ep, LagrangeLoginInfo{
-				IsAsyncRun: true,
-			})
-			return true
-		} else {
-			myDice.Logger.Infof("重新启动go-cqhttp进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
-			pa.CurLoginIndex++
-			pa.GoCqhttpState = StateCodeInit
-			go BuiltinQQServeProcessKill(myDice, ep)
-			time.Sleep(10 * time.Second)                // 上面那个清理有概率卡住，具体不懂，改成等5s -> 10s 超过一次重试间隔
-			GoCqhttpServeRemoveSessionToken(myDice, ep) // 删除session.token
-			pa.GoCqhttpLastRestrictedTime = 0           // 重置风控时间
-			myDice.LastUpdatedTime = time.Now().Unix()
-			myDice.Save(false)
-			GoCqhttpServe(myDice, ep, GoCqhttpLoginInfo{
-				Password:         pa.InPackGoCqhttpPassword,
-				Protocol:         pa.InPackGoCqhttpProtocol,
-				AppVersion:       pa.InPackGoCqhttpAppVersion,
-				IsAsyncRun:       true,
-				UseSignServer:    pa.UseSignServer,
-				SignServerConfig: pa.SignServerConfig,
-			})
-			return true
-		}
-	}
-	return false
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
-	d := pa.EndPoint.Session.Parent
-	c := pa.EndPoint
 	if enable {
-		c.Enable = true
-
-		if pa.UseInPackClient {
-			if pa.BuiltinMode == "lagrange" {
-				BuiltinQQServeProcessKill(d, c)
-				time.Sleep(1 * time.Second)
-				LagrangeServe(d, c, LagrangeLoginInfo{
-					IsAsyncRun: true,
-				})
-			} else {
-				BuiltinQQServeProcessKill(d, c)
-				time.Sleep(1 * time.Second)
-				GoCqhttpServe(d, c, GoCqhttpLoginInfo{
-					Password:         pa.InPackGoCqhttpPassword,
-					Protocol:         pa.InPackGoCqhttpProtocol,
-					AppVersion:       pa.InPackGoCqhttpAppVersion,
-					IsAsyncRun:       true,
-					UseSignServer:    pa.UseSignServer,
-					SignServerConfig: pa.SignServerConfig,
-				})
-				go ServeQQ(d, c)
-			}
-		} else {
-			pa.GoCqhttpState = StateCodeLoginSuccessed
-			go ServeQQ(d, c)
-		}
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		c.Enable = false
-		if pa.UseInPackClient {
-			BuiltinQQServeProcessKill(d, c)
-		}
-		if pa.IsReverse && pa.reverseApp != nil {
-			_ = pa.reverseApp.Close()
-			pa.reverseApp = nil
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
+	}
+}
+
+// LifecycleStart owns one gocq/lagrange lifecycle generation. Built-in clients
+// start their external process here; websocket callbacks report Started/Closed.
+func (pa *PlatformAdapterGocq) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("gocq endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
 	}
+	pa.setLifecycleRun(run)
+	d := pa.EndPoint.Session.Parent
+	ep := pa.EndPoint
+	ep.Enable = true
 
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
+	if pa.UseInPackClient {
+		BuiltinQQServeProcessKill(d, ep)
+		time.Sleep(1 * time.Second)
+		if pa.BuiltinMode == "lagrange" {
+			LagrangeServe(d, ep, LagrangeLoginInfo{IsAsyncRun: true})
+			return nil
+		}
+		GoCqhttpServe(d, ep, GoCqhttpLoginInfo{
+			Password:         pa.InPackGoCqhttpPassword,
+			Protocol:         pa.InPackGoCqhttpProtocol,
+			AppVersion:       pa.InPackGoCqhttpAppVersion,
+			IsAsyncRun:       true,
+			UseSignServer:    pa.UseSignServer,
+			SignServerConfig: pa.SignServerConfig,
+		})
+		return nil
+	}
+
+	pa.GoCqhttpState = StateCodeLoginSuccessed
+	if pa.Serve() != 0 {
+		return errors.New("gocq serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop closes gocq websocket/reverse server/process resources. The
+// supervisor has already invalidated the generation before calling this method.
+func (pa *PlatformAdapterGocq) LifecycleStop(context.Context) error {
+	ep := pa.EndPoint
+	if ep == nil {
+		return nil
+	}
+	d := endpointDice(nil, ep)
+	pa.diceServing = false
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	if pa.InPackGoCqhttpDisconnectedCH != nil {
+		select {
+		case pa.InPackGoCqhttpDisconnectedCH <- -1:
+		default:
+		}
+	}
+	if pa.IsReverse && pa.reverseApp != nil {
+		_ = pa.reverseApp.Close()
+		pa.reverseApp = nil
+	}
+	if d != nil && pa.UseInPackClient {
+		BuiltinQQServeProcessKill(d, ep)
+	}
+	pa.setLifecycleRun(nil)
+	return nil
 }
 
 func (pa *PlatformAdapterGocq) SetQQProtocol(protocol int) bool {

--- a/dice/platform_adapter_gocq_helper.go
+++ b/dice/platform_adapter_gocq_helper.go
@@ -515,8 +515,8 @@ func BuiltinQQServeProcessKillBase(dice *Dice, conn *EndPointInfo, isSync bool) 
 		}
 
 		// 重置状态
-		conn.State = 0
-		pa.GoCqhttpState = 0
+		conn.State = StateDisconnected
+		pa.GoCqhttpState = StateCodeInit
 		pa.GoCqhttpQrcodeData = nil
 
 		if pa.BuiltinMode == "lagrange" {
@@ -617,7 +617,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 
 		if dice.ContainerMode {
 			log.Warn("onebot: 尝试启动内置客户端，但内置客户端在容器模式下被禁用")
-			conn.State = 3
+			conn.State = StateConnectionFailed
 			pa.GoCqhttpState = StateCodeLoginFailed
 			dice.Save(false)
 			return
@@ -632,7 +632,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		pa.GoCqhttpState = StateCodeLoginSuccessed
 		pa.GoCqhttpLoginSucceeded = true
 		dice.Save(false)
-		go ServeQQ(dice, conn)
+		go startQQProtocolConnection(dice, conn)
 	}
 }
 
@@ -878,7 +878,7 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 					dice.LastUpdatedTime = time.Now().Unix()
 					dice.Save(false)
 
-					go ServeQQ(dice, conn)
+					go startQQProtocolConnection(dice, conn)
 				}
 			}
 
@@ -1014,10 +1014,10 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 				BuiltinQQServeProcessKill(dice, conn)
 
 				if isInLogin {
-					conn.State = 3
+					conn.State = StateConnectionFailed
 					pa.GoCqhttpState = StateCodeLoginFailed
 				} else {
-					conn.State = 0
+					conn.State = StateDisconnected
 					pa.GoCqhttpState = GoCqhttpStateCodeClosed
 				}
 			}

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -1,6 +1,8 @@
 package dice
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -39,10 +41,41 @@ func (pa *PlatformAdapterHTTP) Serve() int {
 }
 
 func (pa *PlatformAdapterHTTP) DoRelogin() bool {
-	return false
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
-func (pa *PlatformAdapterHTTP) SetEnable(_ bool) {}
+func (pa *PlatformAdapterHTTP) SetEnable(enable bool) {
+	if enable {
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
+	} else {
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
+	}
+}
+
+// LifecycleStart marks the in-process UI adapter as available. It has no
+// socket to open, but still participates in the shared lifecycle contract.
+func (pa *PlatformAdapterHTTP) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil {
+		return NewEndpointLifecycleFailure(errors.New("http endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	pa.EndPoint.State = StateConnected
+	pa.EndPoint.Enable = true
+	run.Started()
+	return nil
+}
+
+// LifecycleStop has no external resource to close for the UI adapter; the
+// supervisor handles the persisted endpoint state.
+func (pa *PlatformAdapterHTTP) LifecycleStop(context.Context) error {
+	return nil
+}
 
 func getUITestReplySplitLen(ctx *MsgContext) int {
 	if ctx == nil || ctx.UITestReplySplitLen == nil {

--- a/dice/platform_adapter_http.go
+++ b/dice/platform_adapter_http.go
@@ -56,7 +56,7 @@ func (pa *PlatformAdapterHTTP) SetEnable(enable bool) {
 // socket to open, but still participates in the shared lifecycle contract.
 func (pa *PlatformAdapterHTTP) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil {
-		return NewEndpointLifecycleFailure(errors.New("http endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("http endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {

--- a/dice/platform_adapter_kook.go
+++ b/dice/platform_adapter_kook.go
@@ -2,7 +2,9 @@ package dice
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	"io"
@@ -351,7 +353,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 	}
 	pa.IntentSession = s
 	go pa.updateGameStatus()
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 	pa.EndPoint.Enable = true
 	self, _ := s.UserMe()
 	pa.EndPoint.Nickname = self.Nickname
@@ -364,48 +366,48 @@ func (pa *PlatformAdapterKook) Serve() int {
 }
 
 func (pa *PlatformAdapterKook) DoRelogin() bool {
-	log := zap.S().Named(logger.LogKeyAdapter)
-	log.Infof("正在重新登录KOOK服务……")
-	pa.EndPoint.State = 0
-	pa.EndPoint.Enable = false
-	if pa.IntentSession != nil {
-		_ = pa.IntentSession.Close()
-	}
-	pa.IntentSession = nil
-	return pa.Serve() == 0
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterKook) SetEnable(enable bool) {
-	log := zap.S().Named(logger.LogKeyAdapter)
 	if enable {
-		log.Infof("正在启用KOOK服务……")
-		if pa.IntentSession == nil {
-			pa.Serve()
-			return
-		}
-		err := pa.IntentSession.Open()
-		if err != nil {
-			log.Errorf("与KOOK服务进行连接时出错:%s", err)
-			pa.EndPoint.State = 0
-			pa.EndPoint.Enable = false
-			return
-		}
-		pa.updateGameStatus()
-		pa.EndPoint.State = 1
-		pa.EndPoint.Enable = true
-		log.Infof("KOOK 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		if pa.IntentSession == nil {
-			return
-		}
-		pa.EndPoint.State = 0
-		pa.EndPoint.Enable = false
-		_ = pa.IntentSession.Close()
-		pa.IntentSession = nil
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
 	}
-	d := pa.EndPoint.Session.Parent
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
+}
+
+// LifecycleStart opens one KOOK gateway session for the supervisor generation.
+// The adapter no longer owns top-level reconnect scheduling.
+func (pa *PlatformAdapterKook) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("kook endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	_ = pa.LifecycleStop(ctx)
+	zap.S().Named(logger.LogKeyAdapter).Infof("正在启用KOOK服务……")
+	if pa.Serve() != 0 {
+		return errors.New("kook serve failed")
+	}
+	run.Started()
+	return nil
+}
+
+// LifecycleStop closes the current KOOK session. Endpoint state is updated by
+// EndpointLifecycleSupervisor after the stop operation.
+func (pa *PlatformAdapterKook) LifecycleStop(context.Context) error {
+	if pa.IntentSession == nil {
+		return nil
+	}
+	err := pa.IntentSession.Close()
+	pa.IntentSession = nil
+	return err
 }
 
 func (pa *PlatformAdapterKook) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {

--- a/dice/platform_adapter_kook.go
+++ b/dice/platform_adapter_kook.go
@@ -381,7 +381,7 @@ func (pa *PlatformAdapterKook) SetEnable(enable bool) {
 // The adapter no longer owns top-level reconnect scheduling.
 func (pa *PlatformAdapterKook) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("kook endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("kook endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {

--- a/dice/platform_adapter_kook_helper.go
+++ b/dice/platform_adapter_kook_helper.go
@@ -1,13 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-	"go.uber.org/zap"
-
-	"sealdice-core/logger"
-)
+import "github.com/google/uuid"
 
 func NewKookConnItem(token string) *EndPointInfo {
 	conn := new(EndPointInfo)
@@ -24,17 +17,10 @@ func NewKookConnItem(token string) *EndPointInfo {
 }
 
 func ServeKook(d *Dice, ep *EndPointInfo) {
-	log := zap.S().Named(logger.LogKeyAdapter)
 	defer CrashLog()
 	if ep.Platform == "KOOK" {
-		conn := ep.Adapter.(*PlatformAdapterKook)
 		ep.BindRuntime(d.ImSession)
-		log.Infof("KOOK 尝试连接")
-		if conn.Serve() != 0 {
-			log.Errorf("连接KOOK服务失败")
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		d.Logger.Infof("KOOK 尝试连接")
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -64,7 +64,7 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 			if pa.BuiltinMode == "lagrange" {
 				helper.Warn("onebot: 尝试启动内置客户端，但内置客户端在容器模式下被禁用")
 			}
-			conn.State = 3
+			conn.State = StateConnectionFailed
 			pa.GoCqhttpState = StateCodeLoginFailed
 			dice.Save(false)
 			return
@@ -153,7 +153,7 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 			command = fmt.Sprintf(`"%s"`, exeFilePath)
 		}
 		helper.Info("onebot: 正在启动 onebot 客户端…… ", command)
-		conn.State = 2
+		conn.State = StateConnecting
 		conn.Enable = true
 		p := procs.NewProcess(command)
 		p.Dir = workDir
@@ -197,7 +197,7 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 
 					// 经测试，若不延时，登录成功的同一时刻进行ws正向连接有几率导致第一次连接失败
 					time.Sleep(1 * time.Second)
-					go ServeQQ(dice, conn)
+					go startQQProtocolConnection(dice, conn)
 				}
 
 				if strings.Contains(line, qrcodeExpiredSignal) {
@@ -269,10 +269,10 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 
 			isInLogin := pa.IsInLogin()
 			if isInLogin {
-				conn.State = 3
+				conn.State = StateConnectionFailed
 				pa.GoCqhttpState = StateCodeLoginFailed
 			} else {
-				conn.State = 0
+				conn.State = StateDisconnected
 				pa.GoCqhttpState = GoCqhttpStateCodeClosed
 			}
 
@@ -325,7 +325,7 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 		pa.GoCqhttpState = StateCodeLoginSuccessed
 		pa.GoCqhttpLoginSucceeded = true
 		dice.Save(false)
-		go ServeQQ(dice, conn)
+		go startQQProtocolConnection(dice, conn)
 	}
 }
 

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -131,7 +132,7 @@ func (pa *PlatformAdapterMilky) GetGroupInfoAsync(groupID string) {
 
 func (pa *PlatformAdapterMilky) Serve() int {
 	log := zap.S().Named(logger.LogKeyAdapter)
-	pa.EndPoint.State = 2 // 设置状态为连接中
+	pa.EndPoint.State = StateConnecting
 
 	if pa.RestGateway[len(pa.RestGateway)-1] == '/' {
 		pa.RestGateway = pa.RestGateway[:len(pa.RestGateway)-1] // 去掉末尾的斜杠
@@ -417,7 +418,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 	err = pa.IntentSession.Open()
 	if err != nil {
 		log.Errorf("Failed to open Milky session: %v", err)
-		pa.EndPoint.State = 3 // 设置状态为连接失败
+		pa.EndPoint.State = StateConnectionFailed
 		pa.EndPoint.Enable = false
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
@@ -428,7 +429,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		// 获取登录信息失败，视为连接失败
 		log.Errorf("Failed to get login info: %v", err)
 		_ = pa.IntentSession.Close()
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		pa.EndPoint.Enable = false
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
@@ -438,7 +439,7 @@ func (pa *PlatformAdapterMilky) Serve() int {
 	log.Infof("Milky 服务连接成功，账号<%s>(%d)", info.Nickname, info.UIN)
 	pa.EndPoint.UserID = fmt.Sprintf("QQ:%d", info.UIN)
 	pa.EndPoint.Nickname = info.Nickname
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 	pa.EndPoint.Enable = true
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
@@ -642,89 +643,68 @@ func (pa *PlatformAdapterMilky) SetFriendAddRequest(initiatorUid string, approve
 }
 
 func (pa *PlatformAdapterMilky) DoRelogin() bool {
-	log := zap.S().Named(logger.LogKeyAdapter)
-	pa.EndPoint.State = 2
-	// 分离
-	if pa.BuiltInMode == "" {
-		if pa.IntentSession == nil {
-			success := pa.Serve()
-			return success == 0
-		}
-		_ = pa.IntentSession.Close()
-		err := pa.IntentSession.Open()
-		if err != nil {
-			log.Errorf("Milky Connect Error:%s", err.Error())
-			pa.EndPoint.State = 0
-			return false
-		}
-		pa.EndPoint.State = 1
-		pa.EndPoint.Enable = true
-		d := pa.EndPoint.Session.Parent
-		d.LastUpdatedTime = time.Now().Unix()
-		d.Save(false)
-		return true
-	}
-	// 内置
-	// 先断开连接
-	if pa.IntentSession != nil {
-		_ = pa.IntentSession.Close()
-	}
-	// kill
-	BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
-	MilkyRemoveSession(pa.EndPoint.Session.Parent, pa.EndPoint)
-	go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
-	return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterMilky) SetEnable(enable bool) {
 	log := zap.S().Named(logger.LogKeyAdapter)
-	if pa.BuiltInMode == "" {
-		if enable {
-			log.Infof("正在启用Milky服务……")
-			if pa.IntentSession == nil {
-				pa.Serve()
-				return
-			}
-			err := pa.IntentSession.Open()
-			if err != nil {
-				log.Errorf("与Milky服务进行连接时出错:%s", err.Error())
-				pa.EndPoint.State = 3
-				pa.EndPoint.Enable = false
-				return
-			}
-			info, err := pa.IntentSession.GetLoginInfo()
-			if err != nil {
-				log.Errorf("Failed to get login info: %v", err)
-			} else {
-				pa.EndPoint.UserID = fmt.Sprintf("QQ:%d", info.UIN)
-				pa.EndPoint.Nickname = info.Nickname
-				log.Infof("Milky 服务连接成功，账号<%s>(%d)", info.Nickname, info.UIN)
-			}
-			pa.EndPoint.State = 1
-			pa.EndPoint.Enable = true
-		} else {
-			pa.EndPoint.State = 0
-			pa.EndPoint.Enable = false
-			_ = pa.IntentSession.Close()
-		}
-		d := pa.EndPoint.Session.Parent
-		d.LastUpdatedTime = time.Now().Unix()
-		d.Save(false)
-		return
-	}
 	if enable {
-		go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
-	} else {
-		if pa.IntentSession != nil {
-			_ = pa.IntentSession.Close()
+		log.Infof("正在启用Milky服务……")
+		if err := StartEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			log.Errorf("与Milky服务进行连接时出错:%s", err.Error())
 		}
-		BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
-		pa.EndPoint.State = 0
-		pa.EndPoint.Enable = false
-		d := pa.EndPoint.Session.Parent
-		d.LastUpdatedTime = time.Now().Unix()
-		d.Save(false)
+	} else {
+		if err := StopEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			log.Errorf("断开Milky服务时出错:%s", err.Error())
+		}
 	}
+}
+
+// LifecycleStart opens one supervisor-owned Milky run. A fresh generation always
+// closes any previously remembered SDK session before creating the new one.
+func (pa *PlatformAdapterMilky) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if pa.BuiltInMode != "" {
+		return serveMilkyBuiltIn(ctx, pa.EndPoint.Session.Parent, pa.EndPoint, run)
+	}
+
+	if pa.IntentSession != nil {
+		_ = pa.IntentSession.Close()
+		pa.IntentSession = nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if pa.Serve() != 0 {
+		return errors.New("milky serve failed")
+	}
+	select {
+	case <-ctx.Done():
+		_ = pa.IntentSession.Close()
+		pa.IntentSession = nil
+		return ctx.Err()
+	default:
+		run.Started()
+		return nil
+	}
+}
+
+// LifecycleStop closes the SDK websocket and, for built-in Milky, stops the
+// managed client process as part of the same supervisor generation shutdown.
+func (pa *PlatformAdapterMilky) LifecycleStop(ctx context.Context) error {
+	if pa.IntentSession != nil {
+		_ = pa.IntentSession.Close()
+		pa.IntentSession = nil
+	}
+	if pa.BuiltInMode != "" && pa.EndPoint != nil && pa.EndPoint.Session != nil {
+		BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
+	}
+	return ctx.Err()
 }
 
 func ParseMessageToMilky(send []message.IMessageElement) []milky.IMessageElement {

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	milky "github.com/Szzrain/Milky-go-sdk"
@@ -34,6 +35,9 @@ type PlatformAdapterMilky struct {
 	MilkyProcess      *procs.Process  `json:"-" yaml:"-"`
 	BuiltInLoginState MilkyLoginState `json:"loginState" yaml:"-"`
 	QrCodeData        []byte          `json:"-"                          yaml:"-"`
+	// Serializes ownership changes for the built-in child process.
+	builtInProcessMu   sync.Mutex
+	builtInProcessDone chan struct{}
 }
 
 type MilkyLoginState int64

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -193,29 +193,13 @@ func BuiltinMilkyClientKill(dice *Dice, conn *EndPointInfo) {
 		}
 	}()
 	pa, ok := conn.Adapter.(*PlatformAdapterMilky)
-	if !ok {
+	if !ok || pa.BuiltInMode == "" {
 		return
 	}
-	if pa.BuiltInMode == "" {
-		return
-	}
-	defer func() {
-		pa.MilkyProcess = nil
-	}()
-	if pa.MilkyProcess != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		go func() {
-			<-ctx.Done()
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				dice.Logger.Error("Milky 进程未能在 5 秒内退出，可能需要手动结束")
-			}
-		}()
-		err := pa.MilkyProcess.Stop()
-		if err != nil {
-			dice.Logger.Error("停止 Milky 进程失败: ", err)
-		}
-		_ = pa.MilkyProcess.Wait()
+	pa.builtInProcessMu.Lock()
+	defer pa.builtInProcessMu.Unlock()
+	if err := stopMilkyBuiltInLocked(pa); err != nil {
+		dice.Logger.Error("停止 Milky 进程失败: ", err)
 	}
 }
 
@@ -226,6 +210,13 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 
 func serveMilkyBuiltIn(ctx context.Context, d *Dice, ep *EndPointInfo, reporter EndpointRunReporter) error {
 	defer CrashLog()
+	pa, ok := ep.Adapter.(*PlatformAdapterMilky)
+	if !ok || pa.BuiltInMode == "" {
+		return errors.New("milky built-in adapter is unavailable")
+	}
+	pa.builtInProcessMu.Lock()
+	defer pa.builtInProcessMu.Unlock()
+
 	if d.ContainerMode {
 		d.Logger.Warnf("当前处于容器模式，Milky 内置版本不可用")
 		ep.State = StateConnectionFailed
@@ -241,11 +232,10 @@ func serveMilkyBuiltIn(ctx context.Context, d *Dice, ep *EndPointInfo, reporter 
 		d.Save(false)
 		return err
 	}
-	conn := ep.Adapter.(*PlatformAdapterMilky)
 	doServe := func() {
 		if ep.Platform == "QQ" {
 			d.Logger.Infof("Milky 尝试连接")
-			if conn.Serve() != 0 {
+			if pa.Serve() != 0 {
 				d.Logger.Errorf("连接Milky失败")
 				ep.State = StateConnectionFailed
 				d.LastUpdatedTime = time.Now().Unix()
@@ -261,7 +251,6 @@ func serveMilkyBuiltIn(ctx context.Context, d *Dice, ep *EndPointInfo, reporter 
 			}
 		}
 	}
-	pa := conn
 	ep.BindRuntime(d.ImSession)
 	log := zap.S().Named(logger.LogKeyAdapter)
 
@@ -282,29 +271,23 @@ func serveMilkyBuiltIn(ctx context.Context, d *Dice, ep *EndPointInfo, reporter 
 	}
 	_ = os.MkdirAll(workDir, 0o755)
 	_ = os.Chmod(milkyExePath, 0o755)
-	if pa.MilkyProcess != nil {
-		BuiltinMilkyClientKill(d, ep)
+	if pa.IntentSession != nil {
+		_ = pa.IntentSession.Close()
+		pa.IntentSession = nil
 	}
-	if pa.WsGateway == "" {
-		p, err := GetRandomFreePort()
-		if err != nil {
-			log.Errorf("获取随机端口失败: %s", err)
-			ep.State = StateConnectionFailed
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-			return err
-		}
-		pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", p)
-		pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", p)
-		// 生成配置写入文件
-		accessToken := uuid.NewString()
-		pa.Token = accessToken
-		c := GenerateMilkyConfig(p, SealSignV3Url, accessToken, ep)
-		err = os.WriteFile(configFilePath, c, 0o644)
-		if err != nil {
-			log.Errorf("写入 Milky 配置文件失败: %s", err)
-			return err
-		}
+	if err := stopMilkyBuiltInLocked(pa); err != nil {
+		log.Errorf("停止已有 Milky 进程失败: %s", err)
+		ep.State = StateConnectionFailed
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return err
+	}
+	if err := prepareMilkyBuiltInConfig(ep, configFilePath); err != nil {
+		log.Errorf("生成 Milky 启动配置失败: %s", err)
+		ep.State = StateConnectionFailed
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return err
 	}
 	command := fmt.Sprintf(`"%s"`, milkyExePath)
 	p := procs.NewProcess(command)
@@ -397,43 +380,103 @@ func serveMilkyBuiltIn(ctx context.Context, d *Dice, ep *EndPointInfo, reporter 
 		}
 	}()
 
-	run := func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
-			}
-		}()
+	if err := p.Start(); err != nil {
+		log.Info("Milky 进程启动失败: ", err)
+		ep.State = StateConnectionFailed
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return err
+	}
+	done := make(chan struct{})
+	pa.MilkyProcess = p
+	pa.builtInProcessDone = done
+	go waitMilkyBuiltIn(d, pa, p, done, reporter, ctx)
 
-		conn.MilkyProcess = p
-		// processStartTime := time.Now().Unix()
-		errRun := p.Start()
-
-		if errRun == nil {
-			if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
-				errAdd := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process)
-				if errAdd != nil {
-					log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
-				}
-			}
-			errRun = p.Wait() //nolint:ineffassign
-		}
-
-		if errRun != nil {
-			log.Info("Milky 进程异常退出: ", errRun)
-			// Maybe some state change here
-			if reporter != nil && ctx.Err() == nil {
-				reporter.Closed(errRun)
-			}
-		} else {
-			log.Info("Milky 进程退出")
-			if reporter != nil && ctx.Err() == nil {
-				reporter.Closed(nil)
-			}
+	if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
+		if err := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process); err != nil {
+			log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
 		}
 	}
 
-	go run()
+	d.LastUpdatedTime = time.Now().Unix()
+	d.Save(false)
 	return nil
+}
+
+func prepareMilkyBuiltInConfig(ep *EndPointInfo, configFilePath string) error {
+	port, err := GetRandomFreePort()
+	if err != nil {
+		return fmt.Errorf("获取随机端口失败: %w", err)
+	}
+	accessToken := uuid.NewString()
+	config := GenerateMilkyConfig(port, SealSignV3Url, accessToken, ep)
+	if len(config) == 0 {
+		return errors.New("不支持的内置 Milky 模式")
+	}
+	if err := os.WriteFile(configFilePath, config, 0o644); err != nil {
+		return fmt.Errorf("写入 Milky 配置文件失败: %w", err)
+	}
+
+	pa := ep.Adapter.(*PlatformAdapterMilky)
+	pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", port)
+	pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", port)
+	pa.Token = accessToken
+	return nil
+}
+
+func stopMilkyBuiltInLocked(pa *PlatformAdapterMilky) error {
+	process := pa.MilkyProcess
+	if process == nil {
+		return nil
+	}
+	done := pa.builtInProcessDone
+	stopErr := process.Stop()
+	if done == nil {
+		return errors.New("milky 进程缺少退出通知")
+	}
+
+	select {
+	case <-done:
+		if pa.MilkyProcess == process {
+			pa.MilkyProcess = nil
+			pa.builtInProcessDone = nil
+		}
+		return nil
+	case <-time.After(5 * time.Second):
+		if stopErr != nil {
+			return fmt.Errorf("结束进程失败: %w", stopErr)
+		}
+		return errors.New("milky 进程未能在 5 秒内退出，可能需要手动结束")
+	}
+}
+
+func waitMilkyBuiltIn(d *Dice, pa *PlatformAdapterMilky, process *procs.Process, done chan struct{}, reporter EndpointRunReporter, ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			d.Logger.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
+		}
+		close(done)
+
+		pa.builtInProcessMu.Lock()
+		defer pa.builtInProcessMu.Unlock()
+		if pa.MilkyProcess == process {
+			pa.MilkyProcess = nil
+			pa.builtInProcessDone = nil
+		}
+	}()
+
+	err := process.Wait()
+	if err != nil {
+		d.Logger.Info("Milky 进程异常退出: ", err)
+		if reporter != nil && ctx.Err() == nil {
+			reporter.Closed(err)
+		}
+	} else {
+		d.Logger.Info("Milky 进程退出")
+		if reporter != nil && ctx.Err() == nil {
+			reporter.Closed(nil)
+		}
+	}
 }
 
 // GenerateMilkyConfig 似乎暂时不需要 APPInfo, 如果以后需要了再改成双返回值

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -180,15 +180,9 @@ func NewMilkyConnItem(v AddMilkyEcho) *EndPointInfo {
 func ServeMilky(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" {
-		conn := ep.Adapter.(*PlatformAdapterMilky)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Milky 尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Errorf("连接Milky失败")
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }
 
@@ -226,21 +220,26 @@ func BuiltinMilkyClientKill(dice *Dice, conn *EndPointInfo) {
 }
 
 func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
+	ep.BindRuntime(d.ImSession)
+	_ = StartEndpointLifecycle(d, ep)
+}
+
+func serveMilkyBuiltIn(ctx context.Context, d *Dice, ep *EndPointInfo, reporter EndpointRunReporter) error {
 	defer CrashLog()
 	if d.ContainerMode {
 		d.Logger.Warnf("当前处于容器模式，Milky 内置版本不可用")
-		ep.State = 3
+		ep.State = StateConnectionFailed
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return
+		return errors.New("milky built-in is unavailable in container mode")
 	}
 	uin, err := strconv.ParseInt(ExtractQQUserID(ep.UserID), 10, 64)
 	if err != nil {
 		d.Logger.Errorf("解析QQ号失败: %s", ep.UserID)
-		ep.State = 3
+		ep.State = StateConnectionFailed
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return
+		return err
 	}
 	conn := ep.Adapter.(*PlatformAdapterMilky)
 	doServe := func() {
@@ -248,10 +247,17 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 			d.Logger.Infof("Milky 尝试连接")
 			if conn.Serve() != 0 {
 				d.Logger.Errorf("连接Milky失败")
-				ep.State = 3
+				ep.State = StateConnectionFailed
 				d.LastUpdatedTime = time.Now().Unix()
 				d.Save(false)
 				BuiltinMilkyClientKill(d, ep)
+				if reporter != nil {
+					reporter.Failed(errors.New("milky built-in websocket connect failed"))
+				}
+				return
+			}
+			if reporter != nil {
+				reporter.Started()
 			}
 		}
 	}
@@ -283,10 +289,10 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		p, err := GetRandomFreePort()
 		if err != nil {
 			log.Errorf("获取随机端口失败: %s", err)
-			ep.State = 3
+			ep.State = StateConnectionFailed
 			d.LastUpdatedTime = time.Now().Unix()
 			d.Save(false)
-			return
+			return err
 		}
 		pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", p)
 		pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", p)
@@ -297,6 +303,7 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		err = os.WriteFile(configFilePath, c, 0o644)
 		if err != nil {
 			log.Errorf("写入 Milky 配置文件失败: %s", err)
+			return err
 		}
 	}
 	command := fmt.Sprintf(`"%s"`, milkyExePath)
@@ -349,6 +356,9 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 				pa.BuiltInLoginState = MilkyLoginStateFailed
 				log.Infof("Milky 二维码过期，登录失败，账号：%s", ep.UserID)
 				BuiltinMilkyClientKill(d, ep)
+				if reporter != nil {
+					reporter.Failed(errors.New("milky qrcode expired"))
+				}
 			}
 		}
 
@@ -411,12 +421,19 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		if errRun != nil {
 			log.Info("Milky 进程异常退出: ", errRun)
 			// Maybe some state change here
+			if reporter != nil && ctx.Err() == nil {
+				reporter.Closed(errRun)
+			}
 		} else {
 			log.Info("Milky 进程退出")
+			if reporter != nil && ctx.Err() == nil {
+				reporter.Closed(nil)
+			}
 		}
 	}
 
 	go run()
+	return nil
 }
 
 // GenerateMilkyConfig 似乎暂时不需要 APPInfo, 如果以后需要了再改成双返回值

--- a/dice/platform_adapter_milky_helper_test.go
+++ b/dice/platform_adapter_milky_helper_test.go
@@ -1,0 +1,306 @@
+//nolint:testpackage
+package dice
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"sealdice-core/utils/procs"
+)
+
+func newMilkyBuiltInTestAdapter(builtInMode string) *PlatformAdapterMilky {
+	ep := &EndPointInfo{
+		EndPointInfoBase: EndPointInfoBase{
+			UserID: "QQ:10010",
+		},
+	}
+	pa := &PlatformAdapterMilky{EndPoint: ep, BuiltInMode: builtInMode}
+	ep.Adapter = pa
+	return pa
+}
+
+const (
+	milkyHelperEnv   = "GO_WANT_MILKY_HELPER_PROCESS"
+	milkyHelperSleep = "GO_WANT_MILKY_HELPER_SLEEP"
+)
+
+func startMilkyBuiltInHelperProcess(t *testing.T, sleep bool) (*procs.Process, func()) {
+	t.Helper()
+	args := []string{"-test.run=TestMilkyBuiltInHelperProcess"}
+	if sleep {
+		args = append(args, "-test.v")
+	}
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Env = append(os.Environ(), milkyHelperEnv+"=1")
+	if sleep {
+		cmd.Env = append(cmd.Env, milkyHelperSleep+"=1")
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	cleanup := func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	}
+	return &procs.Process{Cmd: cmd}, cleanup
+}
+
+func TestMilkyBuiltInHelperProcess(t *testing.T) {
+	if os.Getenv(milkyHelperEnv) != "1" {
+		return
+	}
+	if os.Getenv(milkyHelperSleep) == "1" {
+		time.Sleep(time.Hour)
+	}
+}
+
+func TestPrepareMilkyBuiltInConfigAssignsNewPortAndToken(t *testing.T) {
+	dir := t.TempDir()
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	configFile := filepath.Join(dir, "appsettings.jsonc")
+
+	if err := prepareMilkyBuiltInConfig(pa.EndPoint, configFile); err != nil {
+		t.Fatalf("prepareMilkyBuiltInConfig() error = %v", err)
+	}
+	firstGateway := pa.WsGateway
+	firstRest := pa.RestGateway
+	firstToken := pa.Token
+	config, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	if !strings.Contains(string(config), firstToken) {
+		t.Fatalf("config file does not contain generated token")
+	}
+
+	if err := prepareMilkyBuiltInConfig(pa.EndPoint, configFile); err != nil {
+		t.Fatalf("second prepareMilkyBuiltInConfig() error = %v", err)
+	}
+	if pa.WsGateway == firstGateway {
+		t.Fatalf("expected a new WsGateway after re-preparing config, got %q", pa.WsGateway)
+	}
+	if pa.RestGateway == firstRest {
+		t.Fatalf("expected a new RestGateway after re-preparing config, got %q", pa.RestGateway)
+	}
+	if pa.Token == firstToken {
+		t.Fatalf("expected a new access token after re-preparing config")
+	}
+}
+
+func TestStopMilkyBuiltInLockedWithoutProcess(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	if err := stopMilkyBuiltInLocked(pa); err != nil {
+		t.Fatalf("stopMilkyBuiltInLocked() nil-process error = %v", err)
+	}
+}
+
+func TestStopMilkyBuiltInLockedMissingDoneChannel(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	process, cleanup := startMilkyBuiltInHelperProcess(t, true)
+	t.Cleanup(cleanup)
+	pa.MilkyProcess = process
+
+	err := stopMilkyBuiltInLocked(pa)
+	if err == nil {
+		t.Fatal("expected stopMilkyBuiltInLocked to report a missing exit notification")
+	}
+	if !strings.Contains(err.Error(), "缺少退出通知") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStopMilkyBuiltInLockedWaitsForExitNotification(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	process, cleanup := startMilkyBuiltInHelperProcess(t, true)
+	t.Cleanup(cleanup)
+	done := make(chan struct{})
+	pa.MilkyProcess = process
+	pa.builtInProcessDone = done
+
+	result := make(chan error, 1)
+	go func() {
+		result <- stopMilkyBuiltInLocked(pa)
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("stopMilkyBuiltInLocked returned before done was closed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(done)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("stopMilkyBuiltInLocked() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stopMilkyBuiltInLocked did not return after done closed")
+	}
+
+	if pa.MilkyProcess != nil {
+		t.Fatalf("expected MilkyProcess to be cleared after stop, got %p", pa.MilkyProcess)
+	}
+	if pa.builtInProcessDone != nil {
+		t.Fatalf("expected builtInProcessDone to be cleared after stop")
+	}
+}
+
+func TestWaitMilkyBuiltInKeepsNewerProcessState(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	oldProcess, cleanup := startMilkyBuiltInHelperProcess(t, false)
+	t.Cleanup(cleanup)
+	newProcess := &procs.Process{}
+	pa.MilkyProcess = newProcess
+	pa.builtInProcessDone = make(chan struct{})
+
+	d := &Dice{Logger: zap.NewNop().Sugar()}
+	done := make(chan struct{})
+	waitMilkyBuiltIn(d, pa, oldProcess, done, nil, nil)
+
+	if pa.MilkyProcess != newProcess {
+		t.Fatalf("waitMilkyBuiltIn cleared a newer process: got %p want %p", pa.MilkyProcess, newProcess)
+	}
+	if pa.builtInProcessDone == nil {
+		t.Fatal("waitMilkyBuiltIn cleared builtInProcessDone for a newer process")
+	}
+}
+
+func TestWaitMilkyBuiltInClearsCurrentProcessState(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	process, cleanup := startMilkyBuiltInHelperProcess(t, false)
+	t.Cleanup(cleanup)
+	done := make(chan struct{})
+	pa.MilkyProcess = process
+	pa.builtInProcessDone = done
+
+	d := &Dice{Logger: zap.NewNop().Sugar()}
+	waitMilkyBuiltIn(d, pa, process, done, nil, nil)
+
+	if pa.MilkyProcess != nil {
+		t.Fatalf("expected MilkyProcess to be cleared, got %p", pa.MilkyProcess)
+	}
+	if pa.builtInProcessDone != nil {
+		t.Fatal("expected builtInProcessDone to be cleared")
+	}
+}
+
+func TestBuiltinMilkyClientKillClearsProcessState(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	process, cleanup := startMilkyBuiltInHelperProcess(t, true)
+	t.Cleanup(cleanup)
+	done := make(chan struct{})
+	close(done)
+	pa.MilkyProcess = process
+	pa.builtInProcessDone = done
+
+	BuiltinMilkyClientKill(&Dice{Logger: zap.NewNop().Sugar()}, pa.EndPoint)
+
+	if pa.MilkyProcess != nil {
+		t.Fatalf("BuiltinMilkyClientKill did not clear MilkyProcess")
+	}
+	if pa.builtInProcessDone != nil {
+		t.Fatalf("BuiltinMilkyClientKill did not clear builtInProcessDone")
+	}
+}
+
+func TestBuiltinMilkyClientKillWaitsForRunningProcess(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+	process, cleanup := startMilkyBuiltInHelperProcess(t, true)
+	t.Cleanup(cleanup)
+	done := make(chan struct{})
+	pa.MilkyProcess = process
+	pa.builtInProcessDone = done
+
+	d := &Dice{Logger: zap.NewNop().Sugar()}
+	waitDone := make(chan struct{})
+	go func() {
+		waitMilkyBuiltIn(d, pa, process, done, nil, nil)
+		close(waitDone)
+	}()
+
+	killDone := make(chan struct{})
+	go func() {
+		BuiltinMilkyClientKill(d, pa.EndPoint)
+		close(killDone)
+	}()
+
+	select {
+	case <-killDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("BuiltinMilkyClientKill did not return after killing the running process")
+	}
+	select {
+	case <-waitDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("waitMilkyBuiltIn did not return after the process was killed")
+	}
+
+	if pa.MilkyProcess != nil {
+		t.Fatalf("expected MilkyProcess to be cleared after kill")
+	}
+	if pa.builtInProcessDone != nil {
+		t.Fatal("expected builtInProcessDone to be cleared after kill")
+	}
+}
+
+func TestMilkyBuiltInProcessOperationsAreSerialized(t *testing.T) {
+	pa := newMilkyBuiltInTestAdapter("lagrangeV2")
+
+	const workerCount = 8
+	var active int32
+	seen := make(chan int32, workerCount)
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	worker := func() {
+		defer wg.Done()
+		pa.builtInProcessMu.Lock()
+		current := atomic.AddInt32(&active, 1)
+		seen <- current
+		<-release
+		atomic.AddInt32(&active, -1)
+		pa.builtInProcessMu.Unlock()
+	}
+
+	for range workerCount {
+		wg.Add(1)
+		go worker()
+	}
+	close(release)
+	wg.Wait()
+	close(seen)
+
+	count := 0
+	for current := range seen {
+		count++
+		if current != 1 {
+			t.Fatalf("expected at most one process operation at a time, saw %d concurrent", current)
+		}
+	}
+	if count != workerCount {
+		t.Fatalf("expected %d workers to run, got %d", workerCount, count)
+	}
+}
+
+func TestPrepareMilkyBuiltInConfigUnsupportedMode(t *testing.T) {
+	dir := t.TempDir()
+	pa := newMilkyBuiltInTestAdapter("unsupported")
+
+	err := prepareMilkyBuiltInConfig(pa.EndPoint, filepath.Join(dir, "config.json"))
+	if err == nil {
+		t.Fatal("expected prepareMilkyBuiltInConfig to reject an unsupported mode")
+	}
+	if !strings.Contains(err.Error(), "不支持的内置 Milky 模式") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/dice/platform_adapter_minecraft.go
+++ b/dice/platform_adapter_minecraft.go
@@ -3,6 +3,7 @@ package dice
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -207,7 +208,7 @@ func (pa *PlatformAdapterMinecraft) LifecycleStart(ctx context.Context, run Endp
 		pa.Socket = nil
 	}
 	if pa.serveWithLifecycle(ctx, run) != 0 {
-		return fmt.Errorf("minecraft serve failed")
+		return errors.New("minecraft serve failed")
 	}
 	return nil
 }

--- a/dice/platform_adapter_minecraft.go
+++ b/dice/platform_adapter_minecraft.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -42,6 +43,10 @@ type SendMessageMinecraft struct {
 func (pa *PlatformAdapterMinecraft) GetGroupInfoAsync(_ string) {}
 
 func (pa *PlatformAdapterMinecraft) Serve() int {
+	return pa.serveWithLifecycle(context.Background(), nil)
+}
+
+func (pa *PlatformAdapterMinecraft) serveWithLifecycle(ctx context.Context, reporter EndpointRunReporter) int {
 	if !strings.HasPrefix(pa.ConnectURL, "ws://") {
 		pa.ConnectURL = "ws://" + pa.ConnectURL
 	}
@@ -52,7 +57,17 @@ func (pa *PlatformAdapterMinecraft) Serve() int {
 	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
-	pa.socketSetup()
+	pa.socketSetupWithLifecycle(reporter)
+	if reporter != nil {
+		// Connect is asynchronous, so bind cancellation to the current socket
+		// until LifecycleStop gets a chance to close it explicitly.
+		go func(socket *gowebsocket.Socket) {
+			<-ctx.Done()
+			if pa.Socket == socket {
+				socket.Close()
+			}
+		}(&socket)
+	}
 	socket.Connect()
 	return 0
 }
@@ -75,12 +90,16 @@ func (pa *PlatformAdapterMinecraft) tryReconnect(socket gowebsocket.Socket) bool
 }
 
 func (pa *PlatformAdapterMinecraft) socketSetup() {
+	pa.socketSetupWithLifecycle(nil)
+}
+
+func (pa *PlatformAdapterMinecraft) socketSetupWithLifecycle(reporter EndpointRunReporter) {
 	ep := pa.EndPoint
 	log := ep.Session.Parent.Logger
 	socket := pa.Socket
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		pa.Reconnecting = true
-		ep.State = 1
+		ep.State = StateConnected
 		ep.Enable = true
 		pa.RetryTimes = 0
 
@@ -89,6 +108,9 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		d.Save(false)
 
 		log.Info("Minecraft 连接成功")
+		if reporter != nil {
+			reporter.Started()
+		}
 		time.Sleep(time.Duration(5) * time.Second)
 		pa.Reconnecting = false
 	}
@@ -101,21 +123,29 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 	}
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
 		log.Errorf("MC websocket出现错误: %s", err)
+		if reporter != nil {
+			reporter.Failed(err)
+			return
+		}
 		if !socket.IsConnected {
 			// socket.Close()
 			if !pa.tryReconnect(*pa.Socket) {
 				log.Errorf("短时间内连接失败次数过多，不再进行重连")
-				ep.State = 3
+				ep.State = StateConnectionFailed
 				ep.Enable = false
 			}
 		}
 	}
 	socket.OnDisconnected = func(err error, socket gowebsocket.Socket) {
 		log.Errorf("与MC服务器断开连接")
+		if reporter != nil {
+			reporter.Closed(err)
+			return
+		}
 		time.Sleep(time.Duration(2) * time.Second)
 		if !pa.tryReconnect(*pa.Socket) {
 			log.Errorf("短时间内连接失败次数过多，不再进行重连")
-			ep.State = 3
+			ep.State = StateConnectionFailed
 			ep.Enable = false
 		}
 	}
@@ -153,45 +183,44 @@ func ExtractMCUserID(id string) string {
 }
 
 func (pa *PlatformAdapterMinecraft) DoRelogin() bool {
-	log := pa.EndPoint.Session.Parent.Logger
-	pa.Reconnecting = true
-	pa.Socket.Close()
-	socket := gowebsocket.New(pa.ConnectURL)
-	log.Infof("MC server 重新连接")
-	pa.Socket = &socket
-	pa.socketSetup()
-	socket.Connect()
-	pa.Reconnecting = false
-	return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterMinecraft) SetEnable(enable bool) {
 	log := pa.EndPoint.Session.Parent.Logger
 	if enable {
 		log.Infof("MC server 连接中")
-		if pa.Socket != nil && pa.Socket.IsConnected {
-			pa.Reconnecting = true
-			pa.Socket.Close()
-			socket := gowebsocket.New(pa.ConnectURL)
-			pa.Socket = &socket
-			pa.socketSetup()
-			socket.Connect()
-			pa.Reconnecting = false
-		} else {
-			pa.Reconnecting = true
-			socket := gowebsocket.New(pa.ConnectURL)
-			pa.Socket = &socket
-			pa.socketSetup()
-			socket.Connect()
-			pa.Reconnecting = false
+		if err := StartEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			log.Errorf("MC server 连接失败: %s", err.Error())
 		}
 	} else {
-		pa.Reconnecting = true
-		if pa.Socket != nil && pa.Socket.IsConnected {
-			pa.Socket.Close()
+		if err := StopEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			log.Errorf("MC server 断开失败: %s", err.Error())
 		}
-		pa.Reconnecting = false
 	}
+}
+
+// LifecycleStart starts one Minecraft websocket owned by the supervisor.
+func (pa *PlatformAdapterMinecraft) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	if pa.serveWithLifecycle(ctx, run) != 0 {
+		return fmt.Errorf("minecraft serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop closes the active Minecraft websocket for the current
+// supervisor generation.
+func (pa *PlatformAdapterMinecraft) LifecycleStop(ctx context.Context) error {
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	pa.Reconnecting = false
+	return ctx.Err()
 }
 
 func (pa *PlatformAdapterMinecraft) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {

--- a/dice/platform_adapter_minecraft_helper.go
+++ b/dice/platform_adapter_minecraft_helper.go
@@ -19,9 +19,8 @@ func NewMinecraftConnItem(url string) *EndPointInfo {
 func ServeMinecraft(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "MC" {
-		conn := ep.Adapter.(*PlatformAdapterMinecraft)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Minecraft 尝试连接")
-		conn.Serve()
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -67,6 +67,8 @@ type PlatformAdapterOfficialQQ struct {
 	CancelFunc     context.CancelFunc   `json:"-" yaml:"-"`
 	tokenSource    oauth2.TokenSource   `json:"-" yaml:"-"`
 	botID          string               `json:"-" yaml:"-"`
+	lifecycleMu    sync.Mutex           `json:"-" yaml:"-"`
+	lifecycleRun   EndpointRunReporter  `json:"-" yaml:"-"`
 
 	// Webhook服务
 	webhookServer *http.Server `json:"-" yaml:"-"`
@@ -321,7 +323,7 @@ func (pa *PlatformAdapterOfficialQQ) stopSessionContext() {
 func (pa *PlatformAdapterOfficialQQ) failConnect() int {
 	ep := pa.EndPoint
 	if ep != nil {
-		ep.State = 3
+		ep.State = StateConnectionFailed
 	}
 	if pa.CancelFunc != nil {
 		pa.CancelFunc()
@@ -339,7 +341,41 @@ func (pa *PlatformAdapterOfficialQQ) failConnect() int {
 	if isQrFlow {
 		pa.markQrLoginFailed()
 	}
+	pa.reportLifecycleFailed(NewEndpointLifecycleFailure(errors.New("official qq connect failed"), LifecycleFailureStop))
 	return 1
+}
+
+func (pa *PlatformAdapterOfficialQQ) setLifecycleRun(run EndpointRunReporter) {
+	pa.lifecycleMu.Lock()
+	defer pa.lifecycleMu.Unlock()
+	pa.lifecycleRun = run
+}
+
+func (pa *PlatformAdapterOfficialQQ) reportLifecycleStarted() {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Started()
+	}
+}
+
+func (pa *PlatformAdapterOfficialQQ) reportLifecycleFailed(err error) {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Failed(err)
+	}
+}
+
+func (pa *PlatformAdapterOfficialQQ) reportLifecycleClosed(err error) {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Closed(err)
+	}
 }
 
 func (pa *PlatformAdapterOfficialQQ) Serve() int {
@@ -360,7 +396,7 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 	if pa.AppID == "" {
 		ctx, cancel := context.WithCancel(context.Background())
 		pa.Ctx, pa.CancelFunc = ctx, cancel
-		ep.State = 2
+		ep.State = StateConnecting
 		log.Info("official qq AppID 为空，进入扫码登录流程")
 		pa.serveQrLogin("sealdice")
 		return 0
@@ -458,23 +494,24 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 			if err := pa.webhookServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				log.Error("official qq webhook服务器启动失败: ", err)
 				if pa.Ctx == ctx {
-					ep.State = 3
-					ep.Enable = false
+					ep.State = StateConnectionFailed
+					pa.reportLifecycleClosed(err)
 				}
 			}
 		}()
 
-		ep.State = 1
+		ep.State = StateConnected
 		ep.Enable = true
 		pa.clearQrLoginState()
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 		log.Info("official qq webhook模式启动成功")
+		pa.reportLifecycleStarted()
 		return 0
 	}
 
 	pa.SessionManager = qqbot.NewSessionManager()
-	ep.State = 2
+	ep.State = StateConnecting
 	log.Debug("official qq connecting")
 	ws, err := pa.Api.WS(ctx, nil, "")
 	if err != nil || ws == nil {
@@ -516,8 +553,8 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 			if r := recover(); r != nil {
 				log.Error("official qq 启动失败: ", r)
 				if isCurrent {
-					ep.State = 3
-					ep.Enable = false
+					ep.State = StateConnectionFailed
+					pa.reportLifecycleFailed(fmt.Errorf("official qq session panic: %v", r))
 				}
 			}
 			if isCurrent {
@@ -529,18 +566,19 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 		if startErr := pa.SessionManager.Start(currentCtx, ws, pa.tokenSource, &intent); startErr != nil {
 			log.Error("official qq session manager 启动失败: ", startErr)
 			if pa.Ctx == currentCtx {
-				ep.State = 3
-				ep.Enable = false
+				ep.State = StateConnectionFailed
+				pa.reportLifecycleClosed(startErr)
 			}
 		}
 	}()
 
-	ep.State = 1
+	ep.State = StateConnected
 	ep.Enable = true
 	pa.clearQrLoginState()
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	log.Info("official qq 连接成功")
+	pa.reportLifecycleStarted()
 	return 0
 }
 
@@ -1260,47 +1298,57 @@ func (pa *PlatformAdapterOfficialQQ) shutdownWebhookServer() {
 }
 
 func (pa *PlatformAdapterOfficialQQ) DoRelogin() bool {
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
+}
+
+func (pa *PlatformAdapterOfficialQQ) SetEnable(enable bool) {
+	if enable {
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
+	} else {
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
+	}
+}
+
+// LifecycleStart starts one Official QQ lifecycle generation. In QR-login mode
+// Serve returns after creating the QR task, so Started is reported later from
+// connect/webhook success paths.
+func (pa *PlatformAdapterOfficialQQ) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("official qq endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	pa.setLifecycleRun(run)
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 official qq 服务")
+	if pa.Serve() != 0 {
+		return NewEndpointLifecycleFailure(errors.New("official qq serve failed"), LifecycleFailureStop)
+	}
+	if pa.Ctx != nil && pa.EndPoint.State == StateConnected {
+		pa.reportLifecycleStarted()
+	}
+	return nil
+}
+
+// LifecycleStop cancels Official QQ websocket/webhook/QR resources. Endpoint
+// state is then persisted by EndpointLifecycleSupervisor.
+func (pa *PlatformAdapterOfficialQQ) LifecycleStop(context.Context) error {
 	if pa.CancelFunc != nil {
 		pa.CancelFunc()
 	}
-	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 official qq 服务")
-	pa.EndPoint.State = 0
-	pa.EndPoint.Enable = false
+	pa.shutdownWebhookServer()
 	pa.Api = nil
+	pa.SessionManager = nil
 	pa.Ctx = nil
 	pa.CancelFunc = nil
 	pa.tokenSource = nil
 	pa.clearQrLoginState()
-	pa.shutdownWebhookServer()
-	return pa.Serve() == 0
-}
-
-func (pa *PlatformAdapterOfficialQQ) SetEnable(enable bool) {
-	d := pa.EndPoint.Session.Parent
-	ep := pa.EndPoint
-	if enable {
-		if pa.Ctx == nil {
-			ep.Enable = false
-			pa.DiceServing = false
-			ep.State = 2
-			ServerOfficialQQ(d, ep)
-		} else {
-			ep.Enable = true
-			ep.State = 1
-		}
-	} else {
-		ep.State = 0
-		ep.Enable = false
-		if pa.CancelFunc != nil {
-			pa.CancelFunc()
-		}
-		pa.shutdownWebhookServer()
-		pa.CancelFunc = nil
-		pa.Ctx = nil
-		pa.tokenSource = nil
-		pa.clearQrLoginState()
-	}
-	d.LastUpdatedTime = time.Now().Unix()
+	pa.setLifecycleRun(nil)
+	return nil
 }
 
 func (pa *PlatformAdapterOfficialQQ) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {
@@ -2702,7 +2750,7 @@ func (pa *PlatformAdapterOfficialQQ) failQrLogin(logMsg string, err error) {
 		log.Error(logMsg)
 	}
 	pa.markQrLoginFailed()
-	ep.State = 3
+	ep.State = StateConnectionFailed
 	ep.Enable = false
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
@@ -2834,7 +2882,7 @@ func (pa *PlatformAdapterOfficialQQ) serveQrLogin(source string) {
 					ep.UserID = ""
 					ep.Nickname = ""
 					pa.markQrLoginFailed()
-					ep.State = 3
+					ep.State = StateConnectionFailed
 					ep.Enable = false
 					d.LastUpdatedTime = time.Now().Unix()
 					d.Save(false)

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -341,7 +341,7 @@ func (pa *PlatformAdapterOfficialQQ) failConnect() int {
 	if isQrFlow {
 		pa.markQrLoginFailed()
 	}
-	pa.reportLifecycleFailed(NewEndpointLifecycleFailure(errors.New("official qq connect failed"), LifecycleFailureStop))
+	pa.reportLifecycleFailed(NewEndpointLifecycleError(errors.New("official qq connect failed"), LifecycleFailureStop))
 	return 1
 }
 
@@ -1314,7 +1314,7 @@ func (pa *PlatformAdapterOfficialQQ) SetEnable(enable bool) {
 // connect/webhook success paths.
 func (pa *PlatformAdapterOfficialQQ) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("official qq endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("official qq endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {
@@ -1326,7 +1326,7 @@ func (pa *PlatformAdapterOfficialQQ) LifecycleStart(ctx context.Context, run End
 	pa.setLifecycleRun(run)
 	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 official qq 服务")
 	if pa.Serve() != 0 {
-		return NewEndpointLifecycleFailure(errors.New("official qq serve failed"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("official qq serve failed"), LifecycleFailureStop)
 	}
 	if pa.Ctx != nil && pa.EndPoint.State == StateConnected {
 		pa.reportLifecycleStarted()

--- a/dice/platform_adapter_official_qq_helper.go
+++ b/dice/platform_adapter_official_qq_helper.go
@@ -33,8 +33,7 @@ func ServerOfficialQQ(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" && ep.ProtocolType == "official" {
 		ep.BindRuntime(d.ImSession)
-		// 连接状态、重试和日志统一由 ServeQQ 及其官方 QQ 分支负责。
-		ServeQQ(d, ep)
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }
 

--- a/dice/platform_adapter_official_qq_test.go
+++ b/dice/platform_adapter_official_qq_test.go
@@ -28,18 +28,20 @@ func (f officialQQTransportFunc) Transport(ctx context.Context, method, url stri
 }
 
 func TestServerOfficialQQSkipsRunningSessionBeforeStateChange(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	conn := &PlatformAdapterOfficialQQ{Ctx: ctx}
-	ep := &EndPointInfo{EndPointInfoBase: EndPointInfoBase{
-		State:  StateConnected,
-		Enable: true,
-	}}
+	_, ep, _, cleanup := newExecuteNewTestDice(t)
+	defer cleanup()
+	conn := &PlatformAdapterOfficialQQ{EndPoint: ep, Ctx: ctx}
+	ep.Adapter = conn
+	ep.State = StateConnected
+	ep.Enable = true
 
-	serverOfficialQQ(&Dice{}, ep, conn)
+	reporter := newOnebotLifecycleReporter()
+	if err := conn.LifecycleStart(ctx, reporter); err != nil {
+		t.Fatalf("LifecycleStart returned error: %v", err)
+	}
 
 	if conn.DiceServing {
 		t.Fatal("running session was marked as a new server")

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -127,7 +127,7 @@ func (p *PlatformAdapterOnebot) reportLifecycleClosed(err error) {
 // callbacks report into the shared endpoint supervisor instead of an adapter FSM.
 func (p *PlatformAdapterOnebot) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if p.EndPoint == nil || p.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("pure onebot endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("pure onebot endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -152,7 +152,7 @@ func (p *PlatformAdapterOnebot) LifecycleStart(ctx context.Context, run Endpoint
 // supervisor updates endpoint state after this method returns.
 func (p *PlatformAdapterOnebot) LifecycleStop(context.Context) error {
 	p.cleanupResources()
-	p.setLifecycleRun(nil, nil)
+	p.setLifecycleRun(context.TODO(), nil)
 	return nil
 }
 

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -12,12 +12,10 @@ import (
 	"time"
 
 	socketio "github.com/PaienNate/pineutil/evsocket/v2"
-	"github.com/avast/retry-go"
 	"github.com/bytedance/sonic"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	loopfsm "github.com/looplab/fsm"
 	"github.com/maypok86/otter"
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
@@ -41,6 +39,9 @@ type PlatformAdapterOnebot struct {
 	ctx                 context.Context
 	cancel              context.CancelFunc
 	logger              *zap.SugaredLogger
+	lifecycleMu         sync.Mutex
+	lifecycleRun        EndpointRunReporter
+	lifecycleCtx        context.Context
 
 	// 保护这几个
 	sendEmitter emitter.Emitter
@@ -55,10 +56,7 @@ type PlatformAdapterOnebot struct {
 	friendRequestDedupeMu    sync.Mutex
 	friendRequestDedupTTL    time.Duration
 
-	retryAttempts  uint         // 当前重试次数
-	isRetrying     bool         // 是否正在重试
-	retryMutex     sync.RWMutex // 重试状态锁
-	isShuttingDown bool         // 是否正在主动关闭连接
+	isShuttingDown bool // 是否正在主动关闭连接
 
 	// 连接建立互斥锁，确保同时只有一个连接建立过程
 	connectionMutex sync.Mutex
@@ -66,37 +64,96 @@ type PlatformAdapterOnebot struct {
 
 	echoServer *echo.Echo
 
-	sm                  *loopfsm.FSM
-	desiredEnabled      bool
 	loginInitRetry      func()
 	loginInitRetrySleep func(time.Duration)
 }
 
 func (p *PlatformAdapterOnebot) Serve() int {
-	p.ensureFSM()
-	p.desiredEnabled = true
-	_ = p.sm.Event(context.Background(), "enable")
+	if err := StartEndpointLifecycle(nil, p.EndPoint); err != nil {
+		return 1
+	}
 	return 0
 }
 
 // DoRelogin 重新登录/重连
 func (p *PlatformAdapterOnebot) DoRelogin() bool {
-	p.logger.Warn("因协议端不支持所谓重新登录，重新登录功能无实际用途。")
-	return true
+	return ReloginEndpointLifecycle(nil, p.EndPoint) == nil
 }
 
 // SetEnable 启用或禁用适配器
 func (p *PlatformAdapterOnebot) SetEnable(enable bool) {
-	p.ensureFSM()
 	if enable {
-		p.logger.Info("正在启用 OneBot 适配器...")
-		p.desiredEnabled = true
-		_ = p.sm.Event(context.Background(), "enable")
+		_ = StartEndpointLifecycle(nil, p.EndPoint)
 	} else {
-		p.logger.Info("正在禁用 OneBot 适配器...")
-		p.desiredEnabled = false
-		_ = p.sm.Event(context.Background(), "disable")
+		_ = StopEndpointLifecycle(nil, p.EndPoint)
 	}
+}
+
+func (p *PlatformAdapterOnebot) setLifecycleRun(ctx context.Context, run EndpointRunReporter) {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+	p.lifecycleCtx = ctx
+	p.lifecycleRun = run
+}
+
+func (p *PlatformAdapterOnebot) lifecycleReporter() (context.Context, EndpointRunReporter) {
+	p.lifecycleMu.Lock()
+	defer p.lifecycleMu.Unlock()
+	return p.lifecycleCtx, p.lifecycleRun
+}
+
+func (p *PlatformAdapterOnebot) reportLifecycleStarted() {
+	_, run := p.lifecycleReporter()
+	if run != nil {
+		run.Started()
+	}
+}
+
+func (p *PlatformAdapterOnebot) reportLifecycleFailed(err error) {
+	_, run := p.lifecycleReporter()
+	if run != nil {
+		run.Failed(err)
+	}
+}
+
+func (p *PlatformAdapterOnebot) reportLifecycleClosed(err error) {
+	_, run := p.lifecycleReporter()
+	if run != nil {
+		run.Closed(err)
+	}
+}
+
+// LifecycleStart starts one Pure OneBot client/server connection. Connection
+// callbacks report into the shared endpoint supervisor instead of an adapter FSM.
+func (p *PlatformAdapterOnebot) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if p.EndPoint == nil || p.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("pure onebot endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	p.setLifecycleRun(ctx, run)
+	if p.logger == nil {
+		p.logger = zap.S().Named(logger.LogKeyAdapter)
+	}
+	p.logger.Info("正在启用 OneBot 适配器...")
+	if err := p.startConnection(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// LifecycleStop shuts down the Pure OneBot server/client resources. The
+// supervisor updates endpoint state after this method returns.
+func (p *PlatformAdapterOnebot) LifecycleStop(context.Context) error {
+	p.cleanupResources()
+	p.setLifecycleRun(nil, nil)
+	return nil
 }
 
 func (p *PlatformAdapterOnebot) QuitGroup(_ *MsgContext, id string) {
@@ -553,7 +610,7 @@ func (p *PlatformAdapterOnebot) onConnected(kws *socketio.WebsocketWrapper) {
 	p.logger.Infof("OneBot 连接成功，账号<%s>(%d)", info.NickName, info.UserId)
 	p.EndPoint.UserID = fmt.Sprintf("QQ:%d", info.UserId)
 	p.EndPoint.Nickname = info.NickName
-	_ = p.sm.Event(context.Background(), "connect_ok")
+	p.reportLifecycleStarted()
 }
 
 // initializeCommonResources 初始化公共资源（移除sync.Once限制，允许重新初始化）
@@ -633,8 +690,6 @@ func (p *PlatformAdapterOnebot) initializeCommonResources() {
 	if _, err := p.ensureFriendRequestDedupeCache(); err != nil {
 		p.logger.Warnf("初始化好友申请去重缓存失败: %v", err)
 	}
-
-	p.ensureFSM()
 }
 
 // setupClientConnection 设置客户端连接
@@ -650,7 +705,7 @@ func (p *PlatformAdapterOnebot) setupClientConnection() error {
 
 	client.OnConnectError = func(err error) {
 		p.logger.Errorf("连接失败: %v", err)
-		_ = p.sm.Event(context.Background(), "connect_fail")
+		p.reportLifecycleFailed(err)
 	}
 
 	client.OnDisconnected = func(err error) {
@@ -666,7 +721,7 @@ func (p *PlatformAdapterOnebot) setupClientConnection() error {
 		} else {
 			p.logger.Warn("连接意外断开")
 		}
-		_ = p.sm.Event(context.Background(), "connection_lost")
+		p.reportLifecycleClosed(err)
 	}
 
 	return client.Connect()
@@ -700,7 +755,8 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 	retryFn := p.loginInitRetry
 	if retryFn == nil {
 		retryFn = func() {
-			if !p.desiredEnabled || p.sendEmitter == nil || p.ctx == nil {
+			lifecycleCtx, _ := p.lifecycleReporter()
+			if lifecycleCtx == nil || lifecycleCtx.Err() != nil || p.sendEmitter == nil || p.ctx == nil {
 				return
 			}
 			sleepFn := p.loginInitRetrySleep
@@ -708,19 +764,20 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 				sleepFn = time.Sleep
 			}
 			sleepFn(3 * time.Second)
-			if !p.desiredEnabled || p.sendEmitter == nil || p.ctx == nil {
+			lifecycleCtx, _ = p.lifecycleReporter()
+			if lifecycleCtx == nil || lifecycleCtx.Err() != nil || p.sendEmitter == nil || p.ctx == nil {
 				return
 			}
 			info, err := p.sendEmitter.GetLoginInfo(p.ctx)
 			if err != nil {
 				p.logger.Errorf("重试获取登录信息异常 %v", err)
-				_ = p.sm.Event(context.Background(), "connect_fail")
+				p.reportLifecycleFailed(err)
 				return
 			}
 			p.logger.Infof("OneBot 连接成功，账号<%s>(%d)", info.NickName, info.UserId)
 			p.EndPoint.UserID = fmt.Sprintf("QQ:%d", info.UserId)
 			p.EndPoint.Nickname = info.NickName
-			_ = p.sm.Event(context.Background(), "connect_ok")
+			p.reportLifecycleStarted()
 		}
 	}
 	go retryFn()
@@ -859,160 +916,11 @@ func (p *PlatformAdapterOnebot) startConnection() error {
 				} else {
 					p.logger.Errorf("启动服务器失败: %v", err)
 				}
-				_ = p.sm.Event(context.Background(), "connect_fail")
+				p.reportLifecycleFailed(err)
 			}
 		}()
 		return nil
 	default:
 		return fmt.Errorf("未知的连接模式: %s", p.Mode)
 	}
-}
-
-// retryConnect 重试连接方法
-func (p *PlatformAdapterOnebot) retryConnect() {
-	// 检查适配器是否已被禁用
-	if !p.desiredEnabled {
-		p.logger.Info("适配器已被禁用，取消重连")
-		return
-	}
-
-	p.retryMutex.Lock()
-	if p.isRetrying {
-		p.retryMutex.Unlock()
-		return // 已经在重试中，避免重复重试
-	}
-	p.isRetrying = true
-	p.retryMutex.Unlock()
-
-	defer func() {
-		p.retryMutex.Lock()
-		p.isRetrying = false
-		p.retryAttempts = 0
-		p.retryMutex.Unlock()
-	}()
-
-	const maxRetries = 5
-	const baseDelay = 2 * time.Second
-
-	err := retry.Do(
-		func() error {
-			// 在每次重试前再次检查适配器是否已被禁用
-			if !p.desiredEnabled {
-				return errors.New("适配器已被禁用，停止重连")
-			}
-
-			p.retryMutex.Lock()
-			p.retryAttempts++
-			currentAttempt := p.retryAttempts
-			p.retryMutex.Unlock()
-
-			// 计算下次重试时间（指数退避）
-			nextRetryDelay := time.Duration(1<<(currentAttempt-1)) * baseDelay
-			if currentAttempt < maxRetries {
-				p.logger.Infof("尝试重新连接 OneBot [%d/%d]，下次重试间隔: %v", currentAttempt, maxRetries, nextRetryDelay)
-			} else {
-				p.logger.Infof("尝试重新连接 OneBot [%d/%d]，最后一次尝试", currentAttempt, maxRetries)
-			}
-
-			// 调用startConnection重新建立连接，确保遵循连接互斥锁机制
-			return p.startConnection()
-		},
-		retry.Attempts(maxRetries),
-		retry.Delay(baseDelay),
-		retry.DelayType(retry.BackOffDelay),
-		retry.OnRetry(func(n uint, err error) {
-			// 在重试前再次检查适配器是否已被禁用
-			if !p.desiredEnabled {
-				p.logger.Info("适配器已被禁用，停止重试")
-				return
-			}
-			nextDelay := time.Duration(1<<n) * baseDelay
-			p.logger.Warnf("重连失败 (第%d次): %v，%v后进行下次重试", n+1, err, nextDelay)
-		}),
-	)
-
-	if err != nil {
-		// 检查是否是因为适配器被禁用而失败
-		if strings.Contains(err.Error(), "适配器已被禁用") {
-			p.logger.Info("重连已停止：适配器被禁用")
-		} else {
-			p.logger.Errorf("重连最终失败，已达到最大重试次数 %d: %v", maxRetries, err)
-			p.EndPoint.State = StateConnectionFailed
-		}
-	} else {
-		p.logger.Infof("OneBot 重连成功")
-		// 重置重试状态
-		p.retryMutex.Lock()
-		p.retryAttempts = 0
-		p.retryMutex.Unlock()
-	}
-}
-
-func (p *PlatformAdapterOnebot) updateAndSave() {
-	session := p.EndPoint.Session
-	if session == nil || session.Parent == nil {
-		return
-	}
-	d := session.Parent
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-}
-
-func (p *PlatformAdapterOnebot) ensureFSM() {
-	if p.sm != nil {
-		return
-	}
-	p.sm = loopfsm.NewFSM(
-		"disconnected",
-		loopfsm.Events{
-			{Name: "enable", Src: []string{"disconnected", "failed"}, Dst: "connecting"},
-			{Name: "connect_ok", Src: []string{"connecting"}, Dst: "connected"},
-			{Name: "connect_fail", Src: []string{"connecting"}, Dst: "failed"},
-			{Name: "disable", Src: []string{"connecting", "connected", "failed", "disconnected"}, Dst: "disconnected"},
-			{Name: "connection_lost", Src: []string{"connected"}, Dst: "connecting"},
-		},
-		loopfsm.Callbacks{
-			"enter_connecting":   p.cbEnterConnecting,
-			"enter_connected":    p.cbEnterConnected,
-			"enter_failed":       p.cbEnterFailed,
-			"enter_disconnected": p.cbEnterDisconnected,
-			"after_disable":      p.cbAfterDisable,
-		},
-	)
-}
-
-func (p *PlatformAdapterOnebot) cbEnterConnecting(_ context.Context, _ *loopfsm.Event) {
-	p.EndPoint.State = StateConnecting
-	// Enable 表示“用户期望启用”，不应由连接成功与否决定；否则连接中/失败会把配置写成禁用，重启后不会自动启动。
-	p.EndPoint.Enable = p.desiredEnabled
-	p.updateAndSave()
-	if err := p.startConnection(); err != nil {
-		_ = p.sm.Event(context.Background(), "connect_fail")
-	}
-}
-
-func (p *PlatformAdapterOnebot) cbEnterConnected(_ context.Context, _ *loopfsm.Event) {
-	p.EndPoint.State = StateConnected
-	p.EndPoint.Enable = true
-	p.updateAndSave()
-}
-
-func (p *PlatformAdapterOnebot) cbEnterFailed(_ context.Context, _ *loopfsm.Event) {
-	p.EndPoint.State = StateConnectionFailed
-	// 连接失败不等于用户禁用；保持 Enable 不变，避免持久化成“禁用”导致重启后不再自动连接。
-	p.EndPoint.Enable = p.desiredEnabled
-	p.updateAndSave()
-	if p.desiredEnabled {
-		go p.retryConnect()
-	}
-}
-
-func (p *PlatformAdapterOnebot) cbEnterDisconnected(_ context.Context, _ *loopfsm.Event) {
-	p.EndPoint.State = StateDisconnected
-	p.EndPoint.Enable = false
-	p.updateAndSave()
-}
-
-func (p *PlatformAdapterOnebot) cbAfterDisable(_ context.Context, _ *loopfsm.Event) {
-	p.cleanupResources()
 }

--- a/dice/platform_adapter_onebot_helper.go
+++ b/dice/platform_adapter_onebot_helper.go
@@ -1,10 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 type AddOnebotEcho struct {
 	Token         string
@@ -38,14 +34,8 @@ func NewOnebotConnItem(v AddOnebotEcho) *EndPointInfo {
 func ServePureOnebot(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "QQ" {
-		conn := ep.Adapter.(*PlatformAdapterOnebot)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Pure Onebot V11尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Errorf("连接Pure Onebot V11失败")
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -606,7 +606,7 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectFailOnLoginInfoError(t *tes
 	defer cleanup()
 
 	reporter := newOnebotLifecycleReporter()
-	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	lifecycleCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	pa.setLifecycleRun(lifecycleCtx, reporter)
 	sleepDurations := make(chan time.Duration, 1)
@@ -644,7 +644,7 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectOkAndSetsEndpoint(t *testin
 	defer cleanup()
 
 	reporter := newOnebotLifecycleReporter()
-	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	lifecycleCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	pa.setLifecycleRun(lifecycleCtx, reporter)
 	sleepDurations := make(chan time.Duration, 1)
@@ -714,7 +714,7 @@ func TestPureOnebotScheduleLoginInfoRetryGuardsBeforeSleeping(t *testing.T) {
 			defer cleanup()
 
 			reporter := newOnebotLifecycleReporter()
-			lifecycleCtx, cancel := context.WithCancel(context.Background())
+			lifecycleCtx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			pa.setLifecycleRun(lifecycleCtx, reporter)
 			sleepDurations := make(chan time.Duration, 1)
@@ -744,7 +744,7 @@ func TestPureOnebotScheduleLoginInfoRetryRechecksGuardsAfterSleeping(t *testing.
 	defer cleanup()
 
 	reporter := newOnebotLifecycleReporter()
-	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	lifecycleCtx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	pa.setLifecycleRun(lifecycleCtx, reporter)
 	sleepDurations := make(chan time.Duration, 1)

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -11,7 +11,6 @@ import (
 
 	socketio "github.com/PaienNate/pineutil/evsocket/v2"
 	"github.com/bytedance/sonic"
-	loopfsm "github.com/looplab/fsm"
 	"github.com/maypok86/otter"
 	"github.com/panjf2000/ants/v2"
 	"github.com/tidwall/gjson"
@@ -207,28 +206,41 @@ func newPureOnebotTestAdapter(t *testing.T) (*Dice, *PlatformAdapterOnebot, *one
 	return d, pa, em, cleanupAll
 }
 
-func newPureOnebotRetryFSM(eventCh chan string) *loopfsm.FSM {
-	return loopfsm.NewFSM(
-		"connecting",
-		loopfsm.Events{
-			{Name: "connect_ok", Src: []string{"connecting"}, Dst: "connected"},
-			{Name: "connect_fail", Src: []string{"connecting"}, Dst: "failed"},
-		},
-		loopfsm.Callbacks{
-			"enter_connected": func(_ context.Context, _ *loopfsm.Event) {
-				select {
-				case eventCh <- "connect_ok":
-				default:
-				}
-			},
-			"enter_failed": func(_ context.Context, _ *loopfsm.Event) {
-				select {
-				case eventCh <- "connect_fail":
-				default:
-				}
-			},
-		},
-	)
+type onebotLifecycleReporter struct {
+	started chan struct{}
+	failed  chan error
+	closed  chan error
+}
+
+func newOnebotLifecycleReporter() *onebotLifecycleReporter {
+	return &onebotLifecycleReporter{
+		started: make(chan struct{}, 1),
+		failed:  make(chan error, 1),
+		closed:  make(chan error, 1),
+	}
+}
+
+func (r *onebotLifecycleReporter) Generation() uint64 { return 1 }
+
+func (r *onebotLifecycleReporter) Started() {
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+}
+
+func (r *onebotLifecycleReporter) Failed(err error) {
+	select {
+	case r.failed <- err:
+	default:
+	}
+}
+
+func (r *onebotLifecycleReporter) Closed(err error) {
+	select {
+	case r.closed <- err:
+	default:
+	}
 }
 
 func TestPureOnebotFriendRequestUsesCanonicalUserIDForBlacklist(t *testing.T) {
@@ -593,10 +605,11 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectFailOnLoginInfoError(t *tes
 	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
 
-	events := make(chan string, 2)
+	reporter := newOnebotLifecycleReporter()
+	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pa.setLifecycleRun(lifecycleCtx, reporter)
 	sleepDurations := make(chan time.Duration, 1)
-	pa.desiredEnabled = true
-	pa.sm = newPureOnebotRetryFSM(events)
 	pa.loginInitRetrySleep = func(delay time.Duration) {
 		select {
 		case sleepDurations <- delay:
@@ -617,16 +630,12 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectFailOnLoginInfoError(t *tes
 	}
 
 	select {
-	case event := <-events:
-		if event != "connect_fail" {
-			t.Fatalf("expected connect_fail event, got %q", event)
+	case err := <-reporter.failed:
+		if !errors.Is(err, em.loginInfoErr) {
+			t.Fatalf("expected login-info error, got %v", err)
 		}
 	case <-time.After(1 * time.Second):
-		t.Fatal("expected connect_fail event")
-	}
-
-	if got := pa.sm.Current(); got != "failed" {
-		t.Fatalf("expected FSM to transition to failed, got %q", got)
+		t.Fatal("expected lifecycle failure report")
 	}
 }
 
@@ -634,10 +643,11 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectOkAndSetsEndpoint(t *testin
 	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
 
-	events := make(chan string, 2)
+	reporter := newOnebotLifecycleReporter()
+	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pa.setLifecycleRun(lifecycleCtx, reporter)
 	sleepDurations := make(chan time.Duration, 1)
-	pa.desiredEnabled = true
-	pa.sm = newPureOnebotRetryFSM(events)
 	pa.loginInitRetrySleep = func(delay time.Duration) {
 		select {
 		case sleepDurations <- delay:
@@ -661,16 +671,9 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectOkAndSetsEndpoint(t *testin
 	}
 
 	select {
-	case event := <-events:
-		if event != "connect_ok" {
-			t.Fatalf("expected connect_ok event, got %q", event)
-		}
+	case <-reporter.started:
 	case <-time.After(1 * time.Second):
-		t.Fatal("expected connect_ok event")
-	}
-
-	if got := pa.sm.Current(); got != "connected" {
-		t.Fatalf("expected FSM to transition to connected, got %q", got)
+		t.Fatal("expected lifecycle started report")
 	}
 	if pa.EndPoint.UserID != "QQ:123456" {
 		t.Fatalf("expected EndPoint.UserID to be set, got %q", pa.EndPoint.UserID)
@@ -683,23 +686,23 @@ func TestPureOnebotScheduleLoginInfoRetryEmitsConnectOkAndSetsEndpoint(t *testin
 func TestPureOnebotScheduleLoginInfoRetryGuardsBeforeSleeping(t *testing.T) {
 	tests := []struct {
 		name      string
-		configure func(pa *PlatformAdapterOnebot)
+		configure func(pa *PlatformAdapterOnebot, cancel context.CancelFunc)
 	}{
 		{
-			name: "disabled adapter",
-			configure: func(pa *PlatformAdapterOnebot) {
-				pa.desiredEnabled = false
+			name: "cancelled lifecycle",
+			configure: func(_ *PlatformAdapterOnebot, cancel context.CancelFunc) {
+				cancel()
 			},
 		},
 		{
 			name: "nil emitter",
-			configure: func(pa *PlatformAdapterOnebot) {
+			configure: func(pa *PlatformAdapterOnebot, _ context.CancelFunc) {
 				pa.sendEmitter = nil
 			},
 		},
 		{
 			name: "nil ctx",
-			configure: func(pa *PlatformAdapterOnebot) {
+			configure: func(pa *PlatformAdapterOnebot, _ context.CancelFunc) {
 				pa.ctx = nil
 			},
 		},
@@ -710,17 +713,18 @@ func TestPureOnebotScheduleLoginInfoRetryGuardsBeforeSleeping(t *testing.T) {
 			_, pa, _, cleanup := newPureOnebotTestAdapter(t)
 			defer cleanup()
 
-			events := make(chan string, 1)
+			reporter := newOnebotLifecycleReporter()
+			lifecycleCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			pa.setLifecycleRun(lifecycleCtx, reporter)
 			sleepDurations := make(chan time.Duration, 1)
-			pa.desiredEnabled = true
-			pa.sm = newPureOnebotRetryFSM(events)
 			pa.loginInitRetrySleep = func(delay time.Duration) {
 				select {
 				case sleepDurations <- delay:
 				default:
 				}
 			}
-			tc.configure(pa)
+			tc.configure(pa, cancel)
 
 			pa.scheduleLoginInfoRetry()
 
@@ -730,15 +734,7 @@ func TestPureOnebotScheduleLoginInfoRetryGuardsBeforeSleeping(t *testing.T) {
 			case <-time.After(100 * time.Millisecond):
 			}
 
-			select {
-			case event := <-events:
-				t.Fatalf("expected no FSM event, got %q", event)
-			case <-time.After(100 * time.Millisecond):
-			}
-
-			if got := pa.sm.Current(); got != "connecting" {
-				t.Fatalf("expected FSM to remain connecting, got %q", got)
-			}
+			assertNoOnebotLifecycleReport(t, reporter)
 		})
 	}
 }
@@ -747,12 +743,13 @@ func TestPureOnebotScheduleLoginInfoRetryRechecksGuardsAfterSleeping(t *testing.
 	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
 
-	events := make(chan string, 1)
+	reporter := newOnebotLifecycleReporter()
+	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pa.setLifecycleRun(lifecycleCtx, reporter)
 	sleepDurations := make(chan time.Duration, 1)
-	pa.desiredEnabled = true
-	pa.sm = newPureOnebotRetryFSM(events)
 	pa.loginInitRetrySleep = func(delay time.Duration) {
-		pa.desiredEnabled = false
+		cancel()
 		select {
 		case sleepDurations <- delay:
 		default:
@@ -776,20 +773,25 @@ func TestPureOnebotScheduleLoginInfoRetryRechecksGuardsAfterSleeping(t *testing.
 		t.Fatal("expected retry sleep hook to be invoked")
 	}
 
-	select {
-	case event := <-events:
-		t.Fatalf("expected no FSM event after desiredEnabled changed during sleep, got %q", event)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	if got := pa.sm.Current(); got != "connecting" {
-		t.Fatalf("expected FSM to remain connecting, got %q", got)
-	}
+	assertNoOnebotLifecycleReport(t, reporter)
 	if pa.EndPoint.UserID != originalUserID {
 		t.Fatalf("expected EndPoint.UserID to remain %q, got %q", originalUserID, pa.EndPoint.UserID)
 	}
 	if pa.EndPoint.Nickname != originalNickname {
 		t.Fatalf("expected EndPoint.Nickname to remain %q, got %q", originalNickname, pa.EndPoint.Nickname)
+	}
+}
+
+func assertNoOnebotLifecycleReport(t *testing.T, reporter *onebotLifecycleReporter) {
+	t.Helper()
+	select {
+	case <-reporter.started:
+		t.Fatal("unexpected lifecycle started report")
+	case <-reporter.failed:
+		t.Fatal("unexpected lifecycle failed report")
+	case <-reporter.closed:
+		t.Fatal("unexpected lifecycle closed report")
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -33,6 +33,7 @@ type onebotTestEmitter struct {
 	loginInfoErr   error
 	sendPvtCh      chan time.Time
 	sendGrCh       chan time.Time
+	lastGrID       int64
 }
 
 type friendReqCall struct {
@@ -60,7 +61,8 @@ func (m *onebotTestEmitter) SendPvtMsg(context.Context, int64, schema.MessageCha
 	return &emitterTypes.SendMsgRes{}, nil
 }
 
-func (m *onebotTestEmitter) SendGrMsg(context.Context, int64, schema.MessageChain) (*emitterTypes.SendMsgRes, error) {
+func (m *onebotTestEmitter) SendGrMsg(_ context.Context, groupID int64, _ schema.MessageChain) (*emitterTypes.SendMsgRes, error) {
+	m.lastGrID = groupID
 	if m.sendGrCh != nil {
 		select {
 		case m.sendGrCh <- time.Now():
@@ -829,6 +831,7 @@ func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenGroupMissing(t *testing.T) {
 
 	core, observed := observer.New(zapcore.InfoLevel)
 	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Logger = pa.logger
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
 
@@ -868,6 +871,7 @@ func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenDisabled(t *testing.T) {
 
 	core, observed := observer.New(zapcore.InfoLevel)
 	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Logger = pa.logger
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
 
@@ -911,6 +915,7 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 
 	core, observed := observer.New(zapcore.InfoLevel)
 	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Logger = pa.logger
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
 
@@ -920,6 +925,10 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 		GroupWelcomeMessage: "欢迎新人",
 		DiceIDExistsMap:     new(SyncMap[string, bool]),
 	})
+
+	oldLastWelcome := lastGroupMemberWelcome
+	defer func() { lastGroupMemberWelcome = oldLastWelcome }()
+	lastGroupMemberWelcome = nil
 
 	req := gjson.Parse(`{
 		"post_type":"notice",
@@ -941,6 +950,10 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 		t.Fatal("expected welcome message to be sent")
 	}
 
+	if em.lastGrID != 77777 {
+		t.Fatalf("expected welcome sent to normalized group 77777, got %d", em.lastGrID)
+	}
+
 	if len(observed.FilterMessageSnippet("need_welcome=true").All()) != 1 {
 		t.Fatalf("expected need_welcome=true log, got %d", len(observed.FilterMessageSnippet("need_welcome=true").All()))
 	}
@@ -957,6 +970,64 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 		!strings.Contains(sendLog, "user_id=QQ:12345") ||
 		!strings.Contains(sendLog, `text="欢迎新人"`) {
 		t.Fatalf("unexpected welcome send log: %q", sendLog)
+	}
+}
+
+func TestPureOnebotHandleJoinGroupDeduplicatesRepeatedEvent(t *testing.T) {
+	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	pa.logger = zap.New(core).Sugar()
+	pa.EndPoint.Session.Parent.Logger = pa.logger
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
+
+	pa.EndPoint.Session.ServiceAtNew.Store("QQ-Group:88888", &GroupInfo{
+		GroupID:             "QQ-Group:88888",
+		ShowGroupWelcome:    true,
+		GroupWelcomeMessage: "欢迎新人",
+		DiceIDExistsMap:     new(SyncMap[string, bool]),
+	})
+
+	oldLastWelcome := lastGroupMemberWelcome
+	defer func() { lastGroupMemberWelcome = oldLastWelcome }()
+	lastGroupMemberWelcome = nil
+
+	req := gjson.Parse(`{
+		"post_type":"notice",
+		"notice_type":"group_increase",
+		"group_id":88888,
+		"user_id":22222,
+		"self_id":54321,
+		"time": 2,
+		"message": []
+	}`)
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error for first event: %v", err)
+	}
+
+	select {
+	case <-em.sendGrCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected welcome message to be sent for first event")
+	}
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error for repeated event: %v", err)
+	}
+
+	waitPureOnebotInfoLog(t, observed, "reason=duplicate_event")
+
+	if len(observed.FilterMessageSnippet("need_welcome=true").All()) != 1 {
+		t.Fatalf("expected exactly one need_welcome=true log, got %d", len(observed.FilterMessageSnippet("need_welcome=true").All()))
+	}
+	if len(observed.FilterMessageSnippet("reason=duplicate_event").All()) != 1 {
+		t.Fatalf("expected one duplicate_event reason log, got %d", len(observed.FilterMessageSnippet("reason=duplicate_event").All()))
+	}
+	if len(observed.FilterMessageSnippet("发送迎新消息").All()) != 1 {
+		t.Fatalf("expected exactly one welcome send log, got %d", len(observed.FilterMessageSnippet("发送迎新消息").All()))
 	}
 }
 

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -310,37 +310,19 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 		})
 	} else {
 		p.logger.Infof("收到非自己的入群通知: group_id=%s user_id=%s", groupId, userId)
+		// 仅构造规范化消息后交由 IMSession.OnGroupMemberJoined 统一处理迎新：
+		// 群状态判断、玩家初始化、变量设置、模板渲染和发送循环均与 Milky 共用。
+		msg := &Message{
+			Time:        req.Get("time").Int(),
+			MessageType: "group",
+			Platform:    "QQ",
+			GroupID:     groupId,
+			Sender: SenderBase{
+				UserID: userId,
+			},
+		}
 		_ = p.submitAsync(func() {
-			time.Sleep(1 * time.Second) // 避免是正在拉人进群的情况（此时会出现大量的迎新），先等一下再取数据
-			targetGroupID := groupId
-			group, ok := ctx.Session.ServiceAtNew.Load(targetGroupID)
-			needWelcome := false
-			reason := "group_not_loaded"
-			if ok && group.ShowGroupWelcome {
-				needWelcome = true
-				reason = "welcome_enabled"
-			} else if ok {
-				reason = "welcome_disabled"
-			}
-			p.logger.Infof("检查是否需要迎新: need_welcome=%t reason=%s group_id=%s user_id=%s", needWelcome, reason, targetGroupID, userId)
-			if !needWelcome {
-				return
-			}
-
-			ctx.Group = group
-			ctx.Player = &GroupPlayerInfo{}
-			uidRaw := req.Get("user_id").String()
-			VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
-			VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
-			stdID := userId
-			VarSetValueStr(ctx, "$t帐号ID", stdID)
-			VarSetValueStr(ctx, "$t账号ID", stdID)
-			text := DiceFormat(ctx, group.GroupWelcomeMessage)
-			p.logger.Infof("发送迎新消息: group_id=%s user_id=%s text=%q", targetGroupID, userId, text)
-			for _, i := range ctx.SplitText(text) {
-				doSleepQQ(ctx)
-				p.SendToGroup(ctx, targetGroupID, strings.TrimSpace(i), "")
-			}
+			ctx.EndPoint.Session.OnGroupMemberJoined(ctx, msg)
 		})
 	}
 

--- a/dice/platform_adapter_qq_helper.go
+++ b/dice/platform_adapter_qq_helper.go
@@ -1,254 +1,35 @@
 package dice
 
-import (
-	"time"
-)
-
+// ServeQQ is retained as the compatibility hook used by built-in QQ process
+// helpers. Normal endpoint startup must enter through StartEndpointLifecycle.
+// When a built-in process becomes ready, this function performs one protocol
+// websocket attempt inside the already active supervisor generation.
 func ServeQQ(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
-	if ep.Platform != "QQ" {
+	if ep == nil || ep.Platform != "QQ" {
+		return
+	}
+	ep.BindRuntime(d.ImSession)
+
+	if ep.lifecycle == nil || ep.State != StateConnecting {
+		_ = StartEndpointLifecycle(d, ep)
 		return
 	}
 
-	switch ep.ProtocolType {
-	case "walle-q":
-		conn := ep.Adapter.(*PlatformAdapterWalleQ)
-		serverWalleQ(d, ep, conn)
-
-	case "red":
-		conn := ep.Adapter.(*PlatformAdapterRed)
-		serverRed(d, ep, conn)
-
-	case "satori":
-		conn := ep.Adapter.(*PlatformAdapterSatori)
-		serverSatori(d, ep, conn)
-
-	case "official":
-		conn := ep.Adapter.(*PlatformAdapterOfficialQQ)
-		serverOfficialQQ(d, ep, conn)
-	case "onebot":
-		fallthrough
-	default: // onebot 作为默认情况
-		conn := ep.Adapter.(*PlatformAdapterGocq)
-		serverGocq(d, ep, conn)
-	}
+	startQQProtocolConnection(d, ep)
 }
 
-func serverGocq(d *Dice, ep *EndPointInfo, conn *PlatformAdapterGocq) {
-	if conn.diceServing {
+// startQQProtocolConnection performs exactly one protocol connection attempt
+// after a built-in QQ process has exposed its websocket endpoint.
+func startQQProtocolConnection(d *Dice, ep *EndPointInfo) {
+	if ep == nil || ep.Adapter == nil {
 		return
 	}
-	conn.diceServing = true
-
-	ep.Enable = true
-	ep.State = 2 // 连接中
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-
-	checkQuit := func() bool {
-		if conn.GoCqhttpState == StateCodeInLoginDeviceLock {
-			d.Logger.Infof("检测到设备锁流程，暂时不再连接")
-			ep.State = 0
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-			return true
-		}
-		if !conn.diceServing {
-			// 退出连接
-			d.Logger.Infof("检测到连接关闭，不再进行此onebot服务的重连: <%s>(%s)", ep.Nickname, ep.UserID)
-			return true
-		}
-		if conn.GoCqhttpState == StateCodeLoginFailed {
-			d.Logger.Infof("检测到登录失败，不再进行此onebot服务的重连: <%s>(%s)", ep.Nickname, ep.UserID)
-			return true
-		}
-		if !ep.Enable {
-			d.Logger.Infof("检测到账号被禁用，不再进行此onebot服务的重连: <%s>(%s)", ep.Nickname, ep.UserID)
-			return true
-		}
-		return false
-	}
-
-	conn.reconnectTimes = 0
-	for !checkQuit() {
-		// 骰子开始连接
-		d.Logger.Infof("开始连接 onebot 服务，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, conn.reconnectTimes, 5)
-		ret := ep.Adapter.Serve()
-
-		if ret == 0 {
-			break
-		}
-
-		if checkQuit() {
-			break
-		}
-
-		if conn.GoCqhttpState == StateCodeInLogin || conn.GoCqhttpState == StateCodeInLoginQrCode {
-			time.Sleep(15 * time.Second)
-			continue
-		}
-
-		conn.reconnectTimes++
-		if conn.reconnectTimes > 5 {
-			d.Logger.Infof("onebot 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			ep.State = 0
-			conn.GoCqhttpState = StateCodeLoginFailed
-			break
-		}
-
-		time.Sleep(15 * time.Second)
-	}
-
-	conn.diceServing = false
-}
-
-func serverWalleQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterWalleQ) {
-	if conn.DiceServing {
-		return
-	}
-	conn.DiceServing = true
-	ep.Enable = true
-	ep.State = 2 // 连接中
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-
-	checkQuit := func() bool {
-		if conn.WalleQState == StateCodeInLoginDeviceLock {
-			d.Logger.Infof("检测到设备锁流程，暂时不再连接")
-			ep.State = 0
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-			return true
-		} // 暂时去掉设备锁检查
-		if !conn.DiceServing {
-			// 退出连接
-			d.Logger.Infof("检测到连接关闭，不再进行此onebot服务的重连: <%s>(%s)", ep.Nickname, ep.UserID)
-			return true
-		}
-		return false
-	}
-
-	waitTimes := 0
-	for !checkQuit() {
-		// 骰子开始连接
-		d.Logger.Infof("开始连接 onebot 服务，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
-		ret := ep.Adapter.Serve()
-
-		if ret == 0 {
-			break
-		}
-
-		if checkQuit() {
-			break
-		}
-
-		waitTimes++
-		if waitTimes > 5 {
-			d.Logger.Infof("onebot 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			conn.DiceServing = false
-			break
-		}
-
-		time.Sleep(15 * time.Second)
-	}
-}
-
-func serverRed(d *Dice, ep *EndPointInfo, conn *PlatformAdapterRed) {
-	if conn.DiceServing {
-		return
-	}
-	conn.DiceServing = true
-
-	ep.Enable = true
-	ep.State = 2 // 连接中
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-	waitTimes := 0
-
-	for {
-		// 骰子开始连接
-		d.Logger.Infof("开始连接 red 服务，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
-		ret := ep.Adapter.Serve()
-
-		if ret == 0 {
-			break
-		}
-
-		waitTimes += 1
-		if waitTimes > 5 {
-			d.Logger.Infof("red 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			conn.DiceServing = false
-			break
-		}
-
-		time.Sleep(15 * time.Second)
-	}
-}
-
-func serverSatori(d *Dice, ep *EndPointInfo, conn *PlatformAdapterSatori) {
-	if conn.DiceServing {
-		return
-	}
-	conn.DiceServing = true
-
-	ep.Enable = true
-	ep.State = 2 // 连接中
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-	waitTimes := 0
-
-	for ep.State == 2 {
-		// 骰子开始连接
-		d.Logger.Infof("开始连接 satori 服务，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
-		ret := ep.Adapter.Serve()
-
-		if ret == 0 {
-			break
-		}
-
-		waitTimes += 1
-		if waitTimes > 5 {
-			d.Logger.Infof("satori 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			conn.DiceServing = false
-			break
-		}
-
-		time.Sleep(15 * time.Second)
-	}
-}
-
-func serverOfficialQQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterOfficialQQ) {
-	// Ctx 非空表示会话已经建立或正在运行，不能重复启动并覆盖端点状态。
-	if conn.Ctx != nil {
-		return
-	}
-	if conn.DiceServing {
-		return
-	}
-	conn.DiceServing = true
-
-	ep.Enable = true
-	ep.State = 2 // 连接中
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-	waitTimes := 0
-
-	for {
-		// 骰子开始连接
-		d.Logger.Infof("开始连接 official qq，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
-		ret := ep.Adapter.Serve()
-
-		if ret == 0 {
-			break
-		}
-
-		waitTimes += 1
-		if waitTimes > 5 {
-			d.Logger.Infof("official qq 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			conn.DiceServing = false
-			break
-		}
-
-		time.Sleep(15 * time.Second)
+	ep.BindRuntime(d.ImSession)
+	switch conn := ep.Adapter.(type) {
+	case *PlatformAdapterGocq:
+		_ = conn.Serve()
+	case *PlatformAdapterWalleQ:
+		_ = conn.Serve()
 	}
 }

--- a/dice/platform_adapter_red.go
+++ b/dice/platform_adapter_red.go
@@ -2,8 +2,10 @@ package dice
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -349,6 +351,10 @@ type GroupMember struct {
 }
 
 func (pa *PlatformAdapterRed) Serve() int {
+	return pa.serveWithLifecycle(context.Background(), nil)
+}
+
+func (pa *PlatformAdapterRed) serveWithLifecycle(ctx context.Context, run EndpointRunReporter) int {
 	ep := pa.EndPoint
 	s := pa.EndPoint.Session
 	log := s.Parent.Logger
@@ -367,10 +373,10 @@ func (pa *PlatformAdapterRed) Serve() int {
 		Path:   "/api",
 	}
 	log.Infof("connecting to %s", wsUrl.String())
-	conn, resp, err := websocket.DefaultDialer.Dial(wsUrl.String(), nil)
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsUrl.String(), nil)
 	if err != nil {
 		log.Error("dial:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	defer resp.Body.Close()
@@ -378,7 +384,7 @@ func (pa *PlatformAdapterRed) Serve() int {
 		_ = conn.Close()
 	}(conn)
 	pa.conn = conn
-	pa.EndPoint.State = 2
+	pa.EndPoint.State = StateConnecting
 
 	// 鉴权
 	auth := &RedPack[RedConnectReq]{
@@ -389,20 +395,20 @@ func (pa *PlatformAdapterRed) Serve() int {
 	err = conn.WriteMessage(websocket.TextMessage, authData)
 	if err != nil {
 		log.Error("auth failed:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	_, authRespData, err := conn.ReadMessage()
 	if err != nil {
 		log.Error("auth failed:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	var authResp RedPack[RedConnectResp]
 	err = json.Unmarshal(authRespData, &authResp)
 	if err != nil {
 		log.Error("auth failed:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	log.Debugf("red auth resp:%+v", authResp)
@@ -410,7 +416,7 @@ func (pa *PlatformAdapterRed) Serve() int {
 	pa.wsUrl = &wsUrl
 	pa.httpUrl = &httpUrl
 	pa.RedVersion = authResp.Payload.Version
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 
 	// 获得用户信息
 	botInfo := pa.getBotInfo()
@@ -420,6 +426,9 @@ func (pa *PlatformAdapterRed) Serve() int {
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	pa.EndPoint.Session.Parent.Logger.Infof("red 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
+	if run != nil {
+		run.Started()
+	}
 
 	// 获得好友列表
 	refreshFriends := func() {
@@ -476,6 +485,14 @@ func (pa *PlatformAdapterRed) Serve() int {
 	for {
 		select {
 		case <-done:
+			if ctx == nil || ctx.Err() == nil {
+				if run != nil {
+					run.Closed(errors.New("red websocket closed"))
+				}
+			}
+			return 0
+		case <-ctx.Done():
+			return 0
 		case <-interrupt:
 			log.Debug("red interrupt")
 
@@ -489,41 +506,46 @@ func (pa *PlatformAdapterRed) Serve() int {
 			case <-done:
 			case <-time.After(time.Second):
 			}
+			return 0
 		}
 	}
 }
 
 func (pa *PlatformAdapterRed) DoRelogin() bool {
-	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 red 连接……")
-	pa.EndPoint.State = 0
-	pa.EndPoint.Enable = false
-	if pa.conn != nil {
-		_ = pa.conn.Close()
-	}
-	pa.conn = nil
-	return pa.Serve() == 0
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterRed) SetEnable(enable bool) {
-	d := pa.EndPoint.Session.Parent
-	e := pa.EndPoint
 	if enable {
-		e.Enable = true
-		pa.DiceServing = false
-
-		if pa.conn == nil {
-			go ServeQQ(d, e)
-		}
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		e.State = 0
-		e.Enable = false
-		if pa.conn != nil {
-			_ = pa.conn.Close()
-			pa.conn = nil
-		}
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
 	}
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
+}
+
+// LifecycleStart opens one Red websocket for the supervisor generation. The
+// blocking read loop reports Started/Closed through the generation reporter.
+func (pa *PlatformAdapterRed) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("red endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	_ = pa.LifecycleStop(ctx)
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 red 连接……")
+	if pa.serveWithLifecycle(ctx, run) != 0 {
+		return errors.New("red serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop closes the active Red websocket; the supervisor owns endpoint
+// state changes after this method returns.
+func (pa *PlatformAdapterRed) LifecycleStop(context.Context) error {
+	if pa.conn == nil {
+		return nil
+	}
+	err := pa.conn.Close()
+	pa.conn = nil
+	return err
 }
 
 func (pa *PlatformAdapterRed) QuitGroup(_ *MsgContext, id string) {

--- a/dice/platform_adapter_red.go
+++ b/dice/platform_adapter_red.go
@@ -527,7 +527,7 @@ func (pa *PlatformAdapterRed) SetEnable(enable bool) {
 // blocking read loop reports Started/Closed through the generation reporter.
 func (pa *PlatformAdapterRed) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("red endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("red endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	_ = pa.LifecycleStop(ctx)
 	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 red 连接……")

--- a/dice/platform_adapter_red_helper.go
+++ b/dice/platform_adapter_red_helper.go
@@ -1,10 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 func NewRedConnItem(host string, port int, token string) *EndPointInfo {
 	conn := new(EndPointInfo)
@@ -24,13 +20,7 @@ func NewRedConnItem(host string, port int, token string) *EndPointInfo {
 
 func ServeRed(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
-	conn := ep.Adapter.(*PlatformAdapterRed)
 	d.Logger.Infof("red 尝试连接")
-	if conn.Serve() == 0 {
-	} else {
-		d.Logger.Errorf("连接 red 服务失败")
-		ep.State = 3
-		d.LastUpdatedTime = time.Now().Unix()
-		d.Save(false)
-	}
+	ep.BindRuntime(d.ImSession)
+	_ = StartEndpointLifecycle(d, ep)
 }

--- a/dice/platform_adapter_satori.go
+++ b/dice/platform_adapter_satori.go
@@ -419,7 +419,7 @@ func (pa *PlatformAdapterSatori) SetEnable(enable bool) {
 // supervisor generation so stale connections cannot report into new runs.
 func (pa *PlatformAdapterSatori) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("satori endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("satori endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	_ = pa.LifecycleStop(ctx)
 	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 satori 连接，请稍后...")

--- a/dice/platform_adapter_satori.go
+++ b/dice/platform_adapter_satori.go
@@ -42,6 +42,13 @@ type PlatformAdapterSatori struct {
 }
 
 func (pa *PlatformAdapterSatori) Serve() int {
+	return pa.serveWithLifecycle(context.Background(), nil)
+}
+
+func (pa *PlatformAdapterSatori) serveWithLifecycle(ctx context.Context, run EndpointRunReporter) int {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	ep := pa.EndPoint
 	s := pa.EndPoint.Session
 	log := s.Parent.Logger
@@ -57,7 +64,7 @@ func (pa *PlatformAdapterSatori) Serve() int {
 		Host:   fmt.Sprintf("%s:%d", pa.Host, pa.Port),
 		Path:   fmt.Sprintf("/%s", pa.Version),
 	}
-	pa.Ctx, pa.CancelFunc = context.WithCancel(context.Background())
+	pa.Ctx, pa.CancelFunc = context.WithCancel(ctx)
 	defer func() {
 		if pa.CancelFunc != nil {
 			pa.CancelFunc()
@@ -68,12 +75,12 @@ func (pa *PlatformAdapterSatori) Serve() int {
 	conn, resp, err := websocket.DefaultDialer.DialContext(pa.Ctx, wsUrl.String(), nil)
 	if err != nil {
 		log.Error("dial:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	defer resp.Body.Close()
 	pa.conn = conn
-	pa.EndPoint.State = 2
+	pa.EndPoint.State = StateConnecting
 
 	// 鉴权
 	auth := &SatoriPayload[SatoriIdentify]{
@@ -84,21 +91,21 @@ func (pa *PlatformAdapterSatori) Serve() int {
 	err = conn.WriteMessage(websocket.TextMessage, authData)
 	if err != nil {
 		log.Error("auth failed:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 
 	_, authRespData, err := conn.ReadMessage()
 	if err != nil {
 		log.Error("auth failed:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	var authResp SatoriPayload[SatoriReady]
 	err = json.Unmarshal(authRespData, &authResp)
 	if err != nil {
 		log.Error("auth failed:", err)
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	}
 	log.Debugf("satori auth resp:%+v", authResp)
@@ -106,7 +113,7 @@ func (pa *PlatformAdapterSatori) Serve() int {
 	var login *SatoriLogin
 	if len(logins) < 1 {
 		log.Error("invalid satori login info")
-		pa.EndPoint.State = 3
+		pa.EndPoint.State = StateConnectionFailed
 		return 1
 	} else if len(logins) > 1 {
 		for _, loginResp := range logins {
@@ -117,7 +124,7 @@ func (pa *PlatformAdapterSatori) Serve() int {
 		}
 		if login == nil {
 			log.Error("invalid satori login info")
-			pa.EndPoint.State = 3
+			pa.EndPoint.State = StateConnectionFailed
 			return 1
 		}
 	} else {
@@ -126,7 +133,7 @@ func (pa *PlatformAdapterSatori) Serve() int {
 
 	pa.wsUrl = &wsUrl
 	pa.httpUrl = &httpUrl
-	pa.EndPoint.State = 1
+	pa.EndPoint.State = StateConnected
 	ep.UserID = formatDiceIDSatori(pa.Platform, login.SelfID)
 	if login.User != nil {
 		ep.Nickname = login.User.Name
@@ -134,6 +141,9 @@ func (pa *PlatformAdapterSatori) Serve() int {
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
 	log.Infof("satori 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
+	if run != nil {
+		run.Started()
+	}
 
 	go func() {
 		for {
@@ -150,6 +160,9 @@ func (pa *PlatformAdapterSatori) Serve() int {
 					if pa.CancelFunc != nil {
 						pa.CancelFunc()
 						pa.CancelFunc = nil
+					}
+					if pa.Ctx != nil && pa.Ctx.Err() == nil && run != nil {
+						run.Closed(err)
 					}
 					return
 				}
@@ -391,33 +404,44 @@ func (pa *PlatformAdapterSatori) refreshMembers(group SatoriGuild) {
 }
 
 func (pa *PlatformAdapterSatori) DoRelogin() bool {
-	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 satori 连接，请稍后...")
-	pa.EndPoint.State = 0
-	pa.EndPoint.Enable = false
-	if pa.CancelFunc != nil {
-		pa.CancelFunc()
-	}
-	return pa.Serve() == 0
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterSatori) SetEnable(enable bool) {
-	d := pa.EndPoint.Session.Parent
-	e := pa.EndPoint
 	if enable {
-		e.Enable = true
-		pa.DiceServing = false
-		if pa.conn == nil {
-			go ServeQQ(d, e)
-		}
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		e.State = 0
-		e.Enable = false
-		if pa.CancelFunc != nil {
-			pa.CancelFunc()
-		}
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
 	}
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
+}
+
+// LifecycleStart opens one Satori websocket and binds its context to the
+// supervisor generation so stale connections cannot report into new runs.
+func (pa *PlatformAdapterSatori) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("satori endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	_ = pa.LifecycleStop(ctx)
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 satori 连接，请稍后...")
+	if pa.serveWithLifecycle(ctx, run) != 0 {
+		return errors.New("satori serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop cancels heartbeat/read loops and closes the active Satori
+// websocket. Endpoint state is handled by EndpointLifecycleSupervisor.
+func (pa *PlatformAdapterSatori) LifecycleStop(context.Context) error {
+	if pa.CancelFunc != nil {
+		pa.CancelFunc()
+		pa.CancelFunc = nil
+	}
+	if pa.conn == nil {
+		return nil
+	}
+	err := pa.conn.Close()
+	pa.conn = nil
+	return err
 }
 
 func (pa *PlatformAdapterSatori) QuitGroup(ctx *MsgContext, _ string) {

--- a/dice/platform_adapter_satori_helper.go
+++ b/dice/platform_adapter_satori_helper.go
@@ -1,10 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 func NewSatoriConnItem(platform string, host string, port int, token string) *EndPointInfo {
 	conn := new(EndPointInfo)
@@ -26,14 +22,7 @@ func NewSatoriConnItem(platform string, host string, port int, token string) *En
 
 func ServeSatori(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
-	conn := ep.Adapter.(*PlatformAdapterSatori)
 	d.Logger.Infof("satori 尝试连接")
 	ep.BindRuntime(d.ImSession)
-	if conn.Serve() == 0 {
-	} else {
-		d.Logger.Errorf("连接 satori 服务失败")
-		ep.State = 3
-		d.LastUpdatedTime = time.Now().Unix()
-		d.Save(false)
-	}
+	_ = StartEndpointLifecycle(d, ep)
 }

--- a/dice/platform_adapter_sealchat.go
+++ b/dice/platform_adapter_sealchat.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -43,6 +44,10 @@ type PlatformAdapterSealChat struct {
 }
 
 func (pa *PlatformAdapterSealChat) Serve() int {
+	return pa.serveWithLifecycle(context.Background(), nil)
+}
+
+func (pa *PlatformAdapterSealChat) serveWithLifecycle(ctx context.Context, reporter EndpointRunReporter) int {
 	if !strings.HasPrefix(pa.ConnectURL, "ws://") && !strings.HasPrefix(pa.ConnectURL, "wss://") {
 		pa.ConnectURL = "ws://" + pa.ConnectURL
 	}
@@ -56,7 +61,17 @@ func (pa *PlatformAdapterSealChat) Serve() int {
 	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
-	pa.socketSetup()
+	pa.socketSetupWithLifecycle(reporter)
+	if reporter != nil {
+		// Stop normally arrives through LifecycleStop, but watching ctx prevents
+		// an abandoned async connect attempt from surviving cancellation.
+		go func(socket *gowebsocket.Socket) {
+			<-ctx.Done()
+			if pa.Socket == socket {
+				socket.Close()
+			}
+		}(&socket)
+	}
 	socket.Connect()
 	return 0
 }
@@ -72,11 +87,15 @@ func (pa *PlatformAdapterSealChat) _sendJSON(socket *gowebsocket.Socket, data an
 }
 
 func (pa *PlatformAdapterSealChat) socketSetup() {
+	pa.socketSetupWithLifecycle(nil)
+}
+
+func (pa *PlatformAdapterSealChat) socketSetupWithLifecycle(reporter EndpointRunReporter) {
 	ep := pa.EndPoint
 	log := pa.EndPoint.Session.Parent.Logger
 	socket := pa.Socket
 	socket.OnConnected = func(socket gowebsocket.Socket) {
-		ep.State = 2
+		ep.State = StateConnecting
 		ep.Enable = true
 
 		d := pa.EndPoint.Session.Parent
@@ -108,7 +127,7 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 				info := gatewayMsg.Body.(map[string]any)
 				if info["errorMsg"] != nil {
 					log.Infof("SealChat 连接失败: %s", info["errorMsg"])
-					ep.State = 3
+					ep.State = StateConnectionFailed
 				} else {
 					data := struct {
 						Body struct {
@@ -122,12 +141,15 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 						pa.UserID = data.Body.User.ID
 						ep.UserID = FormatDiceIDSealChat(data.Body.User.ID)
 						ep.Nickname = data.Body.User.Nick
-						ep.State = 1
+						ep.State = StateConnected
 						log.Infof("SealChat 连接成功: %s", ep.Nickname)
 
 						// 握手成功，通过验证
 						pa.RetryTimes = 0
 						pa.RetryTimesLimit = 15
+						if reporter != nil {
+							reporter.Started()
+						}
 					}
 
 					go func() {
@@ -179,21 +201,29 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
 		log.Errorf("SealChat websocket出现错误: %s", err)
 		pa.stopHeartbeat()
+		if reporter != nil {
+			reporter.Failed(err)
+			return
+		}
 		if !socket.IsConnected {
 			pa.Reconnecting = false
 			time.Sleep(time.Duration(10) * time.Second)
 			if !pa.tryReconnect(*pa.Socket) {
 				log.Errorf("短时间内连接失败次数过多，不再进行重连")
-				ep.State = 3
+				ep.State = StateConnectionFailed
 			}
 		}
 	}
 	socket.OnDisconnected = func(err error, socket gowebsocket.Socket) {
 		log.Info("与SealChat服务器断开连接，尝试进行重连")
 		pa.stopHeartbeat()
+		if reporter != nil {
+			reporter.Closed(err)
+			return
+		}
 		time.Sleep(time.Duration(2) * time.Second)
 		if !pa.tryReconnect(*pa.Socket) {
-			ep.State = 3
+			ep.State = StateConnectionFailed
 			log.Errorf("到达连接次数上限，不再进行重连")
 		}
 	}
@@ -465,50 +495,46 @@ func FormatDiceIDSealChatGroup(id string) string {
 }
 
 func (pa *PlatformAdapterSealChat) DoRelogin() bool {
-	log := pa.EndPoint.Session.Parent.Logger
-	pa.Reconnecting = true
-	if pa.Socket != nil {
-		pa.Socket.Close()
-	}
-
-	socket := gowebsocket.New(pa.ConnectURL)
-	log.Infof("SealChat 重新连接")
-	pa.Socket = &socket
-	pa.socketSetup()
-	socket.Connect()
-	pa.Reconnecting = false
-	return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterSealChat) SetEnable(enable bool) {
 	log := pa.EndPoint.Session.Parent.Logger
 	if enable {
-		pa.EndPoint.Enable = true
 		log.Infof("Sealchat 连接中")
-		if pa.Socket != nil && pa.Socket.IsConnected {
-			pa.Reconnecting = true
-			pa.Socket.Close()
-			socket := gowebsocket.New(pa.ConnectURL)
-			pa.Socket = &socket
-			pa.socketSetup()
-			socket.Connect()
-			pa.Reconnecting = false
-		} else {
-			pa.Reconnecting = true
-			socket := gowebsocket.New(pa.ConnectURL)
-			pa.Socket = &socket
-			pa.socketSetup()
-			socket.Connect()
-			pa.Reconnecting = false
+		if err := StartEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			log.Errorf("Sealchat 连接失败: %s", err.Error())
 		}
 	} else {
-		pa.EndPoint.Enable = false
-		pa.Reconnecting = true
-		if pa.Socket != nil && pa.Socket.IsConnected {
-			pa.Socket.Close()
+		if err := StopEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			log.Errorf("Sealchat 断开失败: %s", err.Error())
 		}
-		pa.Reconnecting = false
 	}
+}
+
+// LifecycleStart starts one SealChat websocket owned by the supervisor. In this
+// mode reconnect decisions are reported upward instead of handled locally.
+func (pa *PlatformAdapterSealChat) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	if pa.serveWithLifecycle(ctx, run) != 0 {
+		return fmt.Errorf("sealchat serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop closes the active SealChat socket and heartbeat for the current
+// supervisor generation.
+func (pa *PlatformAdapterSealChat) LifecycleStop(ctx context.Context) error {
+	pa.stopHeartbeat()
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	pa.Reconnecting = false
+	return ctx.Err()
 }
 
 func (pa *PlatformAdapterSealChat) sendAPIWithEcho(api string, data any) (string, chan any) {
@@ -859,14 +885,9 @@ func (pa *PlatformAdapterSealChat) registerCommands() {
 func ServeSealChat(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "SEALCHAT" {
-		conn := ep.Adapter.(*PlatformAdapterSealChat)
+		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("SealChat 尝试连接")
-		if conn.Serve() != 0 {
-			d.Logger.Errorf("连接SealChat服务失败")
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }
 

--- a/dice/platform_adapter_sealchat.go
+++ b/dice/platform_adapter_sealchat.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -520,7 +521,7 @@ func (pa *PlatformAdapterSealChat) LifecycleStart(ctx context.Context, run Endpo
 		pa.Socket = nil
 	}
 	if pa.serveWithLifecycle(ctx, run) != 0 {
-		return fmt.Errorf("sealchat serve failed")
+		return errors.New("sealchat serve failed")
 	}
 	return nil
 }

--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -25,6 +25,10 @@ type PlatformAdapterSlack struct {
 }
 
 func (pa *PlatformAdapterSlack) Serve() int {
+	return pa.serveWithLifecycle(context.Background(), nil)
+}
+
+func (pa *PlatformAdapterSlack) serveWithLifecycle(ctx context.Context, reporter EndpointRunReporter) int {
 	ep := pa.EndPoint
 	s := ep.Session
 	log := s.Parent.Logger
@@ -33,7 +37,7 @@ func (pa *PlatformAdapterSlack) Serve() int {
 	sh := sm.NewSocketmodeHandler(client)
 	// Connect
 	sh.Handle(sm.EventTypeConnecting, func(event *sm.Event, client *sm.Client) {
-		ep.State = 2
+		ep.State = StateConnecting
 		log.Info("使用 Socket Mode/套接字模式 连接到 Slack 中")
 	})
 	sh.Handle(sm.EventTypeConnected, func(event *sm.Event, client *sm.Client) {
@@ -45,16 +49,25 @@ func (pa *PlatformAdapterSlack) Serve() int {
 		log.Infof("Slack 连接成功：账号<%s>(%s)", test.User, FormatDiceIDSlack(test.UserID))
 		pa.EndPoint.UserID = FormatDiceIDSlack(test.UserID)
 		pa.EndPoint.Nickname = test.User
-		ep.State = 1
+		ep.State = StateConnected
 		ep.Enable = true
+		if reporter != nil {
+			reporter.Started()
+		}
 	})
 	sh.Handle(sm.EventTypeConnectionError, func(event *sm.Event, client *sm.Client) {
-		ep.State = 0
+		ep.State = StateDisconnected
 		log.Errorf("Slack 账号 <%s> 连接失败: %v", pa.EndPoint.UserID, event.Data)
+		if reporter != nil {
+			reporter.Failed(fmt.Errorf("slack connection error: %v", event.Data))
+		}
 	})
 	sh.Handle(sm.EventTypeDisconnect, func(event *sm.Event, client *sm.Client) {
-		ep.State = 0
+		ep.State = StateDisconnected
 		log.Errorf("Slack 账号 <%s> 连接断开：%v", pa.EndPoint.UserID, event.Data)
+		if reporter != nil {
+			reporter.Closed(fmt.Errorf("slack disconnected: %v", event.Data))
+		}
 	})
 	sh.HandleEvents(se.AppMention, func(event *sm.Event, client *sm.Client) {
 		go client.Ack(*event.Request)
@@ -146,10 +159,13 @@ func (pa *PlatformAdapterSlack) Serve() int {
 	})
 	// Start
 	pa.Client = client
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	pa.cancel = cancel
 	err := sh.RunEventLoopContext(ctx)
 	if err != nil {
+		if reporter != nil && ctx.Err() == nil {
+			reporter.Closed(err)
+		}
 		log.Error("SlackEventLoopErr：", err.Error())
 		return 1
 	}
@@ -177,33 +193,39 @@ func (pa *PlatformAdapterSlack) SendFileToGroup(ctx *MsgContext, groupID string,
 }
 
 func (pa *PlatformAdapterSlack) DoRelogin() bool {
-	if pa.cancel != nil {
-		pa.cancel()
-	}
-	pa.Client = nil
-	pa.EndPoint.Enable = false
-	pa.EndPoint.State = 0
-	go pa.Serve()
-	return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterSlack) SetEnable(enable bool) {
 	if enable {
-		if pa.Client == nil {
-			go pa.Serve()
-		} else {
-			pa.Client = nil
-			pa.cancel = nil
-			go pa.Serve()
+		if err := StartEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			pa.EndPoint.Session.Parent.Logger.Errorf("启用Slack服务失败：%s", err.Error())
 		}
 	} else {
-		if pa.cancel != nil {
-			pa.cancel()
+		if err := StopEndpointLifecycle(nil, pa.EndPoint); err != nil {
+			pa.EndPoint.Session.Parent.Logger.Errorf("断开Slack服务失败：%s", err.Error())
 		}
-		pa.Client = nil
-		pa.EndPoint.Enable = false
-		pa.EndPoint.State = 0
 	}
+}
+
+// LifecycleStart runs one Socket Mode event loop owned by the supervisor. The
+// loop inherits the supervisor context so disable/relogin can cancel it.
+func (pa *PlatformAdapterSlack) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.serveWithLifecycle(ctx, run) != 0 {
+		return fmt.Errorf("slack serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop cancels the current Socket Mode loop before clearing pointers,
+// preventing the old loop from surviving a repeated enable.
+func (pa *PlatformAdapterSlack) LifecycleStop(ctx context.Context) error {
+	if pa.cancel != nil {
+		pa.cancel()
+	}
+	pa.cancel = nil
+	pa.Client = nil
+	return ctx.Err()
 }
 
 func (pa *PlatformAdapterSlack) QuitGroup(ctx *MsgContext, id string) {

--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -2,6 +2,7 @@ package dice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -212,7 +213,7 @@ func (pa *PlatformAdapterSlack) SetEnable(enable bool) {
 // loop inherits the supervisor context so disable/relogin can cancel it.
 func (pa *PlatformAdapterSlack) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.serveWithLifecycle(ctx, run) != 0 {
-		return fmt.Errorf("slack serve failed")
+		return errors.New("slack serve failed")
 	}
 	return nil
 }

--- a/dice/platform_adapter_slack_helper.go
+++ b/dice/platform_adapter_slack_helper.go
@@ -1,10 +1,6 @@
 package dice
 
-import (
-	"time"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 func NewSlackConnItem(at string, bt string) *EndPointInfo {
 	conn := new(EndPointInfo)
@@ -24,14 +20,8 @@ func NewSlackConnItem(at string, bt string) *EndPointInfo {
 func ServeSlack(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "SLACK" {
-		conn := ep.Adapter.(*PlatformAdapterSlack)
 		ep.BindRuntime(d.ImSession)
-		if conn.Serve() != 0 {
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-			d.Logger.Info("连接失败！")
-		}
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }
 

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -84,7 +85,7 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 	}
 	if err != nil {
 		pa.EndPoint.Session.Parent.Logger.Errorf("与Telegram服务进行连接时出错:%s", err.Error())
-		ep.State = 3
+		ep.State = StateConnectionFailed
 		ep.Enable = false
 		d := pa.EndPoint.Session.Parent
 		d.LastUpdatedTime = time.Now().Unix()
@@ -95,7 +96,7 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 	pa.IntentSession = bot
 	ep.UserID = FormatDiceIDTelegram(strconv.FormatInt(bot.Self.ID, 10))
 	ep.Nickname = bot.Self.UserName
-	ep.State = 1
+	ep.State = StateConnected
 	ep.Enable = true
 	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
@@ -361,40 +362,47 @@ func (pa *PlatformAdapterTelegram) MemberBan(_ string, _ string, _ int64) {}
 func (pa *PlatformAdapterTelegram) MemberKick(_ string, _ string) {}
 
 func (pa *PlatformAdapterTelegram) DoRelogin() bool {
-	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
-	if pa.IntentSession == nil {
-		go pa.Serve()
-		return true
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
+}
+
+func (pa *PlatformAdapterTelegram) SetEnable(enable bool) {
+	if enable {
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
+	} else {
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
 	}
+}
+
+// LifecycleStart creates one Telegram polling session for the current
+// supervisor generation. Any retry is scheduled by EndpointLifecycleSupervisor.
+func (pa *PlatformAdapterTelegram) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("telegram endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+	}
+	_ = pa.LifecycleStop(ctx)
+	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
+	if pa.Serve() != 0 {
+		return errors.New("telegram serve failed")
+	}
+	run.Started()
+	return nil
+}
+
+// LifecycleStop stops Telegram long polling for the active generation. The
+// shared supervisor owns endpoint state and persistence.
+func (pa *PlatformAdapterTelegram) LifecycleStop(context.Context) error {
 	if pa.IntentSession != nil {
 		pa.IntentSession.StopReceivingUpdates()
 		pa.IntentSession = nil
 	}
-	go pa.Serve()
-	return true
-}
-
-func (pa *PlatformAdapterTelegram) SetEnable(enable bool) {
-	ep := pa.EndPoint
-	if enable {
-		pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
-		if pa.IntentSession == nil {
-			go pa.Serve()
-			return
-		}
-		if pa.IntentSession != nil {
-			pa.IntentSession.StopReceivingUpdates()
-			pa.IntentSession = nil
-		}
-		go pa.Serve()
-	} else {
-		if pa.IntentSession != nil {
-			pa.IntentSession.StopReceivingUpdates()
-			pa.IntentSession = nil
-		}
-		pa.EndPoint.State = 0
-		ep.Enable = false
-	}
+	return nil
 }
 
 func (pa *PlatformAdapterTelegram) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -377,7 +377,7 @@ func (pa *PlatformAdapterTelegram) SetEnable(enable bool) {
 // supervisor generation. Any retry is scheduled by EndpointLifecycleSupervisor.
 func (pa *PlatformAdapterTelegram) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("telegram endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("telegram endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {

--- a/dice/platform_adapter_telegram_helper.go
+++ b/dice/platform_adapter_telegram_helper.go
@@ -20,9 +20,8 @@ func NewTelegramConnItem(token string, proxy string) *EndPointInfo {
 func ServeTelegram(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
 	if ep.Platform == "TG" {
-		conn := ep.Adapter.(*PlatformAdapterTelegram)
 		ep.BindRuntime(d.ImSession)
 		d.Logger.Infof("Telegram 尝试连接")
-		conn.Serve()
+		_ = StartEndpointLifecycle(d, ep)
 	}
 }

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -785,7 +785,7 @@ func (pa *PlatformAdapterWalleQ) SetEnable(enable bool) {
 // login helpers may complete asynchronously and report Started from callbacks.
 func (pa *PlatformAdapterWalleQ) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
 	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
-		return NewEndpointLifecycleFailure(errors.New("walle-q endpoint runtime is not bound"), LifecycleFailureStop)
+		return NewEndpointLifecycleError(errors.New("walle-q endpoint runtime is not bound"), LifecycleFailureStop)
 	}
 	if ctx != nil {
 		select {

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -1,7 +1,9 @@
 package dice
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -51,6 +54,42 @@ type PlatformAdapterWalleQ struct {
 	echoMap        *SyncMap[string, chan *EventWalleQBase] `yaml:"-"`
 	FileMap        *SyncMap[string, string]                // 记录上传文件后得到的 id
 	Implementation string                                  `json:"implementation" yaml:"implementation"`
+
+	lifecycleMu  sync.Mutex          `json:"-" yaml:"-"`
+	lifecycleRun EndpointRunReporter `json:"-" yaml:"-"`
+}
+
+func (pa *PlatformAdapterWalleQ) setLifecycleRun(run EndpointRunReporter) {
+	pa.lifecycleMu.Lock()
+	defer pa.lifecycleMu.Unlock()
+	pa.lifecycleRun = run
+}
+
+func (pa *PlatformAdapterWalleQ) reportLifecycleStarted() {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Started()
+	}
+}
+
+func (pa *PlatformAdapterWalleQ) reportLifecycleFailed(err error) {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Failed(err)
+	}
+}
+
+func (pa *PlatformAdapterWalleQ) reportLifecycleClosed(err error) {
+	pa.lifecycleMu.Lock()
+	run := pa.lifecycleRun
+	pa.lifecycleMu.Unlock()
+	if run != nil {
+		run.Closed(err)
+	}
 }
 
 type EventWalleQBase struct {
@@ -184,8 +223,9 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 	pa.Socket = &socket
 
 	socket.OnConnected = func(socket gowebsocket.Socket) {
-		ep.State = 1
+		ep.State = StateConnected
 		log.Info("onebot 连接成功")
+		pa.reportLifecycleStarted()
 	}
 
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
@@ -193,6 +233,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 		// refused 不算大事
 		log.Error("onebot connection error: ", err)
 		// }
+		pa.reportLifecycleFailed(err)
 		pa.InPackWalleQDisconnectedCH <- 2
 	}
 	var lastWelcome *LastWelcomeInfoWQ
@@ -297,7 +338,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 			}
 			// 连接成功事件
 			if event.DetailType == "connect" {
-				ep.State = 1
+				ep.State = StateConnected
 				log.Info(meta.Version.Impl + "连接成功 >>> Walle-q 版本：" + meta.Version.Version + " | OneBot 协议版本：" + meta.Version.OneBotVersion)
 			}
 
@@ -697,6 +738,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 
 	socket.OnDisconnected = func(err error, socket gowebsocket.Socket) {
 		log.Info("onebot 服务的连接被对方关闭 ")
+		pa.reportLifecycleClosed(err)
 		pa.InPackWalleQDisconnectedCH <- 1
 	}
 
@@ -728,54 +770,71 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 /* 标准方法实现 */
 
 func (pa *PlatformAdapterWalleQ) DoRelogin() bool {
-	d := pa.EndPoint.Session.Parent
-	ep := pa.EndPoint
-	if pa.Socket != nil {
-		go pa.Socket.Close()
-		pa.Socket = nil
-	}
-	if pa.UseInPackWalleQ {
-		if pa.InPackWalleQDisconnectedCH != nil {
-			pa.InPackWalleQDisconnectedCH <- -1
-		}
-		d.Logger.Infof(fmt.Sprintf("重启 Walle-q，账号<%s>(%s)", ep.Nickname, ep.UserID))
-		pa.CurLoginIndex++
-		pa.WalleQState = WqStateCodeInit
-		go WalleQServeProcessKill(d, ep)
-		time.Sleep(10 * time.Second)
-		WalleQServeRemoveSessionToken(d, ep)
-		pa.WalleQLastRestrictedTime = 0
-		WalleQServe(d, ep, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, true)
-		return true
-	}
-	return false
+	return ReloginEndpointLifecycle(nil, pa.EndPoint) == nil
 }
 
 func (pa *PlatformAdapterWalleQ) SetEnable(enable bool) {
-	d := pa.EndPoint.Session.Parent
-	c := pa.EndPoint
 	if enable {
-		c.Enable = true
-		pa.DiceServing = false
-
-		if pa.UseInPackWalleQ {
-			WalleQServeProcessKill(d, c)
-			time.Sleep(1 * time.Second)
-			WalleQServe(d, c, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, true)
-			go ServeQQ(d, c)
-		} else {
-			go ServeQQ(d, c)
-		}
+		_ = StartEndpointLifecycle(nil, pa.EndPoint)
 	} else {
-		c.Enable = false
-		pa.DiceServing = false
-		if pa.UseInPackWalleQ {
-			WalleQServeProcessKill(d, c)
+		_ = StopEndpointLifecycle(nil, pa.EndPoint)
+	}
+}
+
+// LifecycleStart owns one Walle-q process/websocket generation. Built-in
+// login helpers may complete asynchronously and report Started from callbacks.
+func (pa *PlatformAdapterWalleQ) LifecycleStart(ctx context.Context, run EndpointRunReporter) error {
+	if pa.EndPoint == nil || pa.EndPoint.Session == nil {
+		return NewEndpointLifecycleFailure(errors.New("walle-q endpoint runtime is not bound"), LifecycleFailureStop)
+	}
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
 	}
+	pa.setLifecycleRun(run)
+	d := pa.EndPoint.Session.Parent
+	ep := pa.EndPoint
+	ep.Enable = true
 
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
+	if pa.UseInPackWalleQ {
+		WalleQServeProcessKill(d, ep)
+		time.Sleep(1 * time.Second)
+		WalleQServe(d, ep, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, true)
+		return nil
+	}
+
+	if pa.Serve() != 0 {
+		return errors.New("walle-q serve failed")
+	}
+	return nil
+}
+
+// LifecycleStop closes Walle-q websocket and built-in process resources.
+func (pa *PlatformAdapterWalleQ) LifecycleStop(context.Context) error {
+	ep := pa.EndPoint
+	if ep == nil {
+		return nil
+	}
+	d := endpointDice(nil, ep)
+	pa.DiceServing = false
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	if pa.InPackWalleQDisconnectedCH != nil {
+		select {
+		case pa.InPackWalleQDisconnectedCH <- -1:
+		default:
+		}
+	}
+	if d != nil && pa.UseInPackWalleQ {
+		WalleQServeProcessKill(d, ep)
+	}
+	pa.setLifecycleRun(nil)
+	return nil
 }
 
 func (pa *PlatformAdapterWalleQ) GetGroupInfoAsync(id string) {

--- a/dice/platform_adapter_walleq_helper.go
+++ b/dice/platform_adapter_walleq_helper.go
@@ -101,8 +101,8 @@ func WalleQServeProcessKill(dice *Dice, conn *EndPointInfo) {
 		}
 		if pa.UseInPackWalleQ {
 			// 重置状态
-			conn.State = 0
-			pa.WalleQState = 0
+			conn.State = StateDisconnected
+			pa.WalleQState = WqStateCodeInit
 
 			pa.DiceServing = false
 			pa.WalleQQrcodeData = nil
@@ -224,7 +224,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 			}
 
 			if strings.Contains(line, "Walle-Q Login success with") {
-				go ServeQQ(dice, conn)
+				go startQQProtocolConnection(dice, conn)
 			}
 		}
 


### PR DESCRIPTION
## Summary by Sourcery

在共享的生命周期监督器后面集中管理 IM 端点连接，并迁移所有适配器使用它来处理启用/禁用/重新登录、连接状态和重试。

Bug 修复：
- 通过将回调限定到生命周期代次范围，防止过期或重复的适配器连接影响当前端点状态。
- 对齐各适配器的端点状态转换和错误处理，避免启用/状态持久化的不一致。

增强内容：
- 引入 `EndpointLifecycleSupervisor` 和共享的 FSM，由其负责端点的启动/停止/重试，并提供统一的 `EndpointLifecycleDriver` 接口，由所有适配器实现。
- 重构适配器的 `SetEnable`/`DoRelogin` 逻辑，使其委托给 `Start`/`Stop`/`ReloginEndpointLifecycle`，而不是使用临时拼凑的重试循环和状态机。
- 将 QQ/OneBot/gocq/WalleQ/Red/Lagrange 辅助模块中每个适配器独立的重连循环和设备锁检查，替换为集中化的生命周期控制，以及按协议实现的 `LifecycleStart`/`LifecycleStop`。
- 统一各适配器和辅助模块中的端点 `State` 值（`disconnected`/`connecting`/`connected`/`failed`），移除分散的魔法数字。
- 更新测试以覆盖新的生命周期监督器、适配器生命周期上报器，并在合适的地方用生命周期事件替代基于 FSM 的断言。

Tests:
- 添加专门的 `endpoint_lifecycle` 测试，用于覆盖并发启用/禁用/重新登录、重试策略以及生命周期报告的代次范围。
- 调整 Pure OneBot 和 Official QQ 适配器测试，以针对生命周期上报器行为进行断言，而非已移除的适配器本地 FSM。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize IM endpoint connection management behind a shared lifecycle supervisor and migrate all adapters to use it for enable/disable/relogin, connection state, and retries.

Bug Fixes:
- Prevent stale or duplicate adapter connections from affecting current endpoint state by scoping callbacks to lifecycle generations.
- Align endpoint state transitions and error handling across adapters to avoid inconsistent Enable/State persistence.

Enhancements:
- Introduce an EndpointLifecycleSupervisor and shared FSM that own start/stop/retry for endpoints, with a unified EndpointLifecycleDriver interface implemented by all adapters.
- Refactor adapter SetEnable/DoRelogin logic to delegate to Start/Stop/ReloginEndpointLifecycle instead of ad‑hoc retry loops and state machines.
- Replace per-adapter reconnection loops and device-lock checks in QQ/OneBot/gocq/WalleQ/Red/Lagrange helpers with centralized lifecycle control and protocol-specific LifecycleStart/LifecycleStop implementations.
- Standardize endpoint State values (disconnected/connecting/connected/failed) across adapters and helpers, removing scattered magic numbers.
- Update tests to exercise the new lifecycle supervisor, adapter lifecycle reporters, and to replace FSM-based expectations with lifecycle events where appropriate.

Tests:
- Add dedicated endpoint_lifecycle tests covering concurrent enable/disable/relogin, retry policies, and generation scoping of lifecycle reports.
- Adjust Pure OneBot and Official QQ adapter tests to assert against lifecycle reporter behavior instead of the removed adapter-local FSM.

</details>