### PR TITLE
fix(milky): 重登内置客户端时重新分配端口

### DIFF
--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -9,7 +9,6 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	milky "github.com/Szzrain/Milky-go-sdk"
@@ -34,9 +33,6 @@ type PlatformAdapterMilky struct {
 	MilkyProcess      *procs.Process  `json:"-" yaml:"-"`
 	BuiltInLoginState MilkyLoginState `json:"loginState" yaml:"-"`
 	QrCodeData        []byte          `json:"-"                          yaml:"-"`
-	// Serializes ownership changes for the built-in child process.
-	builtInProcessMu   sync.Mutex
-	builtInProcessDone chan struct{}
 }
 
 type MilkyLoginState int64
@@ -668,8 +664,16 @@ func (pa *PlatformAdapterMilky) DoRelogin() bool {
 		d.Save(false)
 		return true
 	}
-	// 内置客户端的停止、会话清理和重启必须是一个串行操作。
-	return ReloginMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
+	// 内置
+	// 先断开连接
+	if pa.IntentSession != nil {
+		_ = pa.IntentSession.Close()
+	}
+	// kill
+	BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
+	MilkyRemoveSession(pa.EndPoint.Session.Parent, pa.EndPoint)
+	go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
+	return true
 }
 
 func (pa *PlatformAdapterMilky) SetEnable(enable bool) {

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	milky "github.com/Szzrain/Milky-go-sdk"
@@ -33,6 +34,9 @@ type PlatformAdapterMilky struct {
 	MilkyProcess      *procs.Process  `json:"-" yaml:"-"`
 	BuiltInLoginState MilkyLoginState `json:"loginState" yaml:"-"`
 	QrCodeData        []byte          `json:"-"                          yaml:"-"`
+	// Serializes ownership changes for the built-in child process.
+	builtInProcessMu   sync.Mutex
+	builtInProcessDone chan struct{}
 }
 
 type MilkyLoginState int64
@@ -664,16 +668,8 @@ func (pa *PlatformAdapterMilky) DoRelogin() bool {
 		d.Save(false)
 		return true
 	}
-	// 内置
-	// 先断开连接
-	if pa.IntentSession != nil {
-		_ = pa.IntentSession.Close()
-	}
-	// kill
-	BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
-	MilkyRemoveSession(pa.EndPoint.Session.Parent, pa.EndPoint)
-	go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
-	return true
+	// 内置客户端的停止、会话清理和重启必须是一个串行操作。
+	return ReloginMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
 }
 
 func (pa *PlatformAdapterMilky) SetEnable(enable bool) {

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -1,6 +1,8 @@
 package dice
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -203,51 +205,34 @@ func BuiltinMilkyClientKill(dice *Dice, conn *EndPointInfo) {
 	if pa.BuiltInMode == "" {
 		return
 	}
-	pa.builtInProcessMu.Lock()
-	defer pa.builtInProcessMu.Unlock()
-	if err := stopMilkyBuiltInLocked(pa); err != nil {
-		dice.Logger.Error("停止 Milky 进程失败: ", err)
+	defer func() {
+		pa.MilkyProcess = nil
+	}()
+	if pa.MilkyProcess != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go func() {
+			<-ctx.Done()
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				dice.Logger.Error("Milky 进程未能在 5 秒内退出，可能需要手动结束")
+			}
+		}()
+		err := pa.MilkyProcess.Stop()
+		if err != nil {
+			dice.Logger.Error("停止 Milky 进程失败: ", err)
+		}
+		_ = pa.MilkyProcess.Wait()
 	}
 }
 
 func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
-	pa, ok := ep.Adapter.(*PlatformAdapterMilky)
-	if !ok || pa.BuiltInMode == "" {
-		return
-	}
-	pa.builtInProcessMu.Lock()
-	defer pa.builtInProcessMu.Unlock()
-	serveMilkyBuiltInLocked(d, ep, pa)
-}
-
-func ReloginMilkyBuiltIn(d *Dice, ep *EndPointInfo) bool {
-	pa, ok := ep.Adapter.(*PlatformAdapterMilky)
-	if !ok || pa.BuiltInMode == "" {
-		return false
-	}
-	pa.builtInProcessMu.Lock()
-	defer pa.builtInProcessMu.Unlock()
-
-	if pa.IntentSession != nil {
-		_ = pa.IntentSession.Close()
-		pa.IntentSession = nil
-	}
-	if err := stopMilkyBuiltInLocked(pa); err != nil {
-		d.Logger.Error("停止 Milky 进程失败: ", err)
-		return false
-	}
-	MilkyRemoveSession(d, ep)
-	return serveMilkyBuiltInLocked(d, ep, pa)
-}
-
-func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky) bool {
 	if d.ContainerMode {
 		d.Logger.Warnf("当前处于容器模式，Milky 内置版本不可用")
 		ep.State = 3
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return false
+		return
 	}
 	uin, err := strconv.ParseInt(ExtractQQUserID(ep.UserID), 10, 64)
 	if err != nil {
@@ -255,9 +240,9 @@ func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky
 		ep.State = 3
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return false
+		return
 	}
-	conn := pa
+	conn := ep.Adapter.(*PlatformAdapterMilky)
 	doServe := func() {
 		if ep.Platform == "QQ" {
 			d.Logger.Infof("Milky 尝试连接")
@@ -270,6 +255,7 @@ func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky
 			}
 		}
 	}
