### PR TITLE
fix(pureonebot): 对齐入群迎新处理链路

### DIFF
--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1703,54 +1703,71 @@ func (s *IMSession) OnGroupJoined(ctx *MsgContext, msg *Message) {
 	}
 }
 
-var lastWelcome *LastWelcomeInfo
+var lastGroupMemberWelcome *LastWelcomeInfo
 
 // OnGroupMemberJoined 群成员进群事件处理，除了 bot 自己以外的群成员入群时调用。其他 Adapter 应当尽快迁移至此方法实现
 func (s *IMSession) OnGroupMemberJoined(ctx *MsgContext, msg *Message) {
 	log := s.Parent.Logger
 
 	groupInfo, ok := s.ServiceAtNew.Load(msg.GroupID)
+	needWelcome := false
+	reason := "group_not_loaded"
+	if ok {
+		if groupInfo.ShowGroupWelcome {
+			needWelcome = true
+			reason = "welcome_enabled"
+		} else {
+			reason = "welcome_disabled"
+		}
+	}
+	if !needWelcome {
+		log.Infof("检查是否需要迎新: need_welcome=%t reason=%s group_id=%s user_id=%s", needWelcome, reason, msg.GroupID, msg.Sender.UserID)
+		return
+	}
+
 	// 进群的是别人，是否迎新？
 	// 这里很诡异，当手机QQ客户端审批进群时，入群后会有一句默认发言
 	// 此时会收到两次完全一样的某用户入群信息，导致发两次欢迎词
-	if ok && groupInfo.ShowGroupWelcome {
-		isDouble := false
-		if lastWelcome != nil {
-			isDouble = msg.GroupID == lastWelcome.GroupID &&
-				msg.Sender.UserID == lastWelcome.UserID &&
-				msg.Time == lastWelcome.Time
-		}
-		lastWelcome = &LastWelcomeInfo{
-			GroupID: msg.GroupID,
-			UserID:  msg.Sender.UserID,
-			Time:    msg.Time,
-		}
-
-		if !isDouble {
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Errorf("迎新致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
-					}
-				}()
-
-				// Ensure context has group set for formatting and attrs access
-				ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
-				// VarSetValueStr(ctx, "$t新人昵称", "<"+msgQQ.Sender.Nickname+">")
-				uidRaw := UserIDExtract(msg.Sender.UserID)
-				VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
-				VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
-				stdID := msg.Sender.UserID
-				VarSetValueStr(ctx, "$t帐号ID", stdID)
-				VarSetValueStr(ctx, "$t账号ID", stdID)
-				text := DiceFormat(ctx, groupInfo.GroupWelcomeMessage)
-				for _, i := range ctx.SplitText(text) {
-					doSleepQQ(ctx)
-					ReplyGroup(ctx, msg, strings.TrimSpace(i))
-				}
-			}()
-		}
+	isDouble := false
+	if lastGroupMemberWelcome != nil {
+		isDouble = msg.GroupID == lastGroupMemberWelcome.GroupID &&
+			msg.Sender.UserID == lastGroupMemberWelcome.UserID &&
+			msg.Time == lastGroupMemberWelcome.Time
 	}
