### PR TITLE
fix(milky): 修复 Milky 不支持消息段导致的空消息发送错误

### DIFF
--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -54,6 +54,10 @@ func (pa *PlatformAdapterMilky) SendSegmentToGroup(ctx *MsgContext, groupID stri
 		return
 	}
 	elements := ParseMessageToMilky(msg)
+	if len(elements) == 0 {
+		log.Warnf("Skipping Milky group message to %s: no supported message elements", groupID)
+		return
+	}
 	ret, err := pa.IntentSession.SendGroupMessage(id, &elements)
 	if err != nil {
 		log.Errorf("Failed to send group message to %s: %v", groupID, err)
@@ -80,6 +84,10 @@ func (pa *PlatformAdapterMilky) SendSegmentToPerson(ctx *MsgContext, userID stri
 		return
 	}
 	elements := ParseMessageToMilky(msg)
+	if len(elements) == 0 {
+		log.Warnf("Skipping Milky private message to %s: no supported message elements", userID)
+		return
+	}
 	ret, err := pa.IntentSession.SendPrivateMessage(id, &elements)
 	if err != nil {
 		log.Errorf("Failed to send private message to %s: %v", userID, err)
@@ -881,6 +889,10 @@ func (pa *PlatformAdapterMilky) SendToPerson(ctx *MsgContext, uid string, text s
 		log.Errorf("Invalid user ID %s: %v", uid, err)
 		return
 	}
+	if len(elements) == 0 {
+		log.Warnf("Skipping Milky private message to %s: no supported message elements", uid)
+		return
+	}
 	ret, err := pa.IntentSession.SendPrivateMessage(id, &elements)
 	if err != nil {
 		log.Errorf("Failed to send private message to %s: %v", uid, err)
@@ -907,9 +919,25 @@ func (pa *PlatformAdapterMilky) SendToGroup(ctx *MsgContext, groupID string, tex
 		log.Errorf("Invalid group ID %s: %v", groupID, err)
 		return
 	}
+	nudgeTargets := make([]int64, 0)
+	for _, element := range send {
+		poke, ok := element.(*message.PokeElement)
+		if !ok {
+			continue
+		}
+		userID, parseErr := strconv.ParseInt(poke.Target, 10, 64)
+		if parseErr != nil || userID <= 0 {
+			log.Warnf("Skipping invalid Milky group nudge target %q", poke.Target)
+			continue
+		}
+		nudgeTargets = append(nudgeTargets, userID)
+	}
+	if len(elements) == 0 && len(nudgeTargets) == 0 {
+		log.Warnf("Skipping Milky group message to %s: no supported message elements", groupID)
+		return
+	}
 	var ret *milky.MessageRet
 	if len(elements) == 0 {
-		log.Debugf("No valid message elements to send to group %s", groupID)
 		ret = &milky.MessageRet{}
 	} else {
 		ret, err = pa.IntentSession.SendGroupMessage(id, &elements)
@@ -918,19 +946,13 @@ func (pa *PlatformAdapterMilky) SendToGroup(ctx *MsgContext, groupID string, tex
 		log.Errorf("Failed to send group message to %s: %v", groupID, err)
 		return
 	}
-	go func() {
-		for _, element := range send {
-			if poke, ok := element.(*message.PokeElement); ok {
-				log.Debugf("Sending group Nudge: %s", poke.Target)
-				userid, err2 := strconv.ParseInt(poke.Target, 10, 64)
-				if err2 != nil {
-					return
-				}
-				_ = pa.IntentSession.SendGroupNudge(id, userid)
-				doSleepQQ(ctx)
-			}
+	go func(targets []int64) {
+		for _, userID := range targets {
+			log.Debugf("Sending group Nudge: %d", userID)
+			_ = pa.IntentSession.SendGroupNudge(id, userID)
+			doSleepQQ(ctx)
 		}
-	}()
+	}(nudgeTargets)
 	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "QQ",
 		MessageType: "group",

--- a/dice/platform_adapter_milky_forward_test.go
+++ b/dice/platform_adapter_milky_forward_test.go
@@ -18,7 +18,10 @@ type milkyForwardRequest struct {
 	Message []struct {
 		Type string `json:"type"`
 		Data struct {
-			Messages []struct {
+			Text       string `json:"text"`
+			UserID     int64  `json:"user_id"`
+			MessageSeq int64  `json:"message_seq"`
+			Messages   []struct {
 				UserID     int64  `json:"user_id"`
 				SenderName string `json:"sender_name"`
 				LegacyName string `json:"name"`
@@ -40,11 +43,13 @@ type milkyForwardHarness struct {
 	mu       sync.Mutex
 	endpoint string
 	request  milkyForwardRequest
+	count    int
+	signal   chan struct{}
 }
 
 func newMilkyForwardHarness(t *testing.T, apiError string) (*milky.Session, *milkyForwardHarness, func()) {
 	t.Helper()
-	h := &milkyForwardHarness{t: t, apiError: apiError}
+	h := &milkyForwardHarness{t: t, apiError: apiError, signal: make(chan struct{}, 1)}
 	server := httptest.NewServer(http.HandlerFunc(h.handle))
 	session, err := milky.New("ws://127.0.0.1", server.URL, "", noopMilkyLogger{})
 	if err != nil {
@@ -66,7 +71,12 @@ func (h *milkyForwardHarness) handle(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	h.endpoint = strings.TrimPrefix(r.URL.Path, "/")
 	h.request = request
+	h.count++
 	h.mu.Unlock()
+	select {
+	case h.signal <- struct{}{}:
+	default:
+	}
 
 	if h.apiError != "" {
 		_ = json.NewEncoder(w).Encode(map[string]any{

--- a/dice/platform_adapter_milky_send_test.go
+++ b/dice/platform_adapter_milky_send_test.go
@@ -1,0 +1,240 @@
+//nolint:testpackage
+package dice
+
+import (
+	"testing"
+	"time"
+
+	milky "github.com/Szzrain/Milky-go-sdk"
+
+	"sealdice-core/message"
+)
+
+func (h *milkyForwardHarness) requestCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.count
+}
+
+func (h *milkyForwardHarness) waitForEndpoint(t *testing.T, expected string) milkyForwardRequest {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		endpoint, request := h.snapshot()
+		if endpoint == expected {
+			return request
+		}
+		select {
+		case <-h.signal:
+		case <-timer.C:
+			t.Fatalf("Milky endpoint = %q, want %q", endpoint, expected)
+			return milkyForwardRequest{}
+		}
+	}
+}
+
+func TestParseMessageToMilkyDropsShake(t *testing.T) {
+	segments := message.ConvertStringMessage("[CQ:shake]")
+	if len(segments) != 1 {
+		t.Fatalf("parsed segment count = %d, want 1", len(segments))
+	}
+	if _, ok := segments[0].(*message.DefaultElement); !ok {
+		t.Fatalf("parsed segment type = %T, want *message.DefaultElement", segments[0])
+	}
+	if converted := ParseMessageToMilky(segments); len(converted) != 0 {
+		t.Fatalf("converted Milky segment count = %d, want 0", len(converted))
+	}
+}
+
+func TestPlatformAdapterMilkySkipsMessagesWithoutSupportedElements(t *testing.T) {
+	shakeSegments := message.ConvertStringMessage("[CQ:shake]")
+	tests := []struct {
+		name string
+		send func(pa *PlatformAdapterMilky, ctx *MsgContext)
+	}{
+		{
+			name: "group string shake",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendToGroup(ctx, "QQ-Group:20020", "[CQ:shake]", "")
+			},
+		},
+		{
+			name: "private string shake",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendToPerson(ctx, "QQ:30030", "[CQ:shake]", "")
+			},
+		},
+		{
+			name: "group segment shake",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendSegmentToGroup(ctx, "QQ-Group:20020", shakeSegments, "")
+			},
+		},
+		{
+			name: "private segment shake",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendSegmentToPerson(ctx, "QQ:30030", shakeSegments, "")
+			},
+		},
+		{
+			name: "empty group string",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendToGroup(ctx, "QQ-Group:20020", "", "")
+			},
+		},
+		{
+			name: "invalid group poke",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendToGroup(ctx, "QQ-Group:20020", "[CQ:poke,qq=invalid]", "")
+			},
+		},
+		{
+			name: "invalid at segment",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendSegmentToPerson(ctx, "QQ:30030", []message.IMessageElement{&message.AtElement{Target: "invalid"}}, "")
+			},
+		},
+		{
+			name: "invalid reply segment",
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendSegmentToGroup(ctx, "QQ-Group:20020", []message.IMessageElement{&message.ReplyElement{ReplySeq: "invalid"}}, "")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session, harness, cleanup := newMilkyForwardHarness(t, "")
+			defer cleanup()
+
+			hookCalls := 0
+			pa, ctx := newMilkyForwardTestContext(session, func(_ *MsgContext, _ *Message, _ string) {
+				hookCalls++
+			})
+
+			test.send(pa, ctx)
+
+			if got := harness.requestCount(); got != 0 {
+				t.Fatalf("Milky request count = %d, want 0", got)
+			}
+			if hookCalls != 0 {
+				t.Fatalf("OnMessageSend calls = %d, want 0", hookCalls)
+			}
+		})
+	}
+}
+
+func TestPlatformAdapterMilkySendsSupportedPartsOfMixedMessage(t *testing.T) {
+	const text = "前缀[CQ:shake]后缀"
+	tests := []struct {
+		name         string
+		endpoint     string
+		messageType  string
+		wantGroupID  string
+		wantTargetID int64
+		send         func(pa *PlatformAdapterMilky, ctx *MsgContext)
+	}{
+		{
+			name:         "group",
+			endpoint:     milky.EndpointSendGroupMessage,
+			messageType:  "group",
+			wantGroupID:  "QQ-Group:20020",
+			wantTargetID: 20020,
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendToGroup(ctx, "QQ-Group:20020", text, "mixed")
+			},
+		},
+		{
+			name:         "private",
+			endpoint:     milky.EndpointSendPrivateMessage,
+			messageType:  "private",
+			wantTargetID: 30030,
+			send: func(pa *PlatformAdapterMilky, ctx *MsgContext) {
+				pa.SendToPerson(ctx, "QQ:30030", text, "mixed")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			session, harness, cleanup := newMilkyForwardHarness(t, "")
+			defer cleanup()
+
+			hookCalls := 0
+			var hookMessage *Message
+			pa, ctx := newMilkyForwardTestContext(session, func(_ *MsgContext, msg *Message, flag string) {
+				hookCalls++
+				hookMessage = msg
+				if flag != "mixed" {
+					t.Errorf("OnMessageSend flag = %q, want %q", flag, "mixed")
+				}
+			})
+
+			test.send(pa, ctx)
+
+			if got := harness.requestCount(); got != 1 {
+				t.Fatalf("Milky request count = %d, want 1", got)
+			}
+			endpoint, request := harness.snapshot()
+			if endpoint != test.endpoint {
+				t.Fatalf("endpoint = %q, want %q", endpoint, test.endpoint)
+			}
+			if test.messageType == "group" && request.GroupID != test.wantTargetID {
+				t.Errorf("group_id = %d, want %d", request.GroupID, test.wantTargetID)
+			}
+			if test.messageType == "private" && request.UserID != test.wantTargetID {
+				t.Errorf("user_id = %d, want %d", request.UserID, test.wantTargetID)
+			}
+			if len(request.Message) != 2 {
+				t.Fatalf("message segment count = %d, want 2", len(request.Message))
+			}
+			wantText := []string{"前缀", "后缀"}
+			for index, segment := range request.Message {
+				if segment.Type != string(milky.Text) || segment.Data.Text != wantText[index] {
+					t.Errorf("message segment %d = (%q, %q), want (%q, %q)", index, segment.Type, segment.Data.Text, milky.Text, wantText[index])
+				}
+			}
+			if hookCalls != 1 || hookMessage == nil {
+				t.Fatalf("OnMessageSend calls = %d, want 1", hookCalls)
+			}
+			if hookMessage.MessageType != test.messageType || hookMessage.GroupID != test.wantGroupID {
+				t.Errorf("hook destination = (%q, %q), want (%q, %q)", hookMessage.MessageType, hookMessage.GroupID, test.messageType, test.wantGroupID)
+			}
+			if hookMessage.Message != text || hookMessage.RawID != int64(321) {
+				t.Errorf("hook message = (%q, %d), want (%q, 321)", hookMessage.Message, hookMessage.RawID, text)
+			}
+		})
+	}
+}
+
+func TestPlatformAdapterMilkyPreservesGroupPoke(t *testing.T) {
+	session, harness, cleanup := newMilkyForwardHarness(t, "")
+	defer cleanup()
+
+	hookCalls := 0
+	var hookMessage *Message
+	pa, ctx := newMilkyForwardTestContext(session, func(_ *MsgContext, msg *Message, _ string) {
+		hookCalls++
+		hookMessage = msg
+	})
+
+	pa.SendToGroup(ctx, "QQ-Group:20020", "[CQ:poke,qq=30030]", "")
+
+	request := harness.waitForEndpoint(t, milky.EndpointSendGroupNudge)
+	if got := harness.requestCount(); got != 1 {
+		t.Fatalf("Milky request count = %d, want 1", got)
+	}
+	if request.GroupID != int64(20020) || request.UserID != int64(30030) {
+		t.Errorf("nudge target = (%d, %d), want (20020, 30030)", request.GroupID, request.UserID)
+	}
+	if len(request.Message) != 0 {
+		t.Errorf("nudge unexpectedly contains message segments: %#v", request.Message)
+	}
+	if hookCalls != 1 || hookMessage == nil {
+		t.Fatalf("OnMessageSend calls = %d, want 1", hookCalls)
+	}
+	if hookMessage.MessageType != "group" || hookMessage.GroupID != "QQ-Group:20020" || hookMessage.RawID != int64(0) {
+		t.Errorf("hook message = (%q, %q, %d), want (%q, %q, 0)", hookMessage.MessageType, hookMessage.GroupID, hookMessage.RawID, "group", "QQ-Group:20020")
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

防止 Milky 适配器发送空的或不受支持的 QQ 消息，并确保群聊戳一戳（nudge）操作安全处理。

Bug 修复：
- 当不存在受支持的消息元素时，避免发送 Milky 群消息和私聊消息。
- 防止只包含不受支持元素的群发消息产生空消息，同时仍然允许发送合法的戳一戳（nudge）。

增强功能：
- 优化 Milky 适配器中的群聊戳一戳（group nudge）处理，以验证目标并支持批量发送。

测试：
- 新增单元测试，用于覆盖丢弃不受支持的抖动（shake）片段以及在仅有不受支持元素时跳过发送的逻辑。
- 新增测试，验证混合消息只发送受支持的文本部分，并确保群聊戳一戳（group poke）操作被正确保留。
- 扩展 Milky 转发测试工具，增加请求计数和端点等待辅助功能，以供新测试使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent Milky adapter from sending empty or unsupported QQ messages and ensure group nudges are handled safely.

Bug Fixes:
- Avoid sending Milky group and private messages when no supported message elements are present.
- Prevent group sends that contain only unsupported elements from producing empty messages while still allowing valid nudges to be sent.

Enhancements:
- Refine group nudge handling in the Milky adapter to validate targets and batch sending.

Tests:
- Add unit tests covering dropping unsupported shake segments and skipping sends with only unsupported elements.
- Add tests verifying mixed messages send only supported text parts and that group poke operations are preserved correctly.
- Extend the Milky forward test harness with request counting and endpoint waiting utilities used by the new tests.

</details>