+	pa := conn
 	ep.BindRuntime(d.ImSession)
 	log := zap.S().Named(logger.LogKeyAdapter)
 
@@ -290,22 +276,43 @@ func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky
 	}
 	_ = os.MkdirAll(workDir, 0o755)
 	_ = os.Chmod(milkyExePath, 0o755)
-	if pa.IntentSession != nil {
-		_ = pa.IntentSession.Close()
-		pa.IntentSession = nil
+	if pa.MilkyProcess != nil {
+		BuiltinMilkyClientKill(d, ep)
 	}
-	if err := stopMilkyBuiltInLocked(pa); err != nil {
-		log.Errorf("停止已有 Milky 进程失败: %s", err)
-		ep.State = 3
-		return false
-	}
-	if err := prepareMilkyBuiltInConfig(ep, configFilePath); err != nil {
-		log.Errorf("生成 Milky 启动配置失败: %s", err)
+	// The temporary listener is released before the child binds, so another
+	// process can still claim this port during the gap.
+	port, err := GetRandomFreePort()
+	if err != nil {
+		log.Errorf("获取随机端口失败: %s", err)
 		ep.State = 3
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return false
+		return
 	}
+	wsGateway := fmt.Sprintf("ws://127.0.0.1:%d/event", port)
+	restGateway := fmt.Sprintf("http://127.0.0.1:%d/api", port)
+	accessToken := pa.Token
+	if accessToken == "" {
+		accessToken = uuid.NewString()
+	}
+	config := GenerateMilkyConfig(port, SealSignV3Url, accessToken, ep)
+	if len(config) == 0 {
+		log.Errorf("不支持的内置 Milky 模式: %s", pa.BuiltInMode)
+		ep.State = 3
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return
+	}
+	if err := os.WriteFile(configFilePath, config, 0o644); err != nil {
+		log.Errorf("写入 Milky 配置文件失败: %s", err)
+		ep.State = 3
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return
+	}
+	pa.WsGateway = wsGateway
+	pa.RestGateway = restGateway
+	pa.Token = accessToken
 	command := fmt.Sprintf(`"%s"`, milkyExePath)
 	p := procs.NewProcess(command)
 	p.Dir = workDir
@@ -313,6 +320,9 @@ func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky
 		fmt.Sprintf("APP_LAUNCHER_SIG=%s", BuildSignature(uint64(uin))),
 	}
 	chQrCode := make(chan int, 1)
+	// Process output can arrive before Start returns. Callback-driven cleanup
+	// must wait until the process is registered on the adapter.
+	processRegistered := make(chan struct{})
 	qrSignalCalled := atomic.Bool{}
 	qrSignalCalled.Store(false)
 	pa.BuiltInLoginState = MilkyLoginStateInit
@@ -355,6 +365,7 @@ func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky
 				// 二维码过期，登录失败，杀掉进程
 				pa.BuiltInLoginState = MilkyLoginStateFailed
 				log.Infof("Milky 二维码过期，登录失败，账号：%s", ep.UserID)
+				<-processRegistered
 				BuiltinMilkyClientKill(d, ep)
 			}
 		}
@@ -394,97 +405,42 @@ func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky
 		}
 	}()
 
-	if err := p.Start(); err != nil {
-		log.Info("Milky 进程启动失败: ", err)
-		ep.State = 3
-		d.LastUpdatedTime = time.Now().Unix()
-		d.Save(false)
-		return false
-	}
-	done := make(chan struct{})
-	pa.MilkyProcess = p
-	pa.builtInProcessDone = done
-	go waitMilkyBuiltIn(d, pa, p, done)
+	run := func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
+			}
+		}()
 