+	lastGroupMemberWelcome = &LastWelcomeInfo{
+		GroupID: msg.GroupID,
+		UserID:  msg.Sender.UserID,
+		Time:    msg.Time,
+	}
+
+	if isDouble {
+		log.Infof("检查是否需要迎新: need_welcome=false reason=duplicate_event group_id=%s user_id=%s", msg.GroupID, msg.Sender.UserID)
+		return
+	}
+
+	log.Infof("检查是否需要迎新: need_welcome=true reason=%s group_id=%s user_id=%s", reason, msg.GroupID, msg.Sender.UserID)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("迎新致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
+			}
+		}()
+
+		// Ensure context has group set for formatting and attrs access
+		ctx.Group, ctx.Player = GetPlayerInfoBySender(ctx, msg)
+		uidRaw := UserIDExtract(msg.Sender.UserID)
+		VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
+		VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
+		stdID := msg.Sender.UserID
+		VarSetValueStr(ctx, "$t帐号ID", stdID)
+		VarSetValueStr(ctx, "$t账号ID", stdID)
+		text := DiceFormat(ctx, groupInfo.GroupWelcomeMessage)
+		log.Infof("发送迎新消息: group_id=%s user_id=%s text=%q", msg.GroupID, msg.Sender.UserID, text)
+		for _, i := range ctx.SplitText(text) {
+			doSleepQQ(ctx)
+			ReplyGroup(ctx, msg, strings.TrimSpace(i))
+		}
+	}()
 }
 
 var platformRE = regexp.MustCompile(`^(.*)-Group:`)

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -660,7 +660,9 @@ type IMSession struct {
 	ServiceAtNew *SyncMap[string, *GroupInfo]       `json:"servicesAt" yaml:"-"`
 	PendingQuits *SyncMap[string, *PendingQuitInfo] `json:"-" yaml:"-"`
 
-	endPointsSnapshot atomic.Pointer[[]*EndPointInfo]
+	endPointsSnapshot      atomic.Pointer[[]*EndPointInfo]
+	groupMemberWelcomeMu   sync.Mutex
+	lastGroupMemberWelcome *LastWelcomeInfo
 }
 
 // EndPointDisplaySnapshot 是托盘菜单所需的端点展示值快照。
@@ -1703,7 +1705,22 @@ func (s *IMSession) OnGroupJoined(ctx *MsgContext, msg *Message) {
 	}
 }
 
