### PR TITLE
fix(package): 保留已移除扩展包的重载范围

### DIFF
--- a/dice/package_manager.go
+++ b/dice/package_manager.go
@@ -44,6 +44,10 @@ type PackageManager struct {
 	parent              *Dice
 	downloadIdleTimeout time.Duration
 
+	// 记录已脱离当前 manifest、但仍需从当前进程运行时清理的内容；进程重启后无需保留。
+	detachedReload    packageReloadContentFlags
+	detachedReloadGen uint64 // 防止重载结束时清除执行期间新增的范围
+
 	// 已安装的包
 	packages map[string]*sealpack.Instance
 
@@ -178,10 +182,14 @@ func (pm *PackageManager) refreshFromDiskLocked(markPendingReload bool) (*Packag
 			if err != nil {
 				pm.parent.Logger.Warnf("恢复扩展包 %s 失败: %v", pkgID, err)
 			} else {
-				if markPendingReload && packageNeedsRefreshPendingReload(pkg, instance, wasStale) {
-					pm.addPendingReloadHints(instance, pm.generateReloadHints(instance.Manifest).ReloadHints)
+				changed := packageSourceChanged(pkg, instance) || wasStale
+				if markPendingReload && changed {
+					pm.retainDetachedReloadScopeLocked(pkg)
+					if packageNeedsRefreshPendingReload(pkg, instance, wasStale) {
+						pm.addPendingReloadHints(instance, pm.generateReloadHints(instance.Manifest).ReloadHints)
+					}
 				}
-				if packageSourceChanged(pkg, instance) || wasStale {
+				if changed {
 					result.Updated = append(result.Updated, pkgID)
 				}
 				loaded[pkgID] = instance
@@ -204,6 +212,9 @@ func (pm *PackageManager) refreshFromDiskLocked(markPendingReload bool) (*Packag
 			}
 		}
 
+		if markPendingReload {
+			pm.retainDetachedReloadScopeLocked(pkg)
+		}
 		pm.parent.Logger.Warnf("扩展包 %s 的源文件和缓存均丢失，已移除记录", pkgID)
 		result.Removed = append(result.Removed, pkgID)
 	}
@@ -891,6 +902,9 @@ func (pm *PackageManager) installFromSourceContext(ctx context.Context, pkgPath 
 		pm.parent.Logger.Warnf("读取扩展包 %s 用户配置失败: %v", pkgID, readErr)
 	}
 
+	if existing != nil {
+		pm.retainDetachedReloadScopeLocked(existing)
+	}
 	pm.packages[pkgID] = &sealpack.Instance{
 		Manifest:      manifest,
 		State:         state,
@@ -1416,6 +1430,7 @@ func (pm *PackageManager) Uninstall(pkgID string, mode sealpack.UninstallMode) e
 			}
 			pm.removeEmptyParents(filepath.Dir(pkg.UserDataPath), filepath.Join(".", "data", "extensions"))
 		}
+		pm.retainDetachedReloadScopeLocked(pkg)
 		delete(pm.packages, pkgID)
 
 	case sealpack.UninstallModeKeepData:
@@ -1427,6 +1442,7 @@ func (pm *PackageManager) Uninstall(pkgID string, mode sealpack.UninstallMode) e
 			_ = os.Remove(pkg.SourcePath)
 			pm.removeEmptyParents(filepath.Dir(pkg.SourcePath), pm.getSourcePackagesPath())
 		}
+		pm.retainDetachedReloadScopeLocked(pkg)
 		delete(pm.packages, pkgID)
 
 	case sealpack.UninstallModeDisable:
@@ -1963,6 +1979,7 @@ func (pm *PackageManager) generateReloadHints(manifest *sealpack.Manifest) *seal
 func (pm *PackageManager) Reload(pkgID string) (*sealpack.ReloadResult, error) {
 	pm.lock.RLock()
 	pkg, exists := pm.packages[pkgID]
+	detachedReloadGen := pm.detachedReloadGen
 	pm.lock.RUnlock()
 
 	if !exists {
@@ -1978,6 +1995,7 @@ func (pm *PackageManager) Reload(pkgID string) (*sealpack.ReloadResult, error) {
 
 	pm.lock.Lock()
 	pendingChanged := pm.clearPendingReloadForAllLocked(exec.succeeded)
+	pm.clearDetachedReloadScopeLocked(exec.succeeded, detachedReloadGen)
 	if pendingChanged {
 		if err := pm.saveState(); err != nil {
 			pm.parent.Logger.Warnf("failed to save package state: %v", err)
@@ -1996,12 +2014,16 @@ func (pm *PackageManager) ReloadByContent(contentType string) (*sealpack.ReloadR
 	if err != nil {
 		return nil, err
 	}
+	pm.lock.RLock()
+	detachedReloadGen := pm.detachedReloadGen
+	pm.lock.RUnlock()
 
 	exec := pm.reloadPackageContent(flags)
 	result := exec.result
 
 	pm.lock.Lock()
 	pendingChanged := pm.clearPendingReloadForAllLocked(exec.succeeded)
+	pm.clearDetachedReloadScopeLocked(exec.succeeded, detachedReloadGen)
 	if pendingChanged {
 		if err := pm.saveState(); err != nil {
 			pm.parent.Logger.Warnf("failed to save package state: %v", err)
@@ -2015,7 +2037,8 @@ func (pm *PackageManager) ReloadByContent(contentType string) (*sealpack.ReloadR
 
 func (pm *PackageManager) ReloadAll() (*sealpack.ReloadResult, error) {
 	pm.lock.RLock()
-	flags := packageReloadContentFlags{}
+	flags := pm.detachedReload
+	detachedReloadGen := pm.detachedReloadGen
 	for _, pkg := range pm.packages {
 		if pkg == nil || pkg.Manifest == nil {
 			continue
@@ -2031,12 +2054,8 @@ func (pm *PackageManager) ReloadAll() (*sealpack.ReloadResult, error) {
 	result := exec.result
 
 	pm.lock.Lock()
-	pendingChanged := false
-	for _, pkg := range pm.packages {
-		if pm.clearPendingReloadLocked(pkg, exec.succeeded) {
-			pendingChanged = true
-		}
-	}
+	pendingChanged := pm.clearPendingReloadForAllLocked(exec.succeeded)
+	pm.clearDetachedReloadScopeLocked(exec.succeeded, detachedReloadGen)
 	if pendingChanged {
 		_ = pm.saveState()
 	}
@@ -2097,6 +2116,63 @@ func (flags packageReloadContentFlags) merge(other packageReloadContentFlags) pa
 	flags.helpdoc = flags.helpdoc || other.helpdoc
 	flags.templates = flags.templates || other.templates
 	return flags
+}
+
+func (flags packageReloadContentFlags) without(other packageReloadContentFlags) packageReloadContentFlags {
+	if other.scripts {
+		flags.scripts = false
+	}
+	if other.decks {
+		flags.decks = false
+	}
+	if other.reply {
+		flags.reply = false
+	}
+	if other.helpdoc {
+		flags.helpdoc = false
+	}
+	if other.templates {
+		flags.templates = false
+	}
+	return flags
+}
+
+func packageReloadContentFlagsFromHints(hints []string) packageReloadContentFlags {
+	flags := packageReloadContentFlags{}
+	for _, hint := range hints {
+		flags.scripts = flags.scripts || reloadHintMatchesContentType(hint, "scripts")
+		flags.decks = flags.decks || reloadHintMatchesContentType(hint, "decks")
+		flags.reply = flags.reply || reloadHintMatchesContentType(hint, "reply")
+		flags.helpdoc = flags.helpdoc || reloadHintMatchesContentType(hint, "helpdoc")
+		flags.templates = flags.templates || reloadHintMatchesContentType(hint, "templates")
+	}
+	return flags
+}
+
+func packageReloadContentFlagsFromPreviousInstance(pkg *sealpack.Instance) packageReloadContentFlags {
+	if pkg == nil {
+		return packageReloadContentFlags{}
+	}
+	if pkg.State == sealpack.PackageStateEnabled {
+		return packageReloadContentFlagsFromManifest(pkg.Manifest)
+	}
+	return packageReloadContentFlagsFromHints(pkg.PendingReload)
+}
+
+func (pm *PackageManager) retainDetachedReloadScopeLocked(pkg *sealpack.Instance) {
+	flags := packageReloadContentFlagsFromPreviousInstance(pkg)
+	if flags.count() == 0 {
+		return
+	}
+	pm.detachedReload = pm.detachedReload.merge(flags)
+	pm.detachedReloadGen++
+}
+
+func (pm *PackageManager) clearDetachedReloadScopeLocked(succeeded packageReloadContentFlags, generation uint64) {
+	if pm.detachedReloadGen != generation {
+		return
+	}
+	pm.detachedReload = pm.detachedReload.without(succeeded)
 }
 
 func (flags packageReloadContentFlags) contains(kind string) bool {

--- a/dice/package_manager_disable_reload_test.go
+++ b/dice/package_manager_disable_reload_test.go
@@ -99,6 +99,137 @@ func TestPackageManagerReloadAllAppliesDisabledDeckPackage(t *testing.T) {
 	}
 }
 
+func TestPackageManagerReloadAllAppliesUninstalledDeckPackage(t *testing.T) {
+	for _, mode := range []sealpack.UninstallMode{
+		sealpack.UninstallModeFull,
+		sealpack.UninstallModeKeepData,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			testDice, pm := newDisableDeckTestPackageManager(t)
+			if err := pm.Init(); err != nil {
+				t.Fatalf("Init() error = %v", err)
+			}
+
+			const pkgID = "alice/deck-pack"
+			installAndReloadDeckTestPackage(t, testDice, pm, pkgID, "1.0.0")
+
+			if err := pm.Uninstall(pkgID, mode); err != nil {
+				t.Fatalf("Uninstall(%s) error = %v", mode, err)
+			}
+			if _, ok := pm.Get(pkgID); ok {
+				t.Fatalf("expected package %s to be removed", pkgID)
+			}
+
+			result, err := pm.ReloadAll()
+			if err != nil {
+				t.Fatalf("ReloadAll() error = %v", err)
+			}
+			if _, ok := result.ReloadedItems["decks"]; !ok {
+				t.Fatalf("ReloadedItems = %#v, want decks", result.ReloadedItems)
+			}
+			assertDisableDeckTestDeckCount(t, testDice, 0)
+
+			result, err = pm.ReloadAll()
+			if err != nil {
+				t.Fatalf("second ReloadAll() error = %v", err)
+			}
+			if len(result.ReloadedItems) != 0 {
+				t.Fatalf("second ReloadedItems = %#v, want empty", result.ReloadedItems)
+			}
+		})
+	}
+}
+
+func TestPackageManagerReloadAllAppliesDiskRemovedDeckPackage(t *testing.T) {
+	testDice, pm := newDisableDeckTestPackageManager(t)
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const pkgID = "alice/disk-removed-deck-pack"
+	installAndReloadDeckTestPackage(t, testDice, pm, pkgID, "1.0.0")
+
+	pkg, ok := pm.Get(pkgID)
+	if !ok || pkg == nil {
+		t.Fatalf("expected package %s to exist", pkgID)
+	}
+	if err := os.Remove(pkg.SourcePath); err != nil {
+		t.Fatalf("Remove(source) error = %v", err)
+	}
+	if err := os.RemoveAll(pkg.InstallPath); err != nil {
+		t.Fatalf("RemoveAll(install) error = %v", err)
+	}
+
+	refreshResult, err := pm.RefreshFromDisk()
+	if err != nil {
+		t.Fatalf("RefreshFromDisk() error = %v", err)
+	}
+	if !containsString(refreshResult.Removed, pkgID) {
+		t.Fatalf("Removed = %#v, want %s", refreshResult.Removed, pkgID)
+	}
+
+	reloadResult, err := pm.ReloadAll()
+	if err != nil {
+		t.Fatalf("ReloadAll() error = %v", err)
+	}
+	if _, ok := reloadResult.ReloadedItems["decks"]; !ok {
+		t.Fatalf("ReloadedItems = %#v, want decks", reloadResult.ReloadedItems)
+	}
+	assertDisableDeckTestDeckCount(t, testDice, 0)
+}
+
+func TestPackageManagerReloadAllAppliesPreviousContentsAfterInstallUpgrade(t *testing.T) {
+	testDice, pm := newDisableDeckTestPackageManager(t)
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const pkgID = "alice/install-upgrade-deck-pack"
+	installAndReloadDeckTestPackage(t, testDice, pm, pkgID, "1.0.0")
+	v2 := createTestSealPack(t, "", pkgID, "2.0.0", nil, nil)
+	if err := pm.Install(v2); err != nil {
+		t.Fatalf("Install(v2) error = %v", err)
+	}
+
+	result, err := pm.ReloadAll()
+	if err != nil {
+		t.Fatalf("ReloadAll() error = %v", err)
+	}
+	if _, ok := result.ReloadedItems["decks"]; !ok {
+		t.Fatalf("ReloadedItems = %#v, want decks", result.ReloadedItems)
+	}
+	assertDisableDeckTestDeckCount(t, testDice, 0)
+}
+
+func TestPackageManagerReloadAllAppliesPreviousContentsAfterRefreshUpgrade(t *testing.T) {
+	testDice, pm := newDisableDeckTestPackageManager(t)
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const pkgID = "alice/refresh-upgrade-deck-pack"
+	installAndReloadDeckTestPackage(t, testDice, pm, pkgID, "1.0.0")
+	v2 := createTestSealPack(t, "", pkgID, "2.0.0", nil, nil)
+	copyTestFile(t, v2, filepath.Join("data", "packages", "alice", "refresh-upgrade-deck-pack@2.0.0.sealpack"))
+
+	refreshResult, err := pm.RefreshFromDisk()
+	if err != nil {
+		t.Fatalf("RefreshFromDisk() error = %v", err)
+	}
+	if !containsString(refreshResult.Updated, pkgID) {
+		t.Fatalf("Updated = %#v, want %s", refreshResult.Updated, pkgID)
+	}
+
+	reloadResult, err := pm.ReloadAll()
+	if err != nil {
+		t.Fatalf("ReloadAll() error = %v", err)
+	}
+	if _, ok := reloadResult.ReloadedItems["decks"]; !ok {
+		t.Fatalf("ReloadedItems = %#v, want decks", reloadResult.ReloadedItems)
+	}
+	assertDisableDeckTestDeckCount(t, testDice, 0)
+}
+
 func TestPackageManagerReloadClearsPendingReloadAcrossPackagesOfSameKind(t *testing.T) {
 	testDice, pm := newDisableDeckTestPackageManager(t)
 	if err := pm.Init(); err != nil {
@@ -168,6 +299,21 @@ func assertDisableDeckTestDeckCount(t *testing.T, testDice *Dice, want int) {
 	if got := len(testDice.DeckList); got != want {
 		t.Fatalf("deck count = %d, want %d", got, want)
 	}
+}
+
+func installAndReloadDeckTestPackage(t *testing.T, testDice *Dice, pm *PackageManager, pkgID, version string) {
+	t.Helper()
+	archive := createDisableDeckTestPackage(t, pkgID, version)
+	if err := pm.Install(archive); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if _, err := pm.Enable(pkgID); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+	if _, err := pm.Reload(pkgID); err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+	assertDisableDeckTestDeckCount(t, testDice, 1)
 }
 
 func newDisableDeckTestPackageManager(t *testing.T) (*Dice, *PackageManager) {
@@ -249,4 +395,146 @@ func TestClearPendingReloadLockedPreservesUnreloadedKinds(t *testing.T) {
 	if len(pkg.PendingReload) != 1 || pkg.PendingReload[0] != "helpdoc" {
 		t.Fatalf("PendingReload = %#v", pkg.PendingReload)
 	}
+}
+
+func TestPackageReloadContentFlagsFromPreviousInstanceCoversAllKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		contents sealpack.Contents
+	}{
+		{name: "scripts", kind: "scripts", contents: sealpack.Contents{Scripts: []string{"scripts/*.js"}}},
+		{name: "decks", kind: "decks", contents: sealpack.Contents{Decks: []string{"decks/*.json"}}},
+		{name: "reply", kind: "reply", contents: sealpack.Contents{Reply: []string{"reply/*.yaml"}}},
+		{name: "helpdoc", kind: "helpdoc", contents: sealpack.Contents{Helpdoc: []string{"helpdoc/*.json"}}},
+		{name: "templates", kind: "templates", contents: sealpack.Contents{Templates: []string{"templates/*.yaml"}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flags := packageReloadContentFlagsFromPreviousInstance(&sealpack.Instance{
+				State: sealpack.PackageStateEnabled,
+				Manifest: &sealpack.Manifest{
+					Contents: test.contents,
+				},
+			})
+			if !flags.contains(test.kind) || flags.count() != 1 {
+				t.Fatalf("flags = %#v, want only %s", flags, test.kind)
+			}
+		})
+	}
+}
+
+func TestPackageReloadContentFlagsFromPreviousDisabledInstanceUsesPendingHints(t *testing.T) {
+	flags := packageReloadContentFlagsFromPreviousInstance(&sealpack.Instance{
+		State: sealpack.PackageStateDisabled,
+		Manifest: &sealpack.Manifest{
+			Contents: sealpack.Contents{
+				Scripts: []string{"scripts/*.js"},
+				Decks:   []string{"decks/*.json"},
+			},
+		},
+		PendingReload: []string{"牌堆 - 可通过重载接口生效"},
+	})
+	if !flags.decks || flags.count() != 1 {
+		t.Fatalf("flags = %#v, want only decks", flags)
+	}
+}
+
+func TestClearDetachedReloadScopeLockedPreservesUnreloadedKinds(t *testing.T) {
+	pm := &PackageManager{
+		detachedReload:    packageReloadContentFlags{scripts: true, helpdoc: true},
+		detachedReloadGen: 1,
+	}
+
+	pm.clearDetachedReloadScopeLocked(packageReloadContentFlags{scripts: true}, 1)
+	if pm.detachedReload.scripts || !pm.detachedReload.helpdoc {
+		t.Fatalf("detachedReload = %#v, want only helpdoc", pm.detachedReload)
+	}
+}
+
+func TestClearDetachedReloadScopeLockedPreservesNewerGeneration(t *testing.T) {
+	pm := &PackageManager{
+		detachedReload:    packageReloadContentFlags{scripts: true},
+		detachedReloadGen: 1,
+	}
+
+	startedGeneration := pm.detachedReloadGen
+	pm.detachedReload = pm.detachedReload.merge(packageReloadContentFlags{decks: true})
+	pm.detachedReloadGen++
+	pm.clearDetachedReloadScopeLocked(packageReloadContentFlags{scripts: true}, startedGeneration)
+
+	if !pm.detachedReload.scripts || !pm.detachedReload.decks {
+		t.Fatalf("detachedReload = %#v, want scripts and decks", pm.detachedReload)
+	}
+}
+
+func TestPackageManagerReloadAllPreservesFailedDetachedScope(t *testing.T) {
+	_, pm := newDisableDeckTestPackageManager(t)
+	pm.detachedReload = packageReloadContentFlags{decks: true, helpdoc: true}
+	pm.detachedReloadGen = 1
+
+	result, err := pm.ReloadAll()
+	if err != nil {
+		t.Fatalf("ReloadAll() error = %v", err)
+	}
+	if result.Success {
+		t.Fatalf("ReloadAll() Success = true, want false: %#v", result.ReloadedItems)
+	}
+	if pm.detachedReload.decks || !pm.detachedReload.helpdoc {
+		t.Fatalf("detachedReload = %#v, want only helpdoc", pm.detachedReload)
+	}
+}
+
+func TestPackageManagerReloadAllExecutesDetachedScriptScope(t *testing.T) {
+	testDice, pm := newScriptReloadTestPackageManager(t)
+	pm.detachedReload = packageReloadContentFlags{scripts: true}
+	pm.detachedReloadGen = 1
+
+	result, err := pm.ReloadAll()
+	if err != nil {
+		t.Fatalf("ReloadAll() error = %v", err)
+	}
+	if _, ok := result.ReloadedItems["scripts"]; !ok {
+		t.Fatalf("ReloadedItems = %#v, want scripts", result.ReloadedItems)
+	}
+	if pm.detachedReload.scripts {
+		t.Fatal("successful script reload should clear detached scope")
+	}
+	if testDice.ExtLoopManager == nil {
+		t.Fatal("script reload should initialize the JS loop manager")
+	}
+}
+
+func newScriptReloadTestPackageManager(t *testing.T) (*Dice, *PackageManager) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	testDice := &Dice{
+		BaseConfig: BaseConfig{DataDir: "."},
+		Logger:     zap.NewNop().Sugar(),
+		ImSession: &IMSession{
+			ServiceAtNew: new(SyncMap[string, *GroupInfo]),
+			EndPoints:    []*EndPointInfo{},
+		},
+		DirtyGroups:        new(SyncMap[string, int64]),
+		AttrsManager:       &AttrsManager{},
+		JsBuiltinDigestSet: map[string]bool{},
+	}
+	testDice.Config = NewConfig(testDice)
+	testDice.ConfigManager = NewConfigManager(filepath.Join(tmpDir, "plugin-configs.json"))
+	pm := NewPackageManager(testDice)
+	testDice.PackageManager = pm
+
+	t.Cleanup(func() {
+		if testDice.JsScriptCron != nil {
+			testDice.JsScriptCron.Stop()
+			testDice.JsScriptCron = nil
+		}
+		if testDice.ExtLoopManager != nil {
+			testDice.ExtLoopManager.SetLoop(nil)
+		}
+	})
+	return testDice, pm
 }

--- a/dice/package_manager_disable_reload_test.go
+++ b/dice/package_manager_disable_reload_test.go
@@ -470,7 +470,11 @@ func TestClearDetachedReloadScopeLockedPreservesNewerGeneration(t *testing.T) {
 }
 
 func TestPackageManagerReloadAllPreservesFailedDetachedScope(t *testing.T) {
-	_, pm := newDisableDeckTestPackageManager(t)
+	testDice, pm := newDisableDeckTestPackageManager(t)
+	if testDice.Parent != nil {
+		t.Fatal("测试要求 Dice.Parent 为空，以确保帮助文档重载因缺少 DiceManager 而失败")
+	}
+	// 牌堆应重载成功；帮助文档因缺少 DiceManager 失败，用于验证只保留失败的重载范围。
 	pm.detachedReload = packageReloadContentFlags{decks: true, helpdoc: true}
 	pm.detachedReloadGen = 1
 
@@ -480,6 +484,12 @@ func TestPackageManagerReloadAllPreservesFailedDetachedScope(t *testing.T) {
 	}
 	if result.Success {
 		t.Fatalf("ReloadAll() Success = true, want false: %#v", result.ReloadedItems)
+	}
+	if got := result.ReloadedItems["decks"]; got != "牌堆已重载" {
+		t.Fatalf("ReloadAll() decks result = %q, want successful reload", got)
+	}
+	if got := result.ReloadedItems["helpdoc"]; !strings.Contains(got, "help manager is unavailable") {
+		t.Fatalf("ReloadAll() helpdoc result = %q, want missing help manager failure", got)
 	}
 	if pm.detachedReload.decks || !pm.detachedReload.helpdoc {
 		t.Fatalf("detachedReload = %#v, want only helpdoc", pm.detachedReload)


### PR DESCRIPTION
close #1779

## Summary by Sourcery

在包的整个生命周期操作中（包括已移除、卸载或升级的扩展，以及分离的脚本/牌组重载），保留并正确应用重载范围。

Bug Fixes:
- 确保在包被卸载或从磁盘移除后，牌组重载能够正确执行并在完成后被正确清除。
- 修复在重新安装或升级包时丢失重载范围信息的问题，从而保证之前加载的内容能够被正确清理。
- 防止在重载执行过程中，当新重载范围被添加时，分离的重载范围被错误清除。

Enhancements:
- 引入对分离重载内容范围的跟踪，并使用“代数计数器”（generation counters），以便在包被移除或替换后，重载操作能够清理运行时状态。
- 利用先前的包实例和待处理的重载提示来推导重载内容标记，从而在不同内容类型之间实现更精确的重载行为。

Tests:
- 增加全面测试，涵盖卸载模式、从磁盘移除的包、安装/刷新升级、分离重载范围行为以及脚本重载执行。
- 增加单元测试，用于从清单和待处理提示中计算重载内容标记，以及用于合并/清除分离的重载范围。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve and correctly apply reload scopes for extensions that have been removed, uninstalled, or upgraded, including detached script/deck reloads across package lifecycle operations.

Bug Fixes:
- Ensure deck reloads are applied and then cleared correctly after packages are uninstalled or removed from disk.
- Fix loss of reload scope information when reinstalling or upgrading packages so previously loaded contents are properly cleaned up.
- Prevent detached reload scopes from being incorrectly cleared when new scopes are added during a reload run.

Enhancements:
- Introduce tracking of detached reload content scopes with generation counters so reload operations can clean up runtime state after package removal or replacement.
- Use previous package instances and pending reload hints to derive reload content flags, enabling more accurate reload behavior across different content kinds.

Tests:
- Add comprehensive tests covering uninstall modes, disk-removed packages, install/refresh upgrades, detached reload scope behavior, and script reload execution.
- Add unit tests for computing reload content flags from manifests and pending hints, and for merging/clearing detached reload scopes.

</details>