-	if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
-		if err := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process); err != nil {
-			log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
+		errRun := p.Start()
+		if errRun != nil {
+			log.Info("Milky 进程启动失败: ", errRun)
+			ep.State = 3
+			d.LastUpdatedTime = time.Now().Unix()
+			d.Save(false)
+			return
+		}
+
+		conn.MilkyProcess = p
+		close(processRegistered)
+		// processStartTime := time.Now().Unix()
+
+		if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
+			errAdd := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process)
+			if errAdd != nil {
+				log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
+			}
+		}
+		errRun = p.Wait() //nolint:ineffassign
+
+		if errRun != nil {
+			log.Info("Milky 进程异常退出: ", errRun)
+		} else {
+			log.Info("Milky 进程退出")
 		}
 	}
 
-	d.LastUpdatedTime = time.Now().Unix()
-	d.Save(false)
-	return true
-}
-
-func prepareMilkyBuiltInConfig(ep *EndPointInfo, configFilePath string) error {
-	port, err := GetRandomFreePort()
-	if err != nil {
-		return fmt.Errorf("获取随机端口失败: %w", err)
-	}
-	accessToken := uuid.NewString()
-	config := GenerateMilkyConfig(port, SealSignV3Url, accessToken, ep)
-	if len(config) == 0 {
-		return fmt.Errorf("不支持的内置 Milky 模式")
-	}
-	if err := os.WriteFile(configFilePath, config, 0o644); err != nil {
-		return fmt.Errorf("写入 Milky 配置文件失败: %w", err)
-	}
-
-	pa := ep.Adapter.(*PlatformAdapterMilky)
-	pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", port)
-	pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", port)
-	pa.Token = accessToken
-	return nil
-}
-
-func stopMilkyBuiltInLocked(pa *PlatformAdapterMilky) error {
-	process := pa.MilkyProcess
-	if process == nil {
-		return nil
-	}
-	done := pa.builtInProcessDone
-	stopErr := process.Stop()
-	if done == nil {
-		return fmt.Errorf("Milky 进程缺少退出通知")
-	}
-
-	select {
-	case <-done:
-		if pa.MilkyProcess == process {
-			pa.MilkyProcess = nil
-			pa.builtInProcessDone = nil
-		}
-		return nil
-	case <-time.After(5 * time.Second):
-		if stopErr != nil {
-			return fmt.Errorf("结束进程失败: %w", stopErr)
-		}
-		return fmt.Errorf("Milky 进程未能在 5 秒内退出，可能需要手动结束")
-	}
-}
-
-func waitMilkyBuiltIn(d *Dice, pa *PlatformAdapterMilky, process *procs.Process, done chan struct{}) {
-	defer func() {
-		if r := recover(); r != nil {
-			d.Logger.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
-		}
-		close(done)
-
-		pa.builtInProcessMu.Lock()
-		defer pa.builtInProcessMu.Unlock()
-		if pa.MilkyProcess == process {
-			pa.MilkyProcess = nil
-			pa.builtInProcessDone = nil
-		}
-	}()
-
-	err := process.Wait()
-	if err != nil {
-		d.Logger.Info("Milky 进程异常退出: ", err)
-	} else {
-		d.Logger.Info("Milky 进程退出")
-	}
+	go run()
 }
 
 // GenerateMilkyConfig 似乎暂时不需要 APPInfo, 如果以后需要了再改成双返回值

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -1,8 +1,6 @@
 package dice
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -205,34 +203,51 @@ func BuiltinMilkyClientKill(dice *Dice, conn *EndPointInfo) {
 	if pa.BuiltInMode == "" {
 		return
 	}
-	defer func() {
-		pa.MilkyProcess = nil
-	}()
-	if pa.MilkyProcess != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		go func() {
-			<-ctx.Done()
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				dice.Logger.Error("Milky 进程未能在 5 秒内退出，可能需要手动结束")
-			}
-		}()
-		err := pa.MilkyProcess.Stop()
-		if err != nil {
-			dice.Logger.Error("停止 Milky 进程失败: ", err)
-		}
-		_ = pa.MilkyProcess.Wait()
+	pa.builtInProcessMu.Lock()
+	defer pa.builtInProcessMu.Unlock()
+	if err := stopMilkyBuiltInLocked(pa); err != nil {
+		dice.Logger.Error("停止 Milky 进程失败: ", err)
 	}
 }
 
 func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