-var lastGroupMemberWelcome *LastWelcomeInfo
+func (s *IMSession) isDuplicateGroupMemberWelcome(msg *Message) bool {
+	s.groupMemberWelcomeMu.Lock()
+	defer s.groupMemberWelcomeMu.Unlock()
+
+	last := s.lastGroupMemberWelcome
+	isDuplicate := last != nil &&
+		msg.GroupID == last.GroupID &&
+		msg.Sender.UserID == last.UserID &&
+		msg.Time == last.Time
+	s.lastGroupMemberWelcome = &LastWelcomeInfo{
+		GroupID: msg.GroupID,
+		UserID:  msg.Sender.UserID,
+		Time:    msg.Time,
+	}
+	return isDuplicate
+}
 
 // OnGroupMemberJoined 群成员进群事件处理，除了 bot 自己以外的群成员入群时调用。其他 Adapter 应当尽快迁移至此方法实现
 func (s *IMSession) OnGroupMemberJoined(ctx *MsgContext, msg *Message) {
@@ -1728,19 +1745,7 @@ func (s *IMSession) OnGroupMemberJoined(ctx *MsgContext, msg *Message) {
 	// 进群的是别人，是否迎新？
 	// 这里很诡异，当手机QQ客户端审批进群时，入群后会有一句默认发言
 	// 此时会收到两次完全一样的某用户入群信息，导致发两次欢迎词
-	isDouble := false
-	if lastGroupMemberWelcome != nil {
-		isDouble = msg.GroupID == lastGroupMemberWelcome.GroupID &&
-			msg.Sender.UserID == lastGroupMemberWelcome.UserID &&
-			msg.Time == lastGroupMemberWelcome.Time
-	}
-	lastGroupMemberWelcome = &LastWelcomeInfo{
-		GroupID: msg.GroupID,
-		UserID:  msg.Sender.UserID,
-		Time:    msg.Time,
-	}
-
-	if isDouble {
+	if s.isDuplicateGroupMemberWelcome(msg) {
 		log.Infof("检查是否需要迎新: need_welcome=false reason=duplicate_event group_id=%s user_id=%s", msg.GroupID, msg.Sender.UserID)
 		return
 	}

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -856,8 +856,9 @@ func TestPureOnebotScheduleLoginInfoRetryRechecksGuardsAfterSleeping(t *testing.
 }
 
 func TestPureOnebotHandleJoinGroupStoresInviterForSelfJoin(t *testing.T) {
-	_, pa, _, cleanup := newPureOnebotTestAdapter(t)
+	d, pa, em, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
+	d.Config.NoticeIDs = []string{pa.EndPoint.UserID + ":only=group"}
 
 	req := gjson.Parse(`{
 		"post_type":"notice",
@@ -872,6 +873,11 @@ func TestPureOnebotHandleJoinGroupStoresInviterForSelfJoin(t *testing.T) {
 
 	if err := pa.handleJoinGroupAction(req, nil); err != nil {
 		t.Fatalf("handleJoinGroupAction returned error: %v", err)
+	}
+	select {
+	case <-em.sendPvtCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected self join processing to complete")
 	}
 
 	group, ok := pa.EndPoint.Session.ServiceAtNew.Load("QQ-Group:66666")
@@ -1084,10 +1090,6 @@ func TestPureOnebotHandleJoinGroupDeduplicatesRepeatedEvent(t *testing.T) {
 		DiceIDExistsMap:     new(SyncMap[string, bool]),
 	})
 
-	oldLastWelcome := lastGroupMemberWelcome
-	defer func() { lastGroupMemberWelcome = oldLastWelcome }()
-	lastGroupMemberWelcome = nil
-
 	req := gjson.Parse(`{
 		"post_type":"notice",
 		"notice_type":"group_increase",
@@ -1098,27 +1100,32 @@ func TestPureOnebotHandleJoinGroupDeduplicatesRepeatedEvent(t *testing.T) {
 		"message": []
 	}`)
 
-	if err := pa.handleJoinGroupAction(req, nil); err != nil {
-		t.Fatalf("handleJoinGroupAction returned error for first event: %v", err)
+	const eventCount = 8
+	for i := range eventCount {
+		if err := pa.handleJoinGroupAction(req, nil); err != nil {
+			t.Fatalf("handleJoinGroupAction returned error for event %d: %v", i+1, err)
+		}
 	}
 
 	select {
 	case <-em.sendGrCh:
 	case <-time.After(3 * time.Second):
-		t.Fatal("expected welcome message to be sent for first event")
+		t.Fatal("expected one welcome message to be sent")
 	}
 
-	if err := pa.handleJoinGroupAction(req, nil); err != nil {
-		t.Fatalf("handleJoinGroupAction returned error for repeated event: %v", err)
-	}
+	waitPureOnebotInfoLogCount(t, observed, "检查是否需要迎新", eventCount)
 
-	waitPureOnebotInfoLog(t, observed, "reason=duplicate_event")
+	select {
+	case <-em.sendGrCh:
+		t.Fatal("expected repeated concurrent events to be deduplicated")
+	default:
+	}
 
 	if len(observed.FilterMessageSnippet("need_welcome=true").All()) != 1 {
 		t.Fatalf("expected exactly one need_welcome=true log, got %d", len(observed.FilterMessageSnippet("need_welcome=true").All()))
 	}
-	if len(observed.FilterMessageSnippet("reason=duplicate_event").All()) != 1 {
-		t.Fatalf("expected one duplicate_event reason log, got %d", len(observed.FilterMessageSnippet("reason=duplicate_event").All()))
+	if len(observed.FilterMessageSnippet("reason=duplicate_event").All()) != eventCount-1 {
+		t.Fatalf("expected %d duplicate_event logs, got %d", eventCount-1, len(observed.FilterMessageSnippet("reason=duplicate_event").All()))
 	}
 	if len(observed.FilterMessageSnippet("发送迎新消息").All()) != 1 {
 		t.Fatalf("expected exactly one welcome send log, got %d", len(observed.FilterMessageSnippet("发送迎新消息").All()))
@@ -1127,13 +1134,18 @@ func TestPureOnebotHandleJoinGroupDeduplicatesRepeatedEvent(t *testing.T) {
 
 func waitPureOnebotInfoLog(t *testing.T, observed *observer.ObservedLogs, snippet string) {
 	t.Helper()
+	waitPureOnebotInfoLogCount(t, observed, snippet, 1)
+}
+
+func waitPureOnebotInfoLogCount(t *testing.T, observed *observer.ObservedLogs, snippet string, count int) {
+	t.Helper()
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if len(observed.FilterMessageSnippet(snippet).All()) > 0 {
+		if len(observed.FilterMessageSnippet(snippet).All()) >= count {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for log snippet %q", snippet)
+	t.Fatalf("timed out waiting for %d log entries containing %q", count, snippet)
 }

--- a/dice/platform_adapter_onebot_internal_test.go
+++ b/dice/platform_adapter_onebot_internal_test.go
@@ -37,6 +37,7 @@ type onebotTestEmitter struct {
 	loginInfoErr         error
 	sendPvtCh            chan time.Time
 	sendGrCh             chan time.Time
+	lastGrID             int64
 }
 
 type friendReqCall struct {
@@ -70,7 +71,8 @@ func (m *onebotTestEmitter) SendPvtMsg(context.Context, int64, schema.MessageCha
 	return &emitterTypes.SendMsgRes{}, nil
 }
 
-func (m *onebotTestEmitter) SendGrMsg(context.Context, int64, schema.MessageChain) (*emitterTypes.SendMsgRes, error) {
+func (m *onebotTestEmitter) SendGrMsg(_ context.Context, groupID int64, _ schema.MessageChain) (*emitterTypes.SendMsgRes, error) {
+	m.lastGrID = groupID
 	if m.sendGrCh != nil {
 		select {
 		case m.sendGrCh <- time.Now():
@@ -881,12 +883,50 @@ func TestPureOnebotHandleJoinGroupStoresInviterForSelfJoin(t *testing.T) {
 	}
 }
 
-func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenGroupMissing(t *testing.T) {
-	_, pa, _, cleanup := newPureOnebotTestAdapter(t)
+func TestPureOnebotHandleJoinGroupSelfJoinUsesIMSessionNoticeFlow(t *testing.T) {
+	d, pa, em, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
 
 	core, observed := observer.New(zapcore.InfoLevel)
-	pa.logger = zap.New(core).Sugar()
+	d.Logger = zap.New(core).Sugar()
+	pa.logger = d.Logger
+	pa.EndPoint.Session.Parent.Logger = d.Logger
+	d.Config.NoticeIDs = []string{pa.EndPoint.UserID + ":only=group"}
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
+
+	req := gjson.Parse(`{
+		"post_type":"notice",
+		"notice_type":"group_increase",
+		"group_id":"66666",
+		"user_id":"54321",
+		"self_id":"54321",
+		"operator_id":"12345",
+		"time": 1,
+		"message": []
+	}`)
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error: %v", err)
+	}
+
+	select {
+	case <-em.sendPvtCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected self join to send group notice via IMSession flow")
+	}
+
+	waitPureOnebotInfoLog(t, observed, "加入群组:")
+}
+
+func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenGroupMissing(t *testing.T) {
+	d, pa, _, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	d.Logger = zap.New(core).Sugar()
+	pa.logger = d.Logger
+	pa.EndPoint.Session.Parent.Logger = d.Logger
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
 
@@ -921,11 +961,13 @@ func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenGroupMissing(t *testing.T) {
 }
 
 func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenDisabled(t *testing.T) {
-	_, pa, _, cleanup := newPureOnebotTestAdapter(t)
+	d, pa, _, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
 
 	core, observed := observer.New(zapcore.InfoLevel)
-	pa.logger = zap.New(core).Sugar()
+	d.Logger = zap.New(core).Sugar()
+	pa.logger = d.Logger
+	pa.EndPoint.Session.Parent.Logger = d.Logger
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
 
@@ -964,11 +1006,13 @@ func TestPureOnebotHandleJoinGroupLogsNoWelcomeWhenDisabled(t *testing.T) {
 }
 
 func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
-	_, pa, em, cleanup := newPureOnebotTestAdapter(t)
+	d, pa, em, cleanup := newPureOnebotTestAdapter(t)
 	defer cleanup()
 
 	core, observed := observer.New(zapcore.InfoLevel)
-	pa.logger = zap.New(core).Sugar()
+	d.Logger = zap.New(core).Sugar()
+	pa.logger = d.Logger
+	pa.EndPoint.Session.Parent.Logger = d.Logger
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
 	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
 
@@ -999,6 +1043,10 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 		t.Fatal("expected welcome message to be sent")
 	}
 
+	if em.lastGrID != 77777 {
+		t.Fatalf("expected welcome sent to normalized group 77777, got %d", em.lastGrID)
+	}
+
 	if len(observed.FilterMessageSnippet("need_welcome=true").All()) != 1 {
 		t.Fatalf("expected need_welcome=true log, got %d", len(observed.FilterMessageSnippet("need_welcome=true").All()))
 	}
@@ -1017,6 +1065,66 @@ func TestPureOnebotHandleJoinGroupLogsWelcomeDecisionAndSend(t *testing.T) {
 		t.Fatalf("unexpected welcome send log: %q", sendLog)
 	}
 }
+
+func TestPureOnebotHandleJoinGroupDeduplicatesRepeatedEvent(t *testing.T) {
+	d, pa, em, cleanup := newPureOnebotTestAdapter(t)
+	defer cleanup()
+
+	core, observed := observer.New(zapcore.InfoLevel)
+	d.Logger = zap.New(core).Sugar()
+	pa.logger = d.Logger
+	pa.EndPoint.Session.Parent.Logger = d.Logger
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeStart = 0
+	pa.EndPoint.Session.Parent.Config.MessageDelayRangeEnd = 0
+
+	pa.EndPoint.Session.ServiceAtNew.Store("QQ-Group:88888", &GroupInfo{
+		GroupID:             "QQ-Group:88888",
+		ShowGroupWelcome:    true,
+		GroupWelcomeMessage: "欢迎新人",
+		DiceIDExistsMap:     new(SyncMap[string, bool]),
+	})
+
+	oldLastWelcome := lastGroupMemberWelcome
+	defer func() { lastGroupMemberWelcome = oldLastWelcome }()
+	lastGroupMemberWelcome = nil
+
+	req := gjson.Parse(`{
+		"post_type":"notice",
+		"notice_type":"group_increase",
+		"group_id":88888,
+		"user_id":22222,
+		"self_id":54321,
+		"time": 2,
+		"message": []
+	}`)
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error for first event: %v", err)
+	}
+
+	select {
+	case <-em.sendGrCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected welcome message to be sent for first event")
+	}
+
+	if err := pa.handleJoinGroupAction(req, nil); err != nil {
+		t.Fatalf("handleJoinGroupAction returned error for repeated event: %v", err)
+	}
+
+	waitPureOnebotInfoLog(t, observed, "reason=duplicate_event")
+
+	if len(observed.FilterMessageSnippet("need_welcome=true").All()) != 1 {
+		t.Fatalf("expected exactly one need_welcome=true log, got %d", len(observed.FilterMessageSnippet("need_welcome=true").All()))
+	}
+	if len(observed.FilterMessageSnippet("reason=duplicate_event").All()) != 1 {
+		t.Fatalf("expected one duplicate_event reason log, got %d", len(observed.FilterMessageSnippet("reason=duplicate_event").All()))
+	}
+	if len(observed.FilterMessageSnippet("发送迎新消息").All()) != 1 {
+		t.Fatalf("expected exactly one welcome send log, got %d", len(observed.FilterMessageSnippet("发送迎新消息").All()))
+	}
+}
+
 func waitPureOnebotInfoLog(t *testing.T, observed *observer.ObservedLogs, snippet string) {
 	t.Helper()
 

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -266,7 +266,7 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 	// 1. 如果发现进群的是自己，要和大家发入群致辞
 	// 2. 如果发现进群的不是自己，对他进行节流的迎新
 	session := p.EndPoint.Session
-	ctx := &MsgContext{EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
+	ctx := &MsgContext{MessageType: "group", EndPoint: p.EndPoint, Session: session, Dice: session.Parent}
 	msg, err := arrayByte2SealdiceMessage(p.logger, []byte(req.String()))
 	if err != nil {
 		return err
@@ -277,70 +277,27 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 	// 迎新逻辑
 	// 发送入群致辞逻辑
 	if userId == selfId {
-		p.logger.Infof("收到自己的入群请求，准备发送入群致辞")
+		p.logger.Infof("收到自己的入群请求，准备转交统一入群处理")
 		ctx.Group = SetBotOnAtGroup(ctx, groupId)
-		ctx.Group.DiceIDExistsMap.Store(ctx.EndPoint.UserID, true)
 		operatorID := canonicalOnebotUserID(req.Get("operator_id").String())
 		if operatorID != "" && operatorID != selfId {
-			ctx.Group.InviteUserID = operatorID
+			msg.Sender.UserID = operatorID
 		}
-		// 入群时间
-		ctx.Group.EnteredTime = time.Now().Unix()
-		// 标记脏数据
-		ctx.Group.MarkDirty(ctx.Dice)
-		// 获取群信息 并发送入群致辞
+		ctx.Group.InviteUserID = msg.Sender.UserID
+		msg.MessageType = "group"
+		msg.Platform = "QQ"
+		msg.GroupID = groupId
 		_ = p.submitAsync(func() {
-			time.Sleep(1 * time.Second)
-			cache := p.GetGroupCacheInfo(groupId)
-			ctx.Player = &GroupPlayerInfo{}
-			p.logger.Infof("发送入群致辞，群: <%s>(%s)", cache.GroupName, groupId)
-			text := DiceFormatTmpl(ctx, "核心:骰子进群")
-			for _, i := range ctx.SplitText(text) {
-				doSleepQQ(ctx)
-				p.SendToGroup(ctx, groupId, strings.TrimSpace(i), "")
-			}
-			if groupInfo, ok := ctx.Session.ServiceAtNew.Load(groupId); ok {
-				groupInfo.TriggerExtHook(ctx.Dice, func(ext *ExtInfo) func() {
-					if ext.OnGroupJoined == nil {
-						return nil
-					}
-					return func() { ext.OnGroupJoined(ctx, msg) }
-				})
-			}
+			session.OnGroupJoined(ctx, msg)
 		})
 	} else {
 		p.logger.Infof("收到非自己的入群通知: group_id=%s user_id=%s", groupId, userId)
+		msg.MessageType = "group"
+		msg.Platform = "QQ"
+		msg.GroupID = groupId
+		msg.Sender.UserID = userId
 		_ = p.submitAsync(func() {
-			time.Sleep(1 * time.Second) // 避免是正在拉人进群的情况（此时会出现大量的迎新），先等一下再取数据
-			targetGroupID := groupId
-			group, ok := ctx.Session.ServiceAtNew.Load(targetGroupID)
-			needWelcome := false
-			reason := "group_not_loaded"
-			if ok && group.ShowGroupWelcome {
-				needWelcome = true
-				reason = "welcome_enabled"
-			} else if ok {
-				reason = "welcome_disabled"
-			}
-			p.logger.Infof("检查是否需要迎新: need_welcome=%t reason=%s group_id=%s user_id=%s", needWelcome, reason, targetGroupID, userId)
-			if !needWelcome {
-				return
-			}
-
-			ctx.Group = group
-			ctx.Player = &GroupPlayerInfo{}
-			uidRaw := req.Get("user_id").String()
-			VarSetValueStr(ctx, "$t帐号ID_RAW", uidRaw)
-			VarSetValueStr(ctx, "$t账号ID_RAW", uidRaw)
-			stdID := userId
-			VarSetValueStr(ctx, "$t帐号ID", stdID)
-			VarSetValueStr(ctx, "$t账号ID", stdID)
-			text := DiceFormat(ctx, group.GroupWelcomeMessage)
-			p.logger.Infof("发送迎新消息: group_id=%s user_id=%s text=%q", targetGroupID, userId, text)
-			for _, i := range ctx.SplitText(text) {
-				doSleepQQ(ctx)
-				p.SendToGroup(ctx, targetGroupID, strings.TrimSpace(i), "")
-			}
+			session.OnGroupMemberJoined(ctx, msg)
 		})
 	}
 

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -274,6 +274,10 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 	userId := canonicalOnebotUserID(req.Get("user_id").String())
 	selfId := canonicalOnebotUserID(req.Get("self_id").String())
 	groupId := canonicalOnebotGroupID(req.Get("group_id").String())
+	msg.MessageType = "group"
+	msg.Platform = "QQ"
+	msg.GroupID = groupId
+	msg.Sender.UserID = userId
 	// 迎新逻辑
 	// 发送入群致辞逻辑
 	if userId == selfId {
@@ -283,19 +287,11 @@ func (p *PlatformAdapterOnebot) handleJoinGroupAction(req gjson.Result, _ *evsoc
 		if operatorID != "" && operatorID != selfId {
 			msg.Sender.UserID = operatorID
 		}
-		ctx.Group.InviteUserID = msg.Sender.UserID
-		msg.MessageType = "group"
-		msg.Platform = "QQ"
-		msg.GroupID = groupId
 		_ = p.submitAsync(func() {
 			session.OnGroupJoined(ctx, msg)
 		})
 	} else {
 		p.logger.Infof("收到非自己的入群通知: group_id=%s user_id=%s", groupId, userId)
-		msg.MessageType = "group"
-		msg.Platform = "QQ"
-		msg.GroupID = groupId
-		msg.Sender.UserID = userId
 		_ = p.submitAsync(func() {
 			session.OnGroupMemberJoined(ctx, msg)
 		})


### PR DESCRIPTION
## Summary
- 将 pureonebot 的自己入群和成员入群迎新统一转交给 `IMSession.OnGroupJoined` / `IMSession.OnGroupMemberJoined`
- 对齐与 milky 一致的共享处理链路，保留最小改动，不引入 endpoint lifecycle / 状态机相关改造
- 补充 pureonebot 入群相关回归测试，包括 self join 通知链路、欢迎日志、重复 `group_increase` 去重
- 收口成员入群去重状态命名，消除 `golangci-lint` 的 `shadow` 告警

## Test Plan
- [x] `go test ./dice -run 'TestPureOnebot(FriendRequestUsesCanonicalUserIDForBlacklist|GroupInviteRejectStopsWithoutApprove|HandleJoinGroup.*)' -count=1`
- [x] `golangci-lint run ./...`

## Summary by Sourcery

将 pureonebot 的入群处理与 IMSession 流程对齐，并改进欢迎消息的日志记录和去重。

New Features:
- 通过统一的 `IMSession.OnGroupJoined` 流程路由 pureonebot 自身入群通知。
- 通过统一的 `IMSession.OnGroupMemberJoined` 流程路由 pureonebot 成员入群通知。

Bug Fixes:
- 规范 pureonebot 测试中用于发送欢迎消息的群 ID。
- 对重复的群成员入群事件进行去重，避免发送多条欢迎消息。

Enhancements:
- 在 IMSession 中集中处理群欢迎的决策与发送逻辑，并通过结构化日志记录原因和消息内容。
- 在 pureonebot 入群相关测试中复用主 bot 日志记录器，以便一致地观察日志。
- 在 onebot 测试发射器中追踪最后发送欢迎消息的群 ID，以验证欢迎消息的目标群。

Tests:
- 添加回归测试，覆盖通过 IMSession 路由自身入群通知、欢迎消息日志记录，以及 pureonebot 中重复 `group_increase` 事件的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align pureonebot group join handling with IMSession flows and improve logging and deduplication for welcome messages.

New Features:
- Route pureonebot self group join notices through the unified IMSession.OnGroupJoined flow.
- Route pureonebot member group join notices through the unified IMSession.OnGroupMemberJoined flow.

Bug Fixes:
- Normalize group IDs used for sending welcome messages in pureonebot tests.
- Deduplicate repeated group member join events to avoid sending multiple welcome messages.

Enhancements:
- Centralize group welcome decision and sending logic in IMSession with structured logging for reasons and message content.
- Reuse the main bot logger across pureonebot join-group tests for consistent log observation.
- Track the last sent group ID in the onebot test emitter to validate welcome targets.

Tests:
- Add regression tests covering self join notice routing via IMSession, welcome logging, and duplicate group_increase event handling in pureonebot.

</details>