+	pa, ok := ep.Adapter.(*PlatformAdapterMilky)
+	if !ok || pa.BuiltInMode == "" {
+		return
+	}
+	pa.builtInProcessMu.Lock()
+	defer pa.builtInProcessMu.Unlock()
+	serveMilkyBuiltInLocked(d, ep, pa)
+}
+
+func ReloginMilkyBuiltIn(d *Dice, ep *EndPointInfo) bool {
+	pa, ok := ep.Adapter.(*PlatformAdapterMilky)
+	if !ok || pa.BuiltInMode == "" {
+		return false
+	}
+	pa.builtInProcessMu.Lock()
+	defer pa.builtInProcessMu.Unlock()
+
+	if pa.IntentSession != nil {
+		_ = pa.IntentSession.Close()
+		pa.IntentSession = nil
+	}
+	if err := stopMilkyBuiltInLocked(pa); err != nil {
+		d.Logger.Error("停止 Milky 进程失败: ", err)
+		return false
+	}
+	MilkyRemoveSession(d, ep)
+	return serveMilkyBuiltInLocked(d, ep, pa)
+}
+
+func serveMilkyBuiltInLocked(d *Dice, ep *EndPointInfo, pa *PlatformAdapterMilky) bool {
 	if d.ContainerMode {
 		d.Logger.Warnf("当前处于容器模式，Milky 内置版本不可用")
 		ep.State = 3
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return
+		return false
 	}
 	uin, err := strconv.ParseInt(ExtractQQUserID(ep.UserID), 10, 64)
 	if err != nil {
@@ -240,9 +255,9 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		ep.State = 3
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
-		return
+		return false
 	}
-	conn := ep.Adapter.(*PlatformAdapterMilky)
+	conn := pa
 	doServe := func() {
 		if ep.Platform == "QQ" {
 			d.Logger.Infof("Milky 尝试连接")
@@ -255,7 +270,6 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 			}
 		}
 	}
-	pa := conn
 	ep.BindRuntime(d.ImSession)
 	log := zap.S().Named(logger.LogKeyAdapter)
 
@@ -276,28 +290,21 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 	}
 	_ = os.MkdirAll(workDir, 0o755)
 	_ = os.Chmod(milkyExePath, 0o755)
-	if pa.MilkyProcess != nil {
-		BuiltinMilkyClientKill(d, ep)
+	if pa.IntentSession != nil {
+		_ = pa.IntentSession.Close()
+		pa.IntentSession = nil
 	}
-	if pa.WsGateway == "" {
-		p, err := GetRandomFreePort()
-		if err != nil {
-			log.Errorf("获取随机端口失败: %s", err)
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
-			return
-		}
-		pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", p)
-		pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", p)
-		// 生成配置写入文件
-		accessToken := uuid.NewString()
-		pa.Token = accessToken
-		c := GenerateMilkyConfig(p, SealSignV3Url, accessToken, ep)
-		err = os.WriteFile(configFilePath, c, 0o644)
-		if err != nil {
-			log.Errorf("写入 Milky 配置文件失败: %s", err)
-		}
+	if err := stopMilkyBuiltInLocked(pa); err != nil {
+		log.Errorf("停止已有 Milky 进程失败: %s", err)
+		ep.State = 3
+		return false
+	}
+	if err := prepareMilkyBuiltInConfig(ep, configFilePath); err != nil {
+		log.Errorf("生成 Milky 启动配置失败: %s", err)
+		ep.State = 3
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return false
 	}
 	command := fmt.Sprintf(`"%s"`, milkyExePath)
 	p := procs.NewProcess(command)
@@ -387,36 +394,97 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		}
 	}()
 
-	run := func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
-			}
-		}()
+	if err := p.Start(); err != nil {
+		log.Info("Milky 进程启动失败: ", err)
+		ep.State = 3
+		d.LastUpdatedTime = time.Now().Unix()
+		d.Save(false)
+		return false
+	}
+	done := make(chan struct{})
+	pa.MilkyProcess = p
+	pa.builtInProcessDone = done
+	go waitMilkyBuiltIn(d, pa, p, done)
 
-		conn.MilkyProcess = p
-		// processStartTime := time.Now().Unix()
-		errRun := p.Start()
-
-		if errRun == nil {
-			if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
-				errAdd := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process)
-				if errAdd != nil {
-					log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
-				}
-			}
-			errRun = p.Wait() //nolint:ineffassign
-		}
-
-		if errRun != nil {
-			log.Info("Milky 进程异常退出: ", errRun)
-			// Maybe some state change here
-		} else {
-			log.Info("Milky 进程退出")
+	if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
+		if err := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process); err != nil {
+			log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
 		}
 	}
 
-	go run()
+	d.LastUpdatedTime = time.Now().Unix()
+	d.Save(false)
+	return true
+}
+
+func prepareMilkyBuiltInConfig(ep *EndPointInfo, configFilePath string) error {
+	port, err := GetRandomFreePort()
+	if err != nil {
+		return fmt.Errorf("获取随机端口失败: %w", err)
+	}
+	accessToken := uuid.NewString()
+	config := GenerateMilkyConfig(port, SealSignV3Url, accessToken, ep)
+	if len(config) == 0 {
+		return fmt.Errorf("不支持的内置 Milky 模式")
+	}
+	if err := os.WriteFile(configFilePath, config, 0o644); err != nil {
+		return fmt.Errorf("写入 Milky 配置文件失败: %w", err)
+	}
+
+	pa := ep.Adapter.(*PlatformAdapterMilky)
+	pa.WsGateway = fmt.Sprintf("ws://127.0.0.1:%d/event", port)
+	pa.RestGateway = fmt.Sprintf("http://127.0.0.1:%d/api", port)
+	pa.Token = accessToken
+	return nil
+}
+
+func stopMilkyBuiltInLocked(pa *PlatformAdapterMilky) error {
+	process := pa.MilkyProcess
+	if process == nil {
+		return nil
+	}
+	done := pa.builtInProcessDone
+	stopErr := process.Stop()
+	if done == nil {
+		return fmt.Errorf("Milky 进程缺少退出通知")
+	}
+
+	select {
+	case <-done:
+		if pa.MilkyProcess == process {
+			pa.MilkyProcess = nil
+			pa.builtInProcessDone = nil
+		}
+		return nil
+	case <-time.After(5 * time.Second):
+		if stopErr != nil {
+			return fmt.Errorf("结束进程失败: %w", stopErr)
+		}
+		return fmt.Errorf("Milky 进程未能在 5 秒内退出，可能需要手动结束")
+	}
+}
+
+func waitMilkyBuiltIn(d *Dice, pa *PlatformAdapterMilky, process *procs.Process, done chan struct{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			d.Logger.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
+		}
+		close(done)
+
+		pa.builtInProcessMu.Lock()
+		defer pa.builtInProcessMu.Unlock()
+		if pa.MilkyProcess == process {
+			pa.MilkyProcess = nil
+			pa.builtInProcessDone = nil
+		}
+	}()
+
+	err := process.Wait()
+	if err != nil {
+		d.Logger.Info("Milky 进程异常退出: ", err)
+	} else {
+		d.Logger.Info("Milky 进程退出")
+	}
 }
 
 // GenerateMilkyConfig 似乎暂时不需要 APPInfo, 如果以后需要了再改成双返回值


### PR DESCRIPTION
由于内置 Milky 在首次启动后会持久化自动分配的端口，因此重新登录会使用同一端口。但退出 Milky 后立即重新登录会导致在旧连接仍然在 TIME-WAIT 状态时尝试绑定端口，触发 EADDRINUSE 冲突错误。

此 PR 通过加入每次启动内置客户端都会重新分配端口的机制，并使启动、停止和重登通过互斥锁执行来修复了此问题并避免了潜在的类似问题。

## Summary by Sourcery

确保内置的 Milky 客户端在安全重启时使用重新分配的端口，并通过串行化的生命周期管理来避免端口绑定冲突和竞态条件。

Bug 修复：
- 通过在每次启动时重新分配新端口，并在复用前完全停止上一进程，解决在快速重新登录内置 Milky 客户端时出现的 EADDRINUSE 错误。

增强功能：
- 在内置 Milky 进程所有权变更周围引入基于互斥锁的串行化机制，以防止并发的启动/停止/重新登录竞态。
- 将内置 Milky 进程生命周期处理重构为专门的辅助方法，用于配置生成、进程关闭和退出监控，并改进日志记录和错误报告。
- 使内置 Milky 客户端的重新登录成为一个单一的原子操作：停止旧进程、清理会话、重新生成配置并重新启动客户端。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the built-in Milky client is safely restarted with a freshly allocated port and serialized lifecycle management to avoid port binding conflicts and race conditions.

Bug Fixes:
- Resolve EADDRINUSE errors when quickly relogging the built-in Milky client by reallocating a new port on each startup and fully stopping the previous process before reuse.

Enhancements:
- Introduce mutex-based serialization around built-in Milky process ownership changes to prevent concurrent start/stop/relogin races.
- Refactor built-in Milky process lifecycle handling into dedicated helpers for configuration generation, process shutdown, and exit monitoring, with improved logging and error reporting.
- Make relogin of the built-in Milky client a single atomic operation that stops the old process, clears sessions, regenerates config, and restarts the client.

</details>