### PR TITLE
feat(backup): 实现安全的进程内备份恢复

### DIFF
--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 	"runtime/debug"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -124,9 +127,158 @@ func hello2(c echo.Context) error {
 }
 
 var (
-	myDice *dice.Dice
-	dm     *dice.DiceManager
+	myDice               *dice.Dice
+	dm                   *dice.DiceManager
+	runtimeGate          sync.RWMutex
+	runtimeMaintenanceMu sync.Mutex
+	runtimeState         atomic.Int32
+	runtimeAuth          atomic.Pointer[runtimeAuthSnapshot]
+	runtimeRestoreFn     func(operationID string) bool
 )
+
+const (
+	runtimeStateRunning int32 = iota
+	runtimeStateReloading
+	runtimeStateUnavailable
+	runtimeGatePollInterval = 5 * time.Millisecond
+)
+
+type runtimeAuthSnapshot struct {
+	Salt             string
+	PasswordRequired bool
+}
+
+func runtimeUnavailableResponse(c echo.Context) error {
+	code := "RUNTIME_RELOADING"
+	message := "Runtime 正在重新加载，请稍后重试"
+	if runtimeState.Load() == runtimeStateUnavailable {
+		code = "RUNTIME_UNAVAILABLE"
+		message = "Runtime 当前不可用"
+	}
+	return c.JSON(http.StatusServiceUnavailable, map[string]any{
+		"result": false,
+		"code":   code,
+		"err":    message,
+	})
+}
+
+func runtimeMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		requestPath := c.Request().URL.Path
+		if !strings.HasPrefix(requestPath, "/sd-api/") && !strings.HasPrefix(requestPath, "/dice/api/") {
+			return next(c)
+		}
+		if requestPath == "/sd-api/backup/restore/status" || requestPath == "/sd-api/signin/salt" {
+			return next(c)
+		}
+		if runtimeState.Load() != runtimeStateRunning {
+			return runtimeUnavailableResponse(c)
+		}
+		runtimeGate.RLock()
+		defer runtimeGate.RUnlock()
+		if runtimeState.Load() != runtimeStateRunning || dm == nil || myDice == nil {
+			return runtimeUnavailableResponse(c)
+		}
+		return next(c)
+	}
+}
+
+func lockRuntimeGateContext(ctx context.Context, tryLock func() bool, unlock func()) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(runtimeGatePollInterval)
+	defer ticker.Stop()
+	for {
+		if tryLock() {
+			if err := ctx.Err(); err != nil {
+				unlock()
+				return err
+			}
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func restoreRuntimeAvailabilityState() {
+	if dm == nil || myDice == nil {
+		runtimeState.Store(runtimeStateUnavailable)
+	} else {
+		runtimeState.Store(runtimeStateRunning)
+	}
+}
+
+func BeginRuntimeMaintenanceContext(ctx context.Context) error {
+	if err := lockRuntimeGateContext(ctx, runtimeMaintenanceMu.TryLock, runtimeMaintenanceMu.Unlock); err != nil {
+		return err
+	}
+	previousState := runtimeState.Swap(runtimeStateReloading)
+	if err := lockRuntimeGateContext(ctx, runtimeGate.TryLock, runtimeGate.Unlock); err != nil {
+		runtimeState.Store(previousState)
+		runtimeMaintenanceMu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func BeginRuntimeMaintenance() {
+	runtimeMaintenanceMu.Lock()
+	runtimeState.Store(runtimeStateReloading)
+	runtimeGate.Lock()
+}
+
+func ReplaceRuntime(manager *dice.DiceManager) {
+	if manager == nil || len(manager.Dice) == 0 || manager.Dice[0] == nil {
+		dm = nil
+		myDice = nil
+		if runtimeState.Load() != runtimeStateReloading {
+			runtimeState.Store(runtimeStateUnavailable)
+		}
+		return
+	}
+	dm = manager
+	myDice = manager.Dice[0]
+	runtimeAuth.Store(&runtimeAuthSnapshot{
+		Salt:             manager.UIPasswordSalt,
+		PasswordRequired: manager.UIPasswordHash != "",
+	})
+	if runtimeState.Load() != runtimeStateReloading {
+		runtimeState.Store(runtimeStateRunning)
+	}
+}
+
+func EndRuntimeMaintenance() {
+	restoreRuntimeAvailabilityState()
+	runtimeGate.Unlock()
+	runtimeMaintenanceMu.Unlock()
+}
+
+// WithCurrentRuntime executes fn while the published Runtime is protected
+// from replacement. Callers must copy any data they need before fn returns.
+func WithCurrentRuntime(fn func(*dice.DiceManager)) bool {
+	if runtimeState.Load() != runtimeStateRunning {
+		return false
+	}
+	runtimeGate.RLock()
+	defer runtimeGate.RUnlock()
+	if runtimeState.Load() != runtimeStateRunning || dm == nil || myDice == nil || fn == nil {
+		return false
+	}
+	fn(dm)
+	return true
+}
+
+func SetRuntimeRestoreFunc(fn func(operationID string) bool) {
+	runtimeRestoreFn = fn
+}
 
 type fStopEcho struct {
 	Key string `json:"key"`
@@ -216,8 +368,14 @@ func forceStop(c echo.Context) error {
 }
 
 func doSignInGetSalt(c echo.Context) error {
-	return c.JSON(http.StatusOK, map[string]string{
-		"salt": myDice.Parent.UIPasswordSalt,
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+	auth := runtimeAuth.Load()
+	if auth == nil {
+		return runtimeUnavailableResponse(c)
+	}
+	return c.JSON(http.StatusOK, map[string]any{
+		"salt":             auth.Salt,
+		"passwordRequired": auth.PasswordRequired,
 	})
 }
 
@@ -577,8 +735,8 @@ func checkCronExpr(c echo.Context) error {
 }
 
 func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
-	dm = _myDice
-	myDice = _myDice.Dice[0]
+	ReplaceRuntime(_myDice)
+	e.Use(runtimeMiddleware)
 
 	prefix := "/sd-api"
 
@@ -669,6 +827,9 @@ func Bind(e *echo.Echo, _myDice *dice.DiceManager) {
 	e.GET(prefix+"/backup/download", backupDownload)
 	e.POST(prefix+"/backup/delete", backupDelete)
 	e.POST(prefix+"/backup/batch_delete", backupBatchDelete)
+	e.POST(prefix+"/backup/upload", backupUpload)
+	e.POST(prefix+"/backup/restore", backupRestore)
+	e.GET(prefix+"/backup/restore/status", backupRestoreStatus)
 
 	e.GET(prefix+"/group/list", groupList)
 	e.POST(prefix+"/group/set_one", groupSetOne)

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -148,7 +148,18 @@ type runtimeAuthSnapshot struct {
 	PasswordRequired bool
 }
 
+func refreshRuntimeAuth() {
+	if dm == nil {
+		return
+	}
+	runtimeAuth.Store(&runtimeAuthSnapshot{
+		Salt:             dm.UIPasswordSalt,
+		PasswordRequired: dm.UIPasswordHash != "",
+	})
+}
+
 func runtimeUnavailableResponse(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
 	code := "RUNTIME_RELOADING"
 	message := "Runtime 正在重新加载，请稍后重试"
 	if runtimeState.Load() == runtimeStateUnavailable {
@@ -246,10 +257,7 @@ func ReplaceRuntime(manager *dice.DiceManager) {
 	}
 	dm = manager
 	myDice = manager.Dice[0]
-	runtimeAuth.Store(&runtimeAuthSnapshot{
-		Salt:             manager.UIPasswordSalt,
-		PasswordRequired: manager.UIPasswordHash != "",
-	})
+	refreshRuntimeAuth()
 	if runtimeState.Load() != runtimeStateReloading {
 		runtimeState.Store(runtimeStateRunning)
 	}

--- a/api/api_bind.go
+++ b/api/api_bind.go
@@ -134,6 +134,7 @@ var (
 	runtimeState         atomic.Int32
 	runtimeAuth          atomic.Pointer[runtimeAuthSnapshot]
 	runtimeRestoreFn     func(operationID string) bool
+	runtimeForceStopFn   func()
 )
 
 const (
@@ -288,6 +289,12 @@ func SetRuntimeRestoreFunc(fn func(operationID string) bool) {
 	runtimeRestoreFn = fn
 }
 
+// SetRuntimeForceStopFunc injects the process-level Runtime stop path used by
+// the Android-only force_stop endpoint instead of its legacy inline cleanup.
+func SetRuntimeForceStopFunc(fn func()) {
+	runtimeForceStopFn = fn
+}
+
 type fStopEcho struct {
 	Key string `json:"key"`
 }
@@ -317,6 +324,15 @@ func forceStop(c echo.Context) error {
 	}
 	if !haskey {
 		return c.JSON(http.StatusForbidden, nil)
+	}
+	if runtimeForceStopFn != nil {
+		go func() {
+			// Let the handler release the runtime gate before stopping.
+			time.Sleep(100 * time.Millisecond)
+			runtimeForceStopFn()
+			os.Exit(0)
+		}()
+		return c.JSON(http.StatusOK, nil)
 	}
 	defer func() {
 		// Same with main.go `cleanUpCreate()` 由于无法导入 main.go 中的函数，所以这里直接复制过来了

--- a/api/backup.go
+++ b/api/backup.go
@@ -1,34 +1,40 @@
 package api
 
 import (
-	"io/fs"
+	"errors"
+	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
-	"strconv"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 
 	"sealdice-core/dice"
-	"sealdice-core/utils/crypto"
+	"sealdice-core/logger"
+	"sealdice-core/utils/constant"
 )
 
-type backupFileItem struct {
-	Name      string `json:"name"`
-	FileSize  int64  `json:"fileSize"`
-	Selection int64  `json:"selection"`
-}
+var restoreRequestIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{8,128}$`)
 
-func ReverseSlice(s interface{}) {
-	size := reflect.ValueOf(s).Len()
-	swap := reflect.Swapper(s)
-	for i, j := 0, size-1; i < j; i, j = i+1, j-1 {
-		swap(i, j)
+func applyRuntimeRestoreCapability(item *dice.BackupArchiveInfo) {
+	if item == nil {
+		return
 	}
+	if dm == nil || dm.Operator == nil {
+		item.Restorable = false
+		item.RestoreError = "Runtime 数据库尚未就绪"
+		return
+	}
+	if dm.Operator.Type() == constant.SQLITE {
+		return
+	}
+	item.Restorable = false
+	item.RestoreError = "当前实例使用外部数据库，仅支持导入、查看和下载备份"
 }
 
 func backupGetList(c echo.Context) error {
@@ -36,33 +42,40 @@ func backupGetList(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, nil)
 	}
 
-	reFn := regexp.MustCompile(`^(bak_\d{6}_\d{6}(?:_auto)?_r([0-9a-f]+))_([0-9a-f]{8})\.zip$`)
-
-	var items []*backupFileItem
-	_ = filepath.Walk(dice.BackupDir, func(path string, info fs.FileInfo, err error) error {
-		if !info.IsDir() {
-			fn := info.Name()
-			matches := reFn.FindStringSubmatch(fn)
-			selection := int64(0)
-			if len(matches) == 4 {
-				hashed := crypto.CalculateSHA512Str([]byte(matches[1]))
-				if hashed[:8] == matches[3] {
-					selection, _ = strconv.ParseInt(matches[2], 16, 64)
-				} else {
-					selection = -1
-				}
-			}
-
-			items = append(items, &backupFileItem{
-				Name:      fn,
-				FileSize:  info.Size(),
-				Selection: selection,
-			})
+	entries, err := os.ReadDir(dice.BackupDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return c.JSON(http.StatusOK, map[string]interface{}{"items": []*dice.BackupArchiveInfo{}})
+	}
+	if err != nil {
+		logger.M().Errorw("[备份列表] 读取备份目录失败", "error", err)
+		return Error(&c, "读取备份列表失败: "+err.Error(), Response{})
+	}
+	type listedBackup struct {
+		info    *dice.BackupArchiveInfo
+		modTime time.Time
+	}
+	listed := make([]listedBackup, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".zip") {
+			continue
 		}
-		return err
-	})
-
-	ReverseSlice(items)
+		entryInfo, infoErr := entry.Info()
+		if infoErr != nil {
+			logger.M().Warnw("[备份列表] 跳过无法读取的文件", "file", entry.Name(), "error", infoErr)
+			continue
+		}
+		archiveInfo := dice.InspectBackupArchive(filepath.Join(dice.BackupDir, entry.Name()))
+		applyRuntimeRestoreCapability(archiveInfo)
+		listed = append(listed, listedBackup{
+			info:    archiveInfo,
+			modTime: entryInfo.ModTime(),
+		})
+	}
+	sort.Slice(listed, func(i, j int) bool { return listed[i].modTime.After(listed[j].modTime) })
+	items := make([]*dice.BackupArchiveInfo, 0, len(listed))
+	for _, item := range listed {
+		items = append(items, item.info)
+	}
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"items": items,
 	})
@@ -79,10 +92,17 @@ func backupDownload(c echo.Context) error {
 	}
 
 	name := c.QueryParam("name")
-	if name != "" && (!strings.Contains(name, "/")) && (!strings.Contains(name, "\\")) {
-		return c.Attachment(dice.BackupDir+"/"+name, name)
+	archive, archiveInfo, err := dice.OpenBackupArchive(name)
+	if err != nil {
+		return Error(&c, err.Error(), Response{})
 	}
-	return c.JSON(http.StatusOK, nil)
+	defer archive.Close()
+	c.Response().Header().Set(
+		echo.HeaderContentDisposition,
+		mime.FormatMediaType("attachment", map[string]string{"filename": name}),
+	)
+	http.ServeContent(c.Response(), c.Request(), name, archiveInfo.ModTime(), archive)
+	return nil
 }
 
 func backupDelete(c echo.Context) error {
@@ -95,14 +115,13 @@ func backupDelete(c echo.Context) error {
 		})
 	}
 
-	var err error
 	name := c.QueryParam("name")
-	if name != "" && (!strings.Contains(name, "/")) && (!strings.Contains(name, "\\")) {
-		err = os.Remove(dice.BackupDir + "/" + name)
+	err := dice.DeleteBackup(name)
+	if err != nil {
+		return Error(&c, err.Error(), Response{})
 	}
-
 	return c.JSON(http.StatusOK, map[string]interface{}{
-		"success": err == nil,
+		"success": true,
 	})
 }
 
@@ -124,11 +143,8 @@ func backupBatchDelete(c echo.Context) error {
 
 	fails := make([]string, 0, len(v.Names))
 	for _, name := range v.Names {
-		if name != "" && (!strings.Contains(name, "/")) && (!strings.Contains(name, "\\")) {
-			err = os.Remove(dice.BackupDir + "/" + name)
-			if err != nil {
-				fails = append(fails, name)
-			}
+		if deleteErr := dice.DeleteBackup(name); deleteErr != nil {
+			fails = append(fails, name)
 		}
 	}
 
@@ -138,6 +154,119 @@ func backupBatchDelete(c echo.Context) error {
 	return Error(&c, "失败列表", Response{
 		"fails": fails,
 	})
+}
+
+func backupUpload(c echo.Context) error {
+	if !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	if dm.JustForTest {
+		return Error(&c, "展示模式不支持该操作", Response{"testMode": true})
+	}
+	reader, err := c.Request().MultipartReader()
+	if err != nil {
+		return Error(&c, "无法读取上传内容: "+err.Error(), Response{})
+	}
+	for {
+		part, nextErr := reader.NextPart()
+		if nextErr != nil {
+			if errors.Is(nextErr, io.EOF) {
+				break
+			}
+			return Error(&c, nextErr.Error(), Response{})
+		}
+		if part.FormName() != "file" {
+			_ = part.Close()
+			continue
+		}
+		originalName := filepath.Base(part.FileName())
+		logger.M().Infow("[备份导入] 开始接收并校验备份", "file", originalName)
+		item, importErr := dice.ImportBackup(part)
+		_ = part.Close()
+		if importErr != nil {
+			logger.M().Errorw("[备份导入] 导入失败", "file", originalName, "error", importErr)
+			return Error(&c, importErr.Error(), Response{})
+		}
+		applyRuntimeRestoreCapability(item)
+		if item.Reused {
+			logger.M().Infow("[备份导入] 内容已存在，复用已有文件: "+item.Name, "file", originalName, "storedAs", item.Name, "size", item.FileSize)
+		} else {
+			logger.M().Infow("[备份导入] 新文件已保存: "+item.Name, "file", originalName, "storedAs", item.Name, "size", item.FileSize)
+		}
+		return Success(&c, Response{"item": item})
+	}
+	return Error(&c, "请上传备份文件", Response{})
+}
+
+func backupRestore(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+	if !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	if dm.JustForTest {
+		return Error(&c, "展示模式不支持该操作", Response{"testMode": true})
+	}
+	var request struct {
+		Name      string `json:"name"`
+		RequestID string `json:"requestId"`
+	}
+	if err := c.Bind(&request); err != nil {
+		return Error(&c, err.Error(), Response{})
+	}
+	if !restoreRequestIDPattern.MatchString(request.RequestID) {
+		return Error(&c, "requestId 格式非法", Response{})
+	}
+	if runtimeRestoreFn == nil {
+		return Error(&c, "Runtime 恢复入口尚未初始化", Response{})
+	}
+	logger.M().Infow("[备份恢复] 收到恢复请求", "source", request.Name)
+	operation, err := dm.ScheduleRestore(request.Name, request.RequestID)
+	if err != nil {
+		logger.M().Errorw("[备份恢复] 创建恢复任务失败", "source", request.Name, "error", err)
+		return Error(&c, err.Error(), Response{})
+	}
+	logger.M().Infow(
+		"[备份恢复] 恢复任务已创建",
+		"operationId", operation.OperationID,
+		"source", request.Name,
+		"reused", operation.Reused,
+	)
+	if !runtimeRestoreFn(operation.OperationID) {
+		logger.M().Errorw(
+			"[备份恢复] Runtime 恢复任务未被调度器接收",
+			"operationId", operation.OperationID,
+		)
+		return Error(&c, "恢复任务已安全排队，但 Runtime 调度器暂不可用；请使用同一请求重试", Response{
+			"operationId": operation.OperationID,
+			"queued":      true,
+		})
+	}
+	return Success(&c, Response{
+		"safetyBackupName": operation.SafetyBackupName,
+		"operationId":      operation.OperationID,
+		"statusToken":      operation.StatusToken,
+		"expiresAt":        operation.ExpiresAt,
+		"reloading":        true,
+		"switchMode":       "runtime",
+	})
+}
+
+func backupRestoreStatus(c echo.Context) error {
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+	operationID := c.Request().Header.Get("X-Seal-Restore-Operation")
+	statusToken := c.Request().Header.Get("X-Seal-Restore-Token")
+	if status, ok := dice.GetRestoreStatusAuthorized(operationID, statusToken); ok {
+		return Success(&c, Response{"status": status})
+	}
+	if runtimeState.Load() != runtimeStateRunning {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	runtimeGate.RLock()
+	defer runtimeGate.RUnlock()
+	if myDice == nil || !doAuth(c) {
+		return c.JSON(http.StatusForbidden, nil)
+	}
+	return Success(&c, Response{"status": dice.GetRestoreStatus()})
 }
 
 // 快速备份

--- a/api/backup.go
+++ b/api/backup.go
@@ -94,7 +94,8 @@ func backupDownload(c echo.Context) error {
 	name := c.QueryParam("name")
 	archive, archiveInfo, err := dice.OpenBackupArchive(name)
 	if err != nil {
-		return Error(&c, err.Error(), Response{})
+		// Preserve the legacy response shape for invalid names.
+		return c.JSON(http.StatusOK, nil)
 	}
 	defer archive.Close()
 	c.Response().Header().Set(
@@ -118,7 +119,11 @@ func backupDelete(c echo.Context) error {
 	name := c.QueryParam("name")
 	err := dice.DeleteBackup(name)
 	if err != nil {
-		return Error(&c, err.Error(), Response{})
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"success": false,
+			"result":  false,
+			"err":     err.Error(),
+		})
 	}
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"success": true,
@@ -143,6 +148,10 @@ func backupBatchDelete(c echo.Context) error {
 
 	fails := make([]string, 0, len(v.Names))
 	for _, name := range v.Names {
+		// Preserve the legacy skip behavior for empty or path-shaped names.
+		if name == "" || strings.Contains(name, "/") || strings.Contains(name, "\\") {
+			continue
+		}
 		if deleteErr := dice.DeleteBackup(name); deleteErr != nil {
 			fails = append(fails, name)
 		}
@@ -167,6 +176,8 @@ func backupUpload(c echo.Context) error {
 	if err != nil {
 		return Error(&c, "无法读取上传内容: "+err.Error(), Response{})
 	}
+	partCount := 0
+	fileParts := 0
 	for {
 		part, nextErr := reader.NextPart()
 		if nextErr != nil {
@@ -175,9 +186,19 @@ func backupUpload(c echo.Context) error {
 			}
 			return Error(&c, nextErr.Error(), Response{})
 		}
+		partCount++
+		if partCount > 64 {
+			_ = part.Close()
+			return Error(&c, "上传包含过多表单字段", Response{})
+		}
 		if part.FormName() != "file" {
 			_ = part.Close()
 			continue
+		}
+		fileParts++
+		if fileParts > 1 {
+			_ = part.Close()
+			return Error(&c, "一次只能上传一个备份文件", Response{})
 		}
 		originalName := filepath.Base(part.FileName())
 		logger.M().Infow("[备份导入] 开始接收并校验备份", "file", originalName)
@@ -231,6 +252,20 @@ func backupRestore(c echo.Context) error {
 		"source", request.Name,
 		"reused", operation.Reused,
 	)
+	if operation.Reused {
+		status := dice.GetRestoreStatus()
+		if status.State == "succeeded" && status.OperationID == operation.OperationID {
+			return Success(&c, Response{
+				"safetyBackupName": operation.SafetyBackupName,
+				"operationId":      operation.OperationID,
+				"statusToken":      operation.StatusToken,
+				"expiresAt":        operation.ExpiresAt,
+				"reloading":        false,
+				"switchMode":       "runtime",
+				"status":           status,
+			})
+		}
+	}
 	if !runtimeRestoreFn(operation.OperationID) {
 		logger.M().Errorw(
 			"[备份恢复] Runtime 恢复任务未被调度器接收",

--- a/api/conn.go
+++ b/api/conn.go
@@ -194,7 +194,7 @@ func ImConnectionsDel(c echo.Context) error {
 					case "onebot":
 						pa := i.Adapter.(*dice.PlatformAdapterGocq)
 						if pa.BuiltinMode == "lagrange" || pa.BuiltinMode == "lagrange-gocq" {
-							dice.BuiltinQQServeProcessKillBase(myDice, i, true)
+							dice.BuiltinQQServeProcessKillBase(myDice, i)
 							// 经测试，若不延时，可能导致清理对应目录失败（原因：文件被占用）
 							time.Sleep(1 * time.Second)
 							dice.LagrangeServeRemoveConfig(myDice, i)

--- a/api/dice_config.go
+++ b/api/dice_config.go
@@ -377,6 +377,7 @@ func DiceConfigSet(c echo.Context) error {
 			myDice.Parent.UIPasswordHash = val.(string)
 			// 清空所有现有的访问令牌，强制重新登录
 			myDice.Parent.AccessTokens = dice.SyncMap[string, bool]{}
+			refreshRuntimeAuth()
 		}
 	}
 

--- a/api/runtime_gate_test.go
+++ b/api/runtime_gate_test.go
@@ -1,0 +1,263 @@
+package api //nolint:testpackage // Tests exercise the unexported Runtime maintenance gate.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"sealdice-core/dice"
+)
+
+func TestBeginRuntimeMaintenanceContextRestoresPublishedStateAfterTimeout(t *testing.T) {
+	manager := &dice.DiceManager{}
+	manager.Dice = []*dice.Dice{{Parent: manager}}
+	ReplaceRuntime(manager)
+	runtimeState.Store(runtimeStateRunning)
+	t.Cleanup(func() {
+		ReplaceRuntime(nil)
+		runtimeState.Store(runtimeStateRunning)
+	})
+
+	runtimeGate.RLock()
+	readerHeld := true
+	defer func() {
+		if readerHeld {
+			runtimeGate.RUnlock()
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if err := BeginRuntimeMaintenanceContext(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("maintenance error = %v, want context deadline exceeded", err)
+	}
+	if runtimeState.Load() != runtimeStateRunning || dm != manager || myDice != manager.Dice[0] {
+		t.Fatal("timed-out maintenance did not restore the published Runtime state")
+	}
+
+	runtimeGate.RUnlock()
+	readerHeld = false
+	if !runtimeMaintenanceMu.TryLock() {
+		t.Fatal("timed-out maintenance retained its acquisition lock")
+	}
+	runtimeMaintenanceMu.Unlock()
+	if !runtimeGate.TryLock() {
+		t.Fatal("timed-out maintenance retained the Runtime gate")
+	}
+	runtimeGate.Unlock()
+}
+
+func TestRuntimeMiddlewareOnlyBlocksAPIPaths(t *testing.T) {
+	runtimeState.Store(runtimeStateReloading)
+	t.Cleanup(func() { runtimeState.Store(runtimeStateRunning) })
+	handler := runtimeMiddleware(func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	e := echo.New()
+	staticRecorder := httptest.NewRecorder()
+	if err := handler(e.NewContext(httptest.NewRequest(http.MethodGet, "/", nil), staticRecorder)); err != nil {
+		t.Fatal(err)
+	}
+	if staticRecorder.Code != http.StatusNoContent {
+		t.Fatalf("static status = %d, want %d", staticRecorder.Code, http.StatusNoContent)
+	}
+
+	apiRecorder := httptest.NewRecorder()
+	if err := handler(e.NewContext(httptest.NewRequest(http.MethodGet, "/sd-api/baseInfo", nil), apiRecorder)); err != nil {
+		t.Fatal(err)
+	}
+	if apiRecorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("api status = %d, want %d", apiRecorder.Code, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(apiRecorder.Body.String(), "RUNTIME_RELOADING") {
+		t.Fatalf("api response = %s, want maintenance code", apiRecorder.Body.String())
+	}
+
+	for _, controlPath := range []string{"/sd-api/backup/restore/status", "/sd-api/signin/salt"} {
+		recorder := httptest.NewRecorder()
+		if err := handler(e.NewContext(httptest.NewRequest(http.MethodGet, controlPath, nil), recorder)); err != nil {
+			t.Fatal(err)
+		}
+		if recorder.Code != http.StatusNoContent {
+			t.Fatalf("control path %s status = %d, want %d", controlPath, recorder.Code, http.StatusNoContent)
+		}
+	}
+}
+
+func TestRuntimeMiddlewareReportsUnavailable(t *testing.T) {
+	runtimeState.Store(runtimeStateUnavailable)
+	t.Cleanup(func() { runtimeState.Store(runtimeStateRunning) })
+	handler := runtimeMiddleware(func(c echo.Context) error { return c.NoContent(http.StatusNoContent) })
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	if err := handler(e.NewContext(httptest.NewRequest(http.MethodGet, "/sd-api/baseInfo", nil), recorder)); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), "RUNTIME_UNAVAILABLE") {
+		t.Fatalf("response = %d %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRuntimeMiddlewareRechecksStateAfterWaitingForGate(t *testing.T) {
+	manager := &dice.DiceManager{}
+	manager.Dice = []*dice.Dice{{Parent: manager}}
+	ReplaceRuntime(manager)
+	runtimeState.Store(runtimeStateRunning)
+	t.Cleanup(func() {
+		ReplaceRuntime(nil)
+		runtimeState.Store(runtimeStateRunning)
+	})
+
+	handlerCalled := make(chan struct{}, 1)
+	handler := runtimeMiddleware(func(c echo.Context) error {
+		handlerCalled <- struct{}{}
+		return c.NoContent(http.StatusNoContent)
+	})
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/sd-api/config", nil)
+	requestDone := make(chan error, 1)
+
+	runtimeGate.Lock()
+	go func() {
+		requestDone <- handler(e.NewContext(request, recorder))
+	}()
+	// Give the request time to pass the optimistic state check and wait for
+	// the gate. The post-lock check remains correct if it has not run yet.
+	time.Sleep(20 * time.Millisecond)
+	runtimeState.Store(runtimeStateReloading)
+	runtimeGate.Unlock()
+
+	if err := <-requestDone; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handlerCalled:
+		t.Fatal("request entered handler after Runtime maintenance started")
+	default:
+	}
+	if recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), "RUNTIME_RELOADING") {
+		t.Fatalf("response = %d %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestReplaceRuntimeRejectsManagerWithoutDice(t *testing.T) {
+	runtimeState.Store(runtimeStateRunning)
+	ReplaceRuntime(&dice.DiceManager{})
+	t.Cleanup(func() {
+		ReplaceRuntime(nil)
+		runtimeState.Store(runtimeStateRunning)
+	})
+
+	if dm != nil || myDice != nil || runtimeState.Load() != runtimeStateUnavailable {
+		t.Fatalf("empty manager was published: dm=%p dice=%p state=%d", dm, myDice, runtimeState.Load())
+	}
+}
+
+func TestSignInSaltDeclaresWhetherPasswordIsRequired(t *testing.T) {
+	t.Cleanup(func() {
+		ReplaceRuntime(nil)
+		runtimeAuth.Store(nil)
+		runtimeState.Store(runtimeStateRunning)
+	})
+	for _, test := range []struct {
+		name     string
+		password string
+		want     string
+	}{
+		{name: "empty password", want: `"passwordRequired":false`},
+		{name: "configured password", password: "hash", want: `"passwordRequired":true`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			manager := &dice.DiceManager{UIPasswordSalt: "salt", UIPasswordHash: test.password}
+			manager.Dice = []*dice.Dice{{Parent: manager}}
+			ReplaceRuntime(manager)
+			e := echo.New()
+			recorder := httptest.NewRecorder()
+			ctx := e.NewContext(httptest.NewRequest(http.MethodGet, "/sd-api/signin/salt", nil), recorder)
+			if err := doSignInGetSalt(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(recorder.Body.String(), test.want) {
+				t.Fatalf("response = %s, want %s", recorder.Body.String(), test.want)
+			}
+			if recorder.Header().Get(echo.HeaderCacheControl) != "no-store" {
+				t.Fatalf("salt cache-control = %q", recorder.Header().Get(echo.HeaderCacheControl))
+			}
+		})
+	}
+}
+
+func installAPITestRuntime(t *testing.T) string {
+	t.Helper()
+	manager := &dice.DiceManager{}
+	manager.Dice = []*dice.Dice{{Parent: manager}}
+	token := "test-token"
+	manager.AccessTokens.Store(token, true)
+	ReplaceRuntime(manager)
+	runtimeState.Store(runtimeStateRunning)
+	t.Cleanup(func() {
+		ReplaceRuntime(nil)
+		runtimeAuth.Store(nil)
+		runtimeRestoreFn = nil
+		runtimeState.Store(runtimeStateRunning)
+	})
+	return token
+}
+
+func TestBackupListOnlyReadsRootArchives(t *testing.T) {
+	t.Chdir(t.TempDir())
+	token := installAPITestRuntime(t)
+	if err := os.MkdirAll(filepath.Join(dice.BackupDir, ".restore"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dice.BackupDir, "root.zip"), []byte("invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dice.BackupDir, ".restore", "source.zip"), []byte("invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/sd-api/backup/list", nil)
+	request.Header.Set("token", token) //nolint:canonicalheader // Private API compatibility header.
+	if err := backupGetList(e.NewContext(request, recorder)); err != nil {
+		t.Fatal(err)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "root.zip") || strings.Contains(body, "source.zip") {
+		t.Fatalf("unexpected backup list: %s", body)
+	}
+}
+
+func TestBackupRestoreRejectsInvalidRequestIDBeforeScheduling(t *testing.T) {
+	token := installAPITestRuntime(t)
+	runtimeRestoreFn = func(_ string) bool {
+		t.Fatal("restore callback must not run")
+		return false
+	}
+	e := echo.New()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/sd-api/backup/restore", bytes.NewBufferString(`{"name":"backup.zip","requestId":"short"}`))
+	request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	request.Header.Set("token", token) //nolint:canonicalheader // Private API compatibility header.
+	if err := backupRestore(e.NewContext(request, recorder)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recorder.Body.String(), "requestId") || !strings.Contains(recorder.Body.String(), `"result":false`) {
+		t.Fatalf("unexpected response: %s", recorder.Body.String())
+	}
+	if recorder.Header().Get(echo.HeaderCacheControl) != "no-store" {
+		t.Fatalf("restore cache-control = %q", recorder.Header().Get(echo.HeaderCacheControl))
+	}
+}

--- a/dice/atomic_replace_linux.go
+++ b/dice/atomic_replace_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package dice
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func replaceFileAtomic(source, target string) error {
+	return os.Rename(source, target)
+}
+
+func renameRestorePath(source, target string) error {
+	return unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, target, unix.RENAME_NOREPLACE)
+}

--- a/dice/atomic_replace_linux.go
+++ b/dice/atomic_replace_linux.go
@@ -3,6 +3,7 @@
 package dice
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -14,4 +15,16 @@ func replaceFileAtomic(source, target string) error {
 
 func renameRestorePath(source, target string) error {
 	return unix.Renameat2(unix.AT_FDCWD, source, unix.AT_FDCWD, target, unix.RENAME_NOREPLACE)
+}
+
+func syncRestoreDirectoryPath(directory string) error {
+	file, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	return errors.Join(file.Sync(), file.Close())
+}
+
+func isLinkedRestorePath(info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
 }

--- a/dice/atomic_replace_unix.go
+++ b/dice/atomic_replace_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package dice
+
+import (
+	"errors"
+	"os"
+)
+
+func replaceFileAtomic(source, target string) error {
+	return os.Rename(source, target)
+}
+
+func renameRestorePath(source, target string) error {
+	return os.Rename(source, target)
+}
+
+func syncRestoreDirectoryPath(directory string) error {
+	file, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	return errors.Join(file.Sync(), file.Close())
+}
+
+func isLinkedRestorePath(info os.FileInfo) bool {
+	return info.Mode()&os.ModeSymlink != 0
+}

--- a/dice/atomic_replace_unix.go
+++ b/dice/atomic_replace_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package dice
 
@@ -12,6 +12,11 @@ func replaceFileAtomic(source, target string) error {
 }
 
 func renameRestorePath(source, target string) error {
+	if _, err := os.Lstat(target); err == nil {
+		return os.ErrExist
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
 	return os.Rename(source, target)
 }
 

--- a/dice/atomic_replace_windows.go
+++ b/dice/atomic_replace_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package dice
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceFileAtomic(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+func renameRestorePath(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
+}
+
+// Windows 的恢复 rename 使用写穿标志；目录句柄不支持可移植的 FlushFileBuffers。
+func syncRestoreDirectoryPath(string) error {
+	return nil
+}
+
+func isLinkedRestorePath(info os.FileInfo) bool {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	attributes, ok := info.Sys().(*syscall.Win32FileAttributeData)
+	return ok && attributes.FileAttributes&syscall.FILE_ATTRIBUTE_REPARSE_POINT != 0
+}

--- a/dice/builtin_commands.go
+++ b/dice/builtin_commands.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -1290,12 +1291,18 @@ func (d *Dice) registerCoreCommands() {
 				reloginFlag = true
 				ReplyToSender(ctx, msg, "将在30s后重新登录，期间可以输入.master relogin --cancel解除\n若遭遇风控，可能会没有任何输出。静等或输入.master relogin --now立即执行\n此指令每5分钟只能执行一次，可能解除风控，也可能使骰子失联。后果自负")
 
-				go func() {
-					time.Sleep(30 * time.Second)
+				ctx.Dice.Parent.GoRuntime(func(runtimeCtx context.Context) {
+					timer := time.NewTimer(30 * time.Second)
+					defer timer.Stop()
+					select {
+					case <-runtimeCtx.Done():
+						return
+					case <-timer.C:
+					}
 					if reloginFlag {
 						doRelogin()
 					}
-				}()
+				})
 			case "backup":
 				ReplyToSender(ctx, msg, "开始备份数据")
 
@@ -1356,8 +1363,13 @@ func (d *Dice) registerCoreCommands() {
 				}
 
 				ReplyToSender(ctx, msg, "开始下载新版本，完成后将自动进行一次备份")
-				go func() {
-					ret := <-dm.UpdateDownloadedChan
+				dm.GoRuntime(func(runtimeCtx context.Context) {
+					var ret string
+					select {
+					case <-runtimeCtx.Done():
+						return
+					case ret = <-dm.UpdateDownloadedChan:
+					}
 
 					if ctx.IsPrivate {
 						ctx.Dice.Config.UpgradeWindowID = msg.Sender.UserID
@@ -1378,7 +1390,7 @@ func (d *Dice) registerCoreCommands() {
 					} else {
 						ReplyToSender(ctx, msg, "升级失败，原因: "+ret)
 					}
-				}()
+				})
 				dm.UpdateRequestChan <- d
 			case "reboot":
 				var dm = ctx.Dice.Parent

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -237,6 +238,8 @@ type Dice struct {
 	JsScriptCronLock *sync.Mutex     `json:"-" yaml:"-"`
 	// 重载使用的互斥锁
 	JsReloadLock sync.Mutex `json:"-" yaml:"-"`
+	jsLoopMu     sync.Mutex
+	jsLoopDone   chan struct{}
 	// 内置脚本摘要表，用于判断内置脚本是否有更新
 	JsBuiltinDigestSet map[string]bool `json:"-" yaml:"-"`
 	// 当前在加载的脚本路径，用于关联 jsScriptInfo 和 ExtInfo
@@ -359,9 +362,16 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 		d.NewCensorManager()
 	}
 
-	go d.PublicDiceSetup()
+	d.Parent.goRuntime(func(ctx context.Context) {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			d.PublicDiceSetup()
+		}
+	})
 
-	go d.StoreSetup()
+	d.StoreSetup()
 
 	// 创建js运行时
 	if d.Config.JsEnable {
@@ -394,11 +404,16 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 	}
 	d.RunAfterLoaded = []func(){}
 
-	autoSave := func() {
+	autoSave := func(ctx context.Context) {
 		count := 0
 		t := time.NewTicker(30 * time.Second)
+		defer t.Stop()
 		for {
-			<-t.C
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			}
 			if d.IsAlreadyLoadConfig {
 				count++
 				d.Save(true)
@@ -418,10 +433,11 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 			}
 		}
 	}
-	go autoSave()
+	d.Parent.goRuntime(autoSave)
 
-	refreshGroupInfo := func() {
+	refreshGroupInfo := func(ctx context.Context) {
 		t := time.NewTicker(35 * time.Second)
+		defer t.Stop()
 		defer func() {
 			// 防止报错
 			if r := recover(); r != nil {
@@ -430,7 +446,11 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 		}()
 
 		for {
-			<-t.C
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+			}
 
 			// 自动更新群信息
 			for _, i := range d.ImSession.EndPoints {
@@ -457,7 +477,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 			}
 		}
 	}
-	go refreshGroupInfo()
+	d.Parent.goRuntime(refreshGroupInfo)
 
 	d.ApplyAliveNotice()
 	if d.Config.JsEnable {
@@ -468,7 +488,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 	}
 
 	if d.Config.UpgradeWindowID != "" {
-		go func() {
+		d.Parent.goRuntime(func(ctx context.Context) {
 			defer ErrorLogAndContinue(d)
 
 			var ep *EndPointInfo
@@ -485,7 +505,13 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 			}
 
 			for {
-				time.Sleep(30 * time.Second)
+				timer := time.NewTimer(30 * time.Second)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
 				text := fmt.Sprintf("升级完成，当前版本: %s", VERSION.String())
 
 				if ep.State == 2 {
@@ -509,7 +535,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 				d.Save(false)
 				break
 			}
-		}()
+		})
 	}
 
 	d.ResetQuitInactiveCron()
@@ -1134,11 +1160,17 @@ func (d *Dice) PublicDiceSetupTick() {
 		d.Cron.Remove(d.PublicDiceTimerId)
 	}
 
-	go func() {
+	d.Parent.goRuntime(func(ctx context.Context) {
 		// 20s后进行第一次调用，此后3min进行一次更新
-		time.Sleep(20 * time.Second)
-		doTickUpdate()
-	}()
+		timer := time.NewTimer(20 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			doTickUpdate()
+		}
+	})
 
 	d.PublicDiceTimerId, _ = d.Cron.AddFunc("@every 3m", doTickUpdate)
 }

--- a/dice/dice.go
+++ b/dice/dice.go
@@ -302,6 +302,14 @@ func (d *Dice) CocExtraRulesAdd(ruleInfo *CocRuleInfo) bool {
 	return true
 }
 
+func (d *Dice) goRuntime(fn func(context.Context)) {
+	if d == nil || d.Parent == nil {
+		go fn(context.Background())
+		return
+	}
+	d.Parent.goRuntime(fn)
+}
+
 func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter) {
 	loggerInstance := logger.M()
 	d.Logger = loggerInstance
@@ -362,7 +370,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 		d.NewCensorManager()
 	}
 
-	d.Parent.goRuntime(func(ctx context.Context) {
+	d.goRuntime(func(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
@@ -433,7 +441,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 			}
 		}
 	}
-	d.Parent.goRuntime(autoSave)
+	d.goRuntime(autoSave)
 
 	refreshGroupInfo := func(ctx context.Context) {
 		t := time.NewTicker(35 * time.Second)
@@ -477,7 +485,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 			}
 		}
 	}
-	d.Parent.goRuntime(refreshGroupInfo)
+	d.goRuntime(refreshGroupInfo)
 
 	d.ApplyAliveNotice()
 	if d.Config.JsEnable {
@@ -488,7 +496,7 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 	}
 
 	if d.Config.UpgradeWindowID != "" {
-		d.Parent.goRuntime(func(ctx context.Context) {
+		d.goRuntime(func(ctx context.Context) {
 			defer ErrorLogAndContinue(d)
 
 			var ep *EndPointInfo
@@ -1160,7 +1168,7 @@ func (d *Dice) PublicDiceSetupTick() {
 		d.Cron.Remove(d.PublicDiceTimerId)
 	}
 
-	d.Parent.goRuntime(func(ctx context.Context) {
+	d.goRuntime(func(ctx context.Context) {
 		// 20s后进行第一次调用，此后3min进行一次更新
 		timer := time.NewTimer(20 * time.Second)
 		defer timer.Stop()

--- a/dice/dice_backup.go
+++ b/dice/dice_backup.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -128,19 +129,24 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 	bakFn += "_r" + strconv.FormatUint(uint64(sel), 16)
 	fnHashed := crypto.CalculateSHA512Str([]byte(bakFn))[:8]
 	bakFn += "_" + fnHashed + ".zip"
+	target := filepath.Join(BackupDir, bakFn)
 
-	fzip, err := os.OpenFile(filepath.Join(BackupDir, bakFn),
-		os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
+	fzip, err := os.CreateTemp(BackupDir, ".bak-*.tmp")
 	if err != nil {
 		return "", err
 	}
-	writer := zip.NewWriter(fzip)
-	completed := false
+	tmpName := fzip.Name()
+	published := false
 	defer func() {
-		if !completed {
-			_ = writer.Close()
+		if !published {
 			_ = fzip.Close()
-			_ = os.Remove(fzip.Name())
+			_ = os.Remove(tmpName)
+		}
+	}()
+	writer := zip.NewWriter(fzip)
+	defer func() {
+		if !published {
+			_ = writer.Close()
 		}
 	}()
 
@@ -155,7 +161,8 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 
 	manifestFiles := make([]backupManifestFile, 0, 32)
 	seen := map[string]struct{}{}
-	var strictErr error
+	var fatalErr error
+	var totalUncompressed uint64
 	logBackupError := func(d *Dice, fn string, err error) {
 		if d != nil && d.Logger != nil {
 			d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
@@ -163,8 +170,38 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 		}
 		log.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
 	}
+	// recordBackupError keeps strict backups all-or-nothing. Best-effort
+	// backups only abort for required files, so one broken optional file or a
+	// symlinked directory can no longer stop automatic backups entirely.
+	recordBackupError := func(d *Dice, fn string, err error, required bool) {
+		logBackupError(d, fn, err)
+		if required || strict {
+			fatalErr = errors.Join(fatalErr, err)
+		}
+	}
+	backupArchiveName := func(fn string) (string, error) {
+		if archiveName, pathErr := managedArchivePath(fn); pathErr == nil || strict {
+			return archiveName, pathErr
+		}
+		// Keep legacy deployments working in best-effort mode even when the
+		// data directory or one of its parents is a symlink. Strict safety
+		// backups keep the managed-path requirement.
+		root, rootErr := filepath.Abs("data")
+		if rootErr != nil {
+			return "", rootErr
+		}
+		targetAbs, targetErr := filepath.Abs(fn)
+		if targetErr != nil {
+			return "", targetErr
+		}
+		relative, relErr := filepath.Rel(root, targetAbs)
+		if relErr != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+			return "", fmt.Errorf("备份文件 %s 不在 data 目录内", fn)
+		}
+		return filepath.ToSlash(filepath.Join("data", relative)), nil
+	}
 	backupFile := func(d *Dice, fn string, required bool) {
-		if strict && strictErr != nil {
+		if strict && fatalErr != nil {
 			return
 		}
 		info, statErr := os.Lstat(fn)
@@ -172,37 +209,52 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 			if errors.Is(statErr, os.ErrNotExist) && !required {
 				return
 			}
-			logBackupError(d, fn, statErr)
-			strictErr = errors.Join(strictErr, fmt.Errorf("备份 %s: %w", fn, statErr))
+			recordBackupError(d, fn, fmt.Errorf("备份 %s: %w", fn, statErr), required)
 			return
 		}
 		if !info.Mode().IsRegular() {
-			err = errors.New("不是普通文件或为符号链接")
-			logBackupError(d, fn, err)
-			strictErr = errors.Join(strictErr, fmt.Errorf("备份 %s: %w", fn, err))
+			recordBackupError(d, fn, fmt.Errorf("备份 %s: 不是普通文件或为符号链接", fn), required)
 			return
 		}
-		archiveName, pathErr := managedArchivePath(fn)
+		archiveName, pathErr := backupArchiveName(fn)
 		if pathErr != nil {
-			logBackupError(d, fn, pathErr)
-			strictErr = errors.Join(strictErr, pathErr)
+			recordBackupError(d, fn, pathErr, required)
+			return
+		}
+		archiveName, nameErr := normalizeBackupEntryName(filepath.ToSlash(archiveName), false)
+		if nameErr != nil {
+			recordBackupError(d, fn, fmt.Errorf("备份条目 %s: %w", fn, nameErr), required)
 			return
 		}
 		if isProcessOwnedRestorePath(archiveName) {
 			log.Warnf("跳过进程级占用文件: %s", archiveName)
 			return
 		}
+		if isSQLiteSidecarPath(archiveName) {
+			log.Warnf("跳过 SQLite 临时文件: %s", archiveName)
+			return
+		}
+		if uint64(info.Size()) > maxBackupEntryUncompressedSize {
+			recordBackupError(d, fn, fmt.Errorf("备份条目 %s 超过单文件大小限制", archiveName), required)
+			return
+		}
+		if math.MaxUint64-totalUncompressed < uint64(info.Size()) ||
+			totalUncompressed+uint64(info.Size()) > maxBackupTotalUncompressedSize {
+			recordBackupError(d, fn, fmt.Errorf("备份总大小超过限制: %s", archiveName), required)
+			return
+		}
 		key := strings.ToLower(archiveName)
 		if _, exists := seen[key]; exists {
-			err = fmt.Errorf("备份路径重复: %s", archiveName)
-			logBackupError(d, fn, err)
-			strictErr = errors.Join(strictErr, err)
+			recordBackupError(d, fn, fmt.Errorf("备份路径重复: %s", archiveName), required)
+			return
+		}
+		if int64(len(manifestFiles))+1 > maxBackupEntries {
+			recordBackupError(d, fn, fmt.Errorf("备份条目超过 %d 个", maxBackupEntries), required)
 			return
 		}
 		file, openErr := os.Open(fn)
 		if openErr != nil {
-			logBackupError(d, fn, openErr)
-			strictErr = errors.Join(strictErr, fmt.Errorf("打开 %s: %w", fn, openErr))
+			recordBackupError(d, fn, fmt.Errorf("打开 %s: %w", fn, openErr), required)
 			return
 		}
 		h := &zip.FileHeader{Name: filepath.ToSlash(archiveName), Method: zip.Deflate, Flags: 0x800}
@@ -210,8 +262,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 		fileWriter, createErr := writer.CreateHeader(h)
 		if createErr != nil {
 			_ = file.Close()
-			logBackupError(d, fn, createErr)
-			strictErr = errors.Join(strictErr, fmt.Errorf("创建 ZIP 条目 %s: %w", archiveName, createErr))
+			recordBackupError(d, fn, fmt.Errorf("创建 ZIP 条目 %s: %w", archiveName, createErr), required)
 			return
 		}
 		hasher := sha256.New()
@@ -225,11 +276,11 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 					copyErr = fmt.Errorf("读取大小变化: 预期 %d，实际 %d", info.Size(), written)
 				}
 			}
-			logBackupError(d, fn, copyErr)
-			strictErr = errors.Join(strictErr, fmt.Errorf("写入 ZIP 条目 %s: %w", archiveName, copyErr))
+			recordBackupError(d, fn, fmt.Errorf("写入 ZIP 条目 %s: %w", archiveName, copyErr), required)
 			return
 		}
 		seen[key] = struct{}{}
+		totalUncompressed += uint64(written)
 		manifestFiles = append(manifestFiles, backupManifestFile{
 			Path:   filepath.ToSlash(archiveName),
 			Size:   uint64(written),
@@ -237,7 +288,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 		})
 	}
 	walkFiles := func(root string, visit func(string, fs.DirEntry) error) {
-		if strict && strictErr != nil {
+		if strict && fatalErr != nil {
 			return
 		}
 		walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -245,16 +296,26 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 				if errors.Is(walkErr, os.ErrNotExist) && path == root {
 					return filepath.SkipDir
 				}
+				if !strict {
+					log.Warnf("跳过无法读取的备份路径: %s, 原因: %s", path, walkErr.Error())
+					return filepath.SkipDir
+				}
 				return walkErr
 			}
 			if entry.Type()&os.ModeSymlink != 0 {
-				return fmt.Errorf("备份目录包含符号链接: %s", path)
+				if strict {
+					return fmt.Errorf("备份目录包含符号链接: %s", path)
+				}
+				log.Warnf("跳过符号链接: %s", path)
+				return nil
 			}
 			return visit(path, entry)
 		})
 		if walkErr != nil {
 			logBackupError(nil, root, walkErr)
-			strictErr = errors.Join(strictErr, walkErr)
+			if strict {
+				fatalErr = errors.Join(fatalErr, walkErr)
+			}
 		}
 	}
 
@@ -264,7 +325,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 		cfgGlb.Decks = true
 		walkFiles("data/decks", func(path string, info fs.DirEntry) error {
 			if !info.IsDir() {
-				backupFile(nil, path, true)
+				backupFile(nil, path, strict)
 				return nil
 			}
 			base := filepath.Base(path)
@@ -285,7 +346,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 			cfgGlb.HelpDoc = true
 			walkFiles("data/helpdoc", func(path string, info fs.DirEntry) error {
 				if !info.IsDir() {
-					backupFile(nil, path, true)
+					backupFile(nil, path, strict)
 				}
 				return nil
 			})
@@ -299,7 +360,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 			cfgGlb.Censor = true
 			walkFiles("data/censor", func(path string, info fs.DirEntry) error {
 				if !info.IsDir() {
-					backupFile(nil, path, true)
+					backupFile(nil, path, strict)
 				}
 				return nil
 			})
@@ -313,7 +374,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 			cfgGlb.Names = true
 			walkFiles("data/names", func(path string, info fs.DirEntry) error {
 				if !info.IsDir() {
-					backupFile(nil, path, true)
+					backupFile(nil, path, strict)
 				}
 				return nil
 			})
@@ -327,7 +388,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 			cfgGlb.Images = true
 			walkFiles("data/images", func(path string, info fs.DirEntry) error {
 				if !info.IsDir() {
-					backupFile(nil, path, true)
+					backupFile(nil, path, strict)
 				}
 				return nil
 			})
@@ -339,10 +400,11 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 
 	for _, d := range dm.Dice {
 		if d == nil {
-			strictErr = errors.Join(strictErr, errors.New("备份列表包含空 Dice 实例"))
 			if strict {
+				fatalErr = errors.Join(fatalErr, errors.New("备份列表包含空 Dice 实例"))
 				break
 			}
+			log.Warn("跳过空 Dice 实例")
 			continue
 		}
 		cfgGlb.Dices[d.BaseConfig.Name] = &cfgDice
@@ -372,7 +434,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 
 			ext := filepath.Ext(path)
 			if ext == ".yaml" || ext == "" {
-				backupFile(d, path, true)
+				backupFile(d, path, strict)
 			}
 			return nil
 		})
@@ -408,7 +470,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 					return nil
 				}
 				if filepath.Ext(info.Name()) == ".js" {
-					backupFile(d, path, true)
+					backupFile(d, path, strict)
 				}
 				return nil
 			})
@@ -422,7 +484,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 					}
 					return nil
 				}
-				backupFile(d, path, true)
+				backupFile(d, path, strict)
 				return nil
 			})
 		}
@@ -433,12 +495,12 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 		databaseType = dm.Operator.Type()
 	}
 	if databaseType == "" {
-		strictErr = errors.Join(strictErr, errors.New("数据库类型为空，无法创建可验证备份"))
+		fatalErr = errors.Join(fatalErr, errors.New("数据库类型为空，无法创建可验证备份"))
 	}
 	if databaseType == constant.SQLITE {
 		databaseFiles, pathErr := managedSQLiteDatabaseFiles(dm, strict)
 		if pathErr != nil {
-			strictErr = errors.Join(strictErr, pathErr)
+			fatalErr = errors.Join(fatalErr, pathErr)
 			if !strict {
 				log.Errorf("备份 SQLite 数据库失败: %v", pathErr)
 			}
@@ -474,7 +536,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 				if flushErr != nil {
 					log.Errorf("备份时 %s 数据库 flush 出错: %v", dbHandles[index].name, flushErr)
 					if strict || databaseFile.Name != "data-censor.db" {
-						strictErr = errors.Join(strictErr, fmt.Errorf("flush %s 数据库: %w", dbHandles[index].name, flushErr))
+						fatalErr = errors.Join(fatalErr, fmt.Errorf("flush %s 数据库: %w", dbHandles[index].name, flushErr))
 					}
 					continue
 				}
@@ -482,10 +544,10 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 			}
 		}
 	} else if strict {
-		strictErr = errors.Join(strictErr, fmt.Errorf("安全备份仅支持 SQLite，当前数据库类型为 %q", databaseType))
+		fatalErr = errors.Join(fatalErr, fmt.Errorf("安全备份仅支持 SQLite，当前数据库类型为 %q", databaseType))
 	}
-	if strictErr != nil {
-		return "", strictErr
+	if fatalErr != nil {
+		return "", fatalErr
 	}
 	sort.Slice(manifestFiles, func(i, j int) bool { return manifestFiles[i].Path < manifestFiles[j].Path })
 
@@ -521,11 +583,19 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 	if err = fzip.Close(); err != nil {
 		return "", err
 	}
+	if _, statErr := os.Lstat(target); statErr == nil {
+		return "", fmt.Errorf("备份文件已存在: %s", bakFn)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return "", statErr
+	}
+	if err = renameRestorePath(tmpName, target); err != nil {
+		return "", err
+	}
 	if err = syncDirectory(BackupDir); err != nil {
 		return "", err
 	}
-	completed = true
-	return fzip.Name(), nil
+	published = true
+	return target, nil
 }
 
 func (dm *DiceManager) BackupAuto() error {

--- a/dice/dice_backup.go
+++ b/dice/dice_backup.go
@@ -127,7 +127,7 @@ func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict b
 		bakFn += "_auto"
 	}
 	bakFn += "_r" + strconv.FormatUint(uint64(sel), 16)
-	fnHashed := crypto.CalculateSHA512Str([]byte(bakFn))[:8]
+	fnHashed := crypto.CalculateSHA512Str([]byte(bakFn + strconv.FormatInt(time.Now().UnixNano(), 16)))[:8]
 	bakFn += "_" + fnHashed + ".zip"
 	target := filepath.Join(BackupDir, bakFn)
 
@@ -639,7 +639,13 @@ func (dm *DiceManager) BackupClean(fromAuto bool) (err error) {
 		if f.IsDir() {
 			continue
 		}
-		if fi, err := f.Info(); err == nil {
+		if strings.HasPrefix(f.Name(), ".bak-") || strings.HasSuffix(f.Name(), ".part") {
+			continue
+		}
+		if !strings.EqualFold(filepath.Ext(f.Name()), ".zip") {
+			continue
+		}
+		if fi, err := f.Info(); err == nil && fi.Mode().IsRegular() {
 			fileInfos = append(fileInfos, fi)
 		}
 	}
@@ -671,17 +677,30 @@ func (dm *DiceManager) BackupClean(fromAuto bool) (err error) {
 	_, _ = fmt.Fprintf(&logMsg, ", 有以下 %d 个将要被删除", len(fileInfoOld)) //nolint:gosec
 
 	errDel := []string{}
+	deletedCount := 0
+	skippedCount := 0
 	for i, fi := range fileInfoOld {
 		_, _ = fmt.Fprintf(&logMsg, "\n%d. %s", i+1, fi.Name()) //nolint:gosec
-		if BackupInUse(fi.Name()) {
+		inUse, useErr := backupInUseLocked(fi.Name())
+		if useErr != nil {
+			skippedCount++
+			_, _ = fmt.Fprintf(&logMsg, "（无法读取恢复事务元数据，已跳过）") //nolint:gosec
+			log.Warnf("清理备份时无法读取恢复事务元数据: %v", useErr)
+			continue
+		}
+		if inUse {
+			skippedCount++
 			_, _ = fmt.Fprintf(&logMsg, "（恢复事务正在使用，已跳过）") //nolint:gosec
 			continue
 		}
 		errDelete := os.Remove(filepath.Join(BackupDir, fi.Name())) //nolint:gosec
 		if errDelete != nil {
 			errDel = append(errDel, errDelete.Error())
+		} else {
+			deletedCount++
 		}
 	}
+	_, _ = fmt.Fprintf(&logMsg, "\n实际删除 %d 个，跳过 %d 个", deletedCount, skippedCount) //nolint:gosec
 
 	log.Info(logMsg.String())
 

--- a/dice/dice_backup.go
+++ b/dice/dice_backup.go
@@ -1,6 +1,8 @@
 package dice
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alexmullins/zip"
@@ -23,6 +26,8 @@ import (
 )
 
 const BackupDir = "./backups"
+
+var backupOperationMu sync.Mutex
 
 type BackupCleanStrategy int
 
@@ -82,8 +87,27 @@ const (
 )
 
 func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error) {
-	_ = os.MkdirAll(BackupDir, 0o755)
-	logger := dm.Dice[0].Logger
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	return dm.backup(sel, fromAuto)
+}
+
+func (dm *DiceManager) backup(sel BackupSelection, fromAuto bool) (string, error) {
+	return dm.backupWithOptions(sel, fromAuto, false)
+}
+
+func (dm *DiceManager) backupStrict(sel BackupSelection) (string, error) {
+	return dm.backupWithOptions(sel, false, true)
+}
+
+func (dm *DiceManager) backupWithOptions(sel BackupSelection, fromAuto, strict bool) (result string, resultErr error) {
+	if dm == nil || len(dm.Dice) == 0 {
+		return "", errors.New("没有可备份的骰子实例")
+	}
+	if err := ensureBackupDirectoryLocked(); err != nil {
+		return "", err
+	}
+	log := logger.M()
 
 	cfgGlb := backupConfigGlobal{
 		Global: true,
@@ -106,73 +130,141 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 	bakFn += "_" + fnHashed + ".zip"
 
 	fzip, err := os.OpenFile(filepath.Join(BackupDir, bakFn),
-		os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o644)
+		os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = fzip.Close() }()
-
 	writer := zip.NewWriter(fzip)
-	defer func(writer *zip.Writer) {
-		_ = writer.Close()
-	}(writer)
+	completed := false
+	defer func() {
+		if !completed {
+			_ = writer.Close()
+			_ = fzip.Close()
+			_ = os.Remove(fzip.Name())
+		}
+	}()
 
 	fileOK := func(fn string) bool {
-		stat, err := os.Stat(fn)
-		return err == nil && !stat.IsDir()
+		stat, statErr := os.Stat(fn)
+		return statErr == nil && !stat.IsDir()
 	}
 	dirOK := func(fn string) bool {
-		stat, err := os.Stat(fn)
-		return err == nil && stat.IsDir()
+		stat, statErr := os.Stat(fn)
+		return statErr == nil && stat.IsDir()
 	}
 
-	backup := func(d *Dice, fn string) {
-		file, err := os.Open(fn)
-		if err != nil && !strings.Contains(fn, "session.token") {
-			if d != nil {
-				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
-			} else {
-				logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
-			}
+	manifestFiles := make([]backupManifestFile, 0, 32)
+	seen := map[string]struct{}{}
+	var strictErr error
+	logBackupError := func(d *Dice, fn string, err error) {
+		if d != nil && d.Logger != nil {
+			d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
 			return
 		}
-		defer file.Close()
-
-		h := &zip.FileHeader{Name: fn, Method: zip.Deflate, Flags: 0x800}
-		fileWriter, err := writer.CreateHeader(h)
-		if err != nil {
-			if d != nil {
-				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
-			} else {
-				logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
-			}
+		log.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
+	}
+	backupFile := func(d *Dice, fn string, required bool) {
+		if strict && strictErr != nil {
 			return
 		}
-
-		_, err = io.Copy(fileWriter, file)
-		if err != nil {
-			if d != nil {
-				d.Logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
-			} else {
-				logger.Errorf("备份文件失败: %s, 原因: %s", fn, err.Error())
+		info, statErr := os.Lstat(fn)
+		if statErr != nil {
+			if errors.Is(statErr, os.ErrNotExist) && !required {
+				return
 			}
+			logBackupError(d, fn, statErr)
+			strictErr = errors.Join(strictErr, fmt.Errorf("备份 %s: %w", fn, statErr))
+			return
+		}
+		if !info.Mode().IsRegular() {
+			err = errors.New("不是普通文件或为符号链接")
+			logBackupError(d, fn, err)
+			strictErr = errors.Join(strictErr, fmt.Errorf("备份 %s: %w", fn, err))
+			return
+		}
+		archiveName, pathErr := managedArchivePath(fn)
+		if pathErr != nil {
+			logBackupError(d, fn, pathErr)
+			strictErr = errors.Join(strictErr, pathErr)
+			return
+		}
+		if isProcessOwnedRestorePath(archiveName) {
+			log.Warnf("跳过进程级占用文件: %s", archiveName)
+			return
+		}
+		key := strings.ToLower(archiveName)
+		if _, exists := seen[key]; exists {
+			err = fmt.Errorf("备份路径重复: %s", archiveName)
+			logBackupError(d, fn, err)
+			strictErr = errors.Join(strictErr, err)
+			return
+		}
+		file, openErr := os.Open(fn)
+		if openErr != nil {
+			logBackupError(d, fn, openErr)
+			strictErr = errors.Join(strictErr, fmt.Errorf("打开 %s: %w", fn, openErr))
+			return
+		}
+		h := &zip.FileHeader{Name: filepath.ToSlash(archiveName), Method: zip.Deflate, Flags: 0x800}
+		h.SetMode(0o600)
+		fileWriter, createErr := writer.CreateHeader(h)
+		if createErr != nil {
+			_ = file.Close()
+			logBackupError(d, fn, createErr)
+			strictErr = errors.Join(strictErr, fmt.Errorf("创建 ZIP 条目 %s: %w", archiveName, createErr))
+			return
+		}
+		hasher := sha256.New()
+		written, copyErr := io.Copy(io.MultiWriter(fileWriter, hasher), file)
+		closeErr := file.Close()
+		if copyErr != nil || closeErr != nil || written != info.Size() {
+			if copyErr == nil {
+				if closeErr != nil {
+					copyErr = closeErr
+				} else {
+					copyErr = fmt.Errorf("读取大小变化: 预期 %d，实际 %d", info.Size(), written)
+				}
+			}
+			logBackupError(d, fn, copyErr)
+			strictErr = errors.Join(strictErr, fmt.Errorf("写入 ZIP 条目 %s: %w", archiveName, copyErr))
+			return
+		}
+		seen[key] = struct{}{}
+		manifestFiles = append(manifestFiles, backupManifestFile{
+			Path:   filepath.ToSlash(archiveName),
+			Size:   uint64(written),
+			SHA256: hex.EncodeToString(hasher.Sum(nil)),
+		})
+	}
+	walkFiles := func(root string, visit func(string, fs.DirEntry) error) {
+		if strict && strictErr != nil {
+			return
+		}
+		walkErr := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				if errors.Is(walkErr, os.ErrNotExist) && path == root {
+					return filepath.SkipDir
+				}
+				return walkErr
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return fmt.Errorf("备份目录包含符号链接: %s", path)
+			}
+			return visit(path, entry)
+		})
+		if walkErr != nil {
+			logBackupError(nil, root, walkErr)
+			strictErr = errors.Join(strictErr, walkErr)
 		}
 	}
 
-	backupDir := func(path string, info fs.FileInfo, _ error) error {
-		if !info.IsDir() {
-			backup(nil, path)
-		}
-		return nil
-	}
-
-	backup(nil, "data/dice.yaml")
+	backupFile(nil, "data/dice.yaml", true)
 
 	if sel&BackupSelectionDecks != 0 {
 		cfgGlb.Decks = true
-		_ = filepath.Walk("data/decks", func(path string, info fs.FileInfo, _ error) error {
+		walkFiles("data/decks", func(path string, info fs.DirEntry) error {
 			if !info.IsDir() {
-				backup(nil, path)
+				backupFile(nil, path, true)
 				return nil
 			}
 			base := filepath.Base(path)
@@ -188,37 +280,57 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 
 	if sel&BackupSelectionHelpDoc != 0 {
 		if !dirOK("data/helpdoc") {
-			logger.Warn("备份 helpdoc 失败: 不存在或不是目录")
+			log.Warn("备份 helpdoc 失败: 不存在或不是目录")
 		} else {
 			cfgGlb.HelpDoc = true
-			_ = filepath.Walk("data/helpdoc", backupDir)
+			walkFiles("data/helpdoc", func(path string, info fs.DirEntry) error {
+				if !info.IsDir() {
+					backupFile(nil, path, true)
+				}
+				return nil
+			})
 		}
 	}
 
 	if sel&BackupSelectionCensor != 0 {
 		if !dirOK("data/censor") {
-			logger.Warn("备份 censor 失败: 不存在或不是目录")
+			log.Warn("备份 censor 失败: 不存在或不是目录")
 		} else {
 			cfgGlb.Censor = true
-			_ = filepath.Walk("data/censor", backupDir)
+			walkFiles("data/censor", func(path string, info fs.DirEntry) error {
+				if !info.IsDir() {
+					backupFile(nil, path, true)
+				}
+				return nil
+			})
 		}
 	}
 
 	if sel&BackupSelectionNames != 0 {
 		if !dirOK("data/names") {
-			logger.Warn("备份 names 失败: 不存在或不是目录")
+			log.Warn("备份 names 失败: 不存在或不是目录")
 		} else {
 			cfgGlb.Names = true
-			_ = filepath.Walk("data/names", backupDir)
+			walkFiles("data/names", func(path string, info fs.DirEntry) error {
+				if !info.IsDir() {
+					backupFile(nil, path, true)
+				}
+				return nil
+			})
 		}
 	}
 
 	if sel&BackupSelectionImages != 0 {
 		if !dirOK("data/images") {
-			logger.Warn("备份 images 失败: 不存在或不是目录")
+			log.Warn("备份 images 失败: 不存在或不是目录")
 		} else {
 			cfgGlb.Images = true
-			_ = filepath.Walk("data/images", backupDir)
+			walkFiles("data/images", func(path string, info fs.DirEntry) error {
+				if !info.IsDir() {
+					backupFile(nil, path, true)
+				}
+				return nil
+			})
 		}
 	}
 
@@ -226,41 +338,27 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 	cfgDice.JSScripts = withJS
 
 	for _, d := range dm.Dice {
+		if d == nil {
+			strictErr = errors.Join(strictErr, errors.New("备份列表包含空 Dice 实例"))
+			if strict {
+				break
+			}
+			continue
+		}
 		cfgGlb.Dices[d.BaseConfig.Name] = &cfgDice
 		dataDir := d.BaseConfig.DataDir
 
-		backup(d, filepath.Join(dataDir, "serve.yaml"))
+		backupFile(d, filepath.Join(dataDir, "serve.yaml"), true)
 		if fn := filepath.Join(dataDir, "advanced.yaml"); fileOK(fn) {
-			backup(d, fn)
+			backupFile(d, fn, true)
 		}
 		if fn := filepath.Join(dataDir, "configs", "plugin-configs.json"); fileOK(fn) {
-			backup(d, fn)
+			backupFile(d, fn, true)
 		}
 
-		err := service.FlushWAL(d.DBOperator.GetDataDB(constant.WRITE))
-		if err != nil {
-			d.Logger.Errorf("备份时data数据库flush出错 错误为:%v", err.Error())
-		} else {
-			backup(d, filepath.Join(dataDir, "data.db"))
-		}
-		err = service.FlushWAL(d.DBOperator.GetLogDB(constant.WRITE))
-		if err != nil {
-			d.Logger.Errorf("备份时logs数据库flush出错 错误为:%v", err.Error())
-		} else {
-			backup(d, filepath.Join(dataDir, "data-logs.db"))
-		}
-		if d.CensorManager != nil && d.CensorManager.DB != nil {
-			err = service.FlushWAL(d.DBOperator.GetCensorDB(constant.WRITE))
-			if err != nil {
-				d.Logger.Errorf("备份时censor数据库flush出错 %v", err.Error())
-			} else {
-				backup(d, filepath.Join(dataDir, "data-censor.db"))
-			}
-		}
+		backupFile(d, filepath.Join(dataDir, "configs/text-template.yaml"), false)
 
-		backup(d, filepath.Join(dataDir, "configs/text-template.yaml"))
-
-		_ = filepath.WalkDir(filepath.Join(dataDir, "extensions/reply"), func(path string, info fs.DirEntry, _ error) error {
+		walkFiles(filepath.Join(dataDir, "extensions/reply"), func(path string, info fs.DirEntry) error {
 			// NOTE(Xiangze Li): copied from dice.ReplyReload. Should extract as function, but I'm lazy
 			if info.IsDir() {
 				if strings.EqualFold(info.Name(), "assets") || strings.EqualFold(info.Name(), "images") {
@@ -274,30 +372,35 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 
 			ext := filepath.Ext(path)
 			if ext == ".yaml" || ext == "" {
-				backup(d, path)
+				backupFile(d, path, true)
 			}
 			return nil
 		})
 
-		for _, i := range d.ImSession.EndPoints {
-			if i.Platform == "QQ" {
-				if pa, ok := i.Adapter.(*PlatformAdapterGocq); ok && pa.UseInPackClient {
-					workDir := i.RelWorkDir
-					if pa.BuiltinMode == "lagrange" {
-						backup(d, filepath.Join(dataDir, workDir, "appsettings.json"))
-						backup(d, filepath.Join(dataDir, workDir, "device.json"))
-						backup(d, filepath.Join(dataDir, workDir, "keystore.json"))
-					} else {
-						backup(d, filepath.Join(dataDir, workDir, "config.yml"))
-						backup(d, filepath.Join(dataDir, workDir, "device.json"))
-						backup(d, filepath.Join(dataDir, workDir, "session.token"))
+		if d.ImSession != nil {
+			for _, i := range d.ImSession.EndPoints {
+				if i == nil {
+					continue
+				}
+				if i.Platform == "QQ" {
+					if pa, ok := i.Adapter.(*PlatformAdapterGocq); ok && pa.UseInPackClient {
+						workDir := i.RelWorkDir
+						if pa.BuiltinMode == "lagrange" {
+							backupFile(d, filepath.Join(dataDir, workDir, "appsettings.json"), false)
+							backupFile(d, filepath.Join(dataDir, workDir, "device.json"), false)
+							backupFile(d, filepath.Join(dataDir, workDir, "keystore.json"), false)
+						} else {
+							backupFile(d, filepath.Join(dataDir, workDir, "config.yml"), false)
+							backupFile(d, filepath.Join(dataDir, workDir, "device.json"), false)
+							backupFile(d, filepath.Join(dataDir, workDir, "session.token"), false)
+						}
 					}
 				}
 			}
 		}
 
 		if withJS {
-			_ = filepath.WalkDir(filepath.Join(dataDir, "scripts"), func(path string, info fs.DirEntry, _ error) error {
+			walkFiles(filepath.Join(dataDir, "scripts"), func(path string, info fs.DirEntry) error {
 				if info.IsDir() {
 					if info.Name() == "_builtin" {
 						return filepath.SkipDir
@@ -305,12 +408,12 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 					return nil
 				}
 				if filepath.Ext(info.Name()) == ".js" {
-					backup(d, path)
+					backupFile(d, path, true)
 				}
 				return nil
 			})
 			extDataDir := filepath.Join(dataDir, "extensions")
-			_ = filepath.WalkDir(extDataDir, func(path string, info fs.DirEntry, err error) error {
+			walkFiles(extDataDir, func(path string, info fs.DirEntry) error {
 				if info.IsDir() {
 					if filepath.Dir(path) == extDataDir {
 						if ext := d.ExtFind(info.Name(), false); ext == nil || !ext.IsJsExt {
@@ -319,23 +422,109 @@ func (dm *DiceManager) Backup(sel BackupSelection, fromAuto bool) (string, error
 					}
 					return nil
 				}
-				backup(d, path)
+				backupFile(d, path, true)
 				return nil
 			})
 		}
 	}
 
+	databaseType := ""
+	if dm.Operator != nil {
+		databaseType = dm.Operator.Type()
+	}
+	if databaseType == "" {
+		strictErr = errors.Join(strictErr, errors.New("数据库类型为空，无法创建可验证备份"))
+	}
+	if databaseType == constant.SQLITE {
+		databaseFiles, pathErr := managedSQLiteDatabaseFiles(dm, strict)
+		if pathErr != nil {
+			strictErr = errors.Join(strictErr, pathErr)
+			if !strict {
+				log.Errorf("备份 SQLite 数据库失败: %v", pathErr)
+			}
+		} else {
+			dbHandles := []struct {
+				name string
+				db   func() error
+			}{
+				{name: "data", db: func() error {
+					database := dm.Operator.GetDataDB(constant.WRITE)
+					if database == nil {
+						return errors.New("data 数据库句柄为空")
+					}
+					return service.FlushWAL(database)
+				}},
+				{name: "logs", db: func() error {
+					database := dm.Operator.GetLogDB(constant.WRITE)
+					if database == nil {
+						return errors.New("logs 数据库句柄为空")
+					}
+					return service.FlushWAL(database)
+				}},
+				{name: "censor", db: func() error {
+					database := dm.Operator.GetCensorDB(constant.WRITE)
+					if database == nil {
+						return errors.New("censor 数据库句柄为空")
+					}
+					return service.FlushWAL(database)
+				}},
+			}
+			for index, databaseFile := range databaseFiles {
+				flushErr := dbHandles[index].db()
+				if flushErr != nil {
+					log.Errorf("备份时 %s 数据库 flush 出错: %v", dbHandles[index].name, flushErr)
+					if strict || databaseFile.Name != "data-censor.db" {
+						strictErr = errors.Join(strictErr, fmt.Errorf("flush %s 数据库: %w", dbHandles[index].name, flushErr))
+					}
+					continue
+				}
+				backupFile(nil, databaseFile.Path, strict || databaseFile.Name != "data-censor.db")
+			}
+		}
+	} else if strict {
+		strictErr = errors.Join(strictErr, fmt.Errorf("安全备份仅支持 SQLite，当前数据库类型为 %q", databaseType))
+	}
+	if strictErr != nil {
+		return "", strictErr
+	}
+	sort.Slice(manifestFiles, func(i, j int) bool { return manifestFiles[i].Path < manifestFiles[j].Path })
+
 	// 写入文件信息
-	data, _ := json.Marshal(map[string]interface{}{
-		"config":      cfgGlb,
-		"version":     VERSION.String(),
-		"versionCode": VERSION_CODE,
+	data, err := json.Marshal(backupManifest{
+		FormatVersion: backupManifestFormatVersion,
+		RestorePolicy: backupRestorePolicyOverlay,
+		DatabaseType:  databaseType,
+		Files:         manifestFiles,
+		Config:        mustMarshalJSON(cfgGlb),
+		Version:       mustMarshalJSON(VERSION.String()),
+		VersionCode:   VERSION_CODE,
 	})
+	if err != nil {
+		return "", err
+	}
 
 	h := &zip.FileHeader{Name: "backup_info.json", Method: zip.Deflate, Flags: 0x800}
-	fileWriter, _ := writer.CreateHeader(h)
-	_, _ = fileWriter.Write(data)
-
+	h.SetMode(0o600)
+	fileWriter, err := writer.CreateHeader(h)
+	if err != nil {
+		return "", err
+	}
+	if _, err = fileWriter.Write(data); err != nil {
+		return "", err
+	}
+	if err = writer.Close(); err != nil {
+		return "", err
+	}
+	if err = fzip.Sync(); err != nil {
+		return "", err
+	}
+	if err = fzip.Close(); err != nil {
+		return "", err
+	}
+	if err = syncDirectory(BackupDir); err != nil {
+		return "", err
+	}
+	completed = true
 	return fzip.Name(), nil
 }
 
@@ -351,6 +540,11 @@ func (dm *DiceManager) BackupClean(fromAuto bool) (err error) {
 
 	if fromAuto && (dm.BackupCleanTrigger&BackupCleanTriggerRotate == 0) {
 		return nil
+	}
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err = validateBackupDirectoryLocked(); err != nil {
+		return err
 	}
 
 	log := logger.M()
@@ -408,7 +602,11 @@ func (dm *DiceManager) BackupClean(fromAuto bool) (err error) {
 
 	errDel := []string{}
 	for i, fi := range fileInfoOld {
-		_, _ = fmt.Fprintf(&logMsg, "\n%d. %s", i+1, fi.Name())     //nolint:gosec
+		_, _ = fmt.Fprintf(&logMsg, "\n%d. %s", i+1, fi.Name()) //nolint:gosec
+		if BackupInUse(fi.Name()) {
+			_, _ = fmt.Fprintf(&logMsg, "（恢复事务正在使用，已跳过）") //nolint:gosec
+			continue
+		}
 		errDelete := os.Remove(filepath.Join(BackupDir, fi.Name())) //nolint:gosec
 		if errDelete != nil {
 			errDel = append(errDel, errDelete.Error())

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -135,7 +136,7 @@ type restoreJournalRecord struct {
 
 type restoreStatusAuth struct {
 	OperationID string `json:"operationId"`
-	Token       string `json:"token,omitempty"`
+	Token       string `json:"-"`
 	TokenHash   string `json:"tokenHash,omitempty"`
 	ExpiresAt   int64  `json:"expiresAt"`
 }
@@ -169,6 +170,7 @@ var (
 	restoreSyncMutationParents = syncRestoreMutationParents
 	probeRestoreDiskSpace      = platformPackageDiskSpace
 	errEmptyRestoreJournal     = errors.New("恢复日志不含完整 begin 记录")
+	restoreTokenMemory         sync.Map // operationID -> in-memory status token
 )
 
 func mustMarshalJSON(value any) json.RawMessage {
@@ -198,12 +200,14 @@ func newRestoreStatusAuth(operationID string) (*restoreStatusAuth, error) {
 		return nil, err
 	}
 	digest := sha256.Sum256([]byte(token))
-	return &restoreStatusAuth{
+	auth := &restoreStatusAuth{
 		OperationID: operationID,
 		Token:       token,
 		TokenHash:   hex.EncodeToString(digest[:]),
 		ExpiresAt:   time.Now().Add(restoreStatusTokenValidDuration).Unix(),
-	}, nil
+	}
+	restoreTokenMemory.Store(operationID, token)
+	return auth, nil
 }
 
 func restoreDir() string { return filepath.Join(BackupDir, restoreDirName) }
@@ -1510,6 +1514,13 @@ func readRestoreStatusAuth() (*restoreStatusAuth, error) {
 	if err = json.Unmarshal(data, &auth); err != nil {
 		return nil, err
 	}
+	if auth.Token == "" && auth.TokenHash != "" {
+		if cached, ok := restoreTokenMemory.Load(auth.OperationID); ok {
+			if token, ok := cached.(string); ok && restoreStatusTokenMatches(token, auth.TokenHash) {
+				auth.Token = token
+			}
+		}
+	}
 	return &auth, nil
 }
 
@@ -1545,7 +1556,7 @@ func refreshRestoreStatusAuth(pending *restorePending, auth *restoreStatusAuth) 
 		return nil, errors.New("恢复授权不完整")
 	}
 	now := time.Now().Unix()
-	if auth.ExpiresAt > now {
+	if auth.ExpiresAt > now && auth.Token != "" {
 		if !restoreStatusTokenMatches(auth.Token, auth.TokenHash) {
 			return nil, errors.New("恢复授权 token 与哈希不一致")
 		}
@@ -1678,6 +1689,22 @@ func restoreOperationFromExisting(name, requestID string) (*RestoreOperation, bo
 	}
 	if !errors.Is(pendingErr, os.ErrNotExist) {
 		return nil, false, fmt.Errorf("读取已有恢复任务失败: %w", pendingErr)
+	}
+	// A finished restore keeps its terminal status after metadata cleanup, so
+	// an idempotent replay can be answered without re-scheduling anything.
+	if status.State == "succeeded" && status.OperationID == requestID && status.SourceName == name {
+		auth, authErr := readRestoreStatusAuth()
+		if authErr == nil && auth.OperationID == requestID {
+			auth, authErr = refreshRestoreStatusAuth(nil, auth)
+			if authErr != nil {
+				return nil, false, fmt.Errorf("刷新终态恢复授权失败: %w", authErr)
+			}
+			return &RestoreOperation{OperationID: requestID, StatusToken: auth.Token, ExpiresAt: auth.ExpiresAt, Reused: true}, true, nil
+		}
+		if authErr != nil && !errors.Is(authErr, os.ErrNotExist) {
+			return nil, false, fmt.Errorf("读取终态恢复授权失败: %w", authErr)
+		}
+		return &RestoreOperation{OperationID: requestID, Reused: true}, true, nil
 	}
 	auth, authErr := readRestoreStatusAuth()
 	if errors.Is(authErr, os.ErrNotExist) || (authErr == nil && auth.OperationID != requestID) {
@@ -2996,6 +3023,11 @@ func cleanupCommittedArtifacts(removeMetadata bool) error {
 	if cleanupErr == nil {
 		if err := restoreRemove(restoreJournalPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
 			cleanupErr = fmt.Errorf("清理恢复日志: %w", err)
+		}
+	}
+	if cleanupErr == nil {
+		if err := restoreRemove(restoreStatusAuthPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErr = fmt.Errorf("清理恢复授权: %w", err)
 		}
 	}
 	if cleanupErr == nil {

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -1,0 +1,3362 @@
+package dice
+
+import (
+	"archive/zip"
+	"bytes"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+
+	"sealdice-core/logger"
+	"sealdice-core/utils/constant"
+)
+
+const (
+	restoreDirName                  = ".restore"
+	restorePendingName              = "pending.json"
+	restoreStatusName               = "status.json"
+	restoreSourceName               = "source.zip"
+	restoreStagingName              = "staging"
+	restoreRollbackName             = "rollback"
+	restoreJournalName              = "journal.jsonl"
+	restoreLegacyJournalName        = "journal.json"
+	restoreStatusAuthName           = "status-auth.json"
+	restoreLegacyOldDataName        = "old-data"
+	backupManifestFormatVersion     = 2
+	backupRestorePolicyOverlay      = "overlay"
+	maxBackupEntries                = 100000
+	maxBackupCentralDirectorySize   = uint64(256 << 20)
+	maxBackupEntryPathBytes         = 4096
+	maxImportedBackupSize           = uint64(8 << 30)
+	maxBackupEntryUncompressedSize  = uint64(16 << 30)
+	maxBackupTotalUncompressedSize  = uint64(64 << 30)
+	maxBackupCompressionRatio       = uint64(1000)
+	compressionRatioMinimumSize     = uint64(64 << 20)
+	maxRestoreJournalSize           = int64(256 << 20)
+	maxRestoreDiceConfigSize        = uint64(16 << 20)
+	maxRestoreRequestIDBytes        = 128
+	minimumDiskReserve              = uint64(1 << 30)
+	restoreStatusTokenValidDuration = 24 * time.Hour // 覆盖大型安全备份、恢复应用和 Runtime 重建的完整维护窗口。
+	restoreStatusTokenBytes         = 32
+)
+
+type BackupArchiveInfo struct {
+	Name             string `json:"name"`
+	FileSize         int64  `json:"fileSize"`
+	Selection        int64  `json:"selection"`
+	Version          string `json:"version"`
+	VersionCode      int64  `json:"versionCode"`
+	FormatVersion    int    `json:"formatVersion,omitempty"`
+	DatabaseType     string `json:"databaseType,omitempty"`
+	Valid            bool   `json:"valid"`
+	Restorable       bool   `json:"restorable"`
+	Error            string `json:"error,omitempty"`
+	RestoreError     string `json:"restoreError,omitempty"`
+	Reused           bool   `json:"reused,omitempty"`
+	UncompressedSize uint64 `json:"-"`
+}
+
+type RestoreStatus struct {
+	State            string `json:"state"`
+	OperationID      string `json:"operationId,omitempty"`
+	SourceName       string `json:"sourceName,omitempty"`
+	SafetyBackupName string `json:"safetyBackupName,omitempty"`
+	Message          string `json:"message,omitempty"`
+	UpdatedAt        int64  `json:"updatedAt"`
+}
+
+type restorePending struct {
+	Phase            string `json:"phase"`
+	OperationID      string `json:"operationId"`
+	StatusTokenHash  string `json:"statusTokenHash,omitempty"`
+	ExpiresAt        int64  `json:"expiresAt,omitempty"`
+	SourceName       string `json:"sourceName"`
+	SafetyBackupName string `json:"safetyBackupName,omitempty"`
+}
+
+type RestoreOperation struct {
+	OperationID      string `json:"operationId"`
+	StatusToken      string `json:"statusToken"`
+	ExpiresAt        int64  `json:"expiresAt"`
+	SafetyBackupName string `json:"safetyBackupName,omitempty"`
+	Reused           bool   `json:"reused"`
+}
+
+type restoreJournalEntry struct {
+	Target      string `json:"target"`
+	Rollback    string `json:"rollback"`
+	Staged      string `json:"staged,omitempty"`
+	HadOriginal bool   `json:"hadOriginal"`
+	State       string `json:"-"`
+
+	backupIntent  bool
+	backupDone    bool
+	installIntent bool
+	installDone   bool
+	removeIntent  bool
+	removeDone    bool
+	restoreIntent bool
+	restoreDone   bool
+}
+
+type restoreJournal struct {
+	OperationID string
+	State       string
+	Entries     []restoreJournalEntry
+}
+
+type restoreJournalRecord struct {
+	OperationID string                `json:"operationId"`
+	Type        string                `json:"type"`
+	State       string                `json:"state,omitempty"`
+	Index       int                   `json:"index,omitempty"`
+	Step        string                `json:"step,omitempty"`
+	Phase       string                `json:"phase,omitempty"`
+	Entries     []restoreJournalEntry `json:"entries,omitempty"`
+}
+
+type restoreStatusAuth struct {
+	OperationID string `json:"operationId"`
+	Token       string `json:"token,omitempty"`
+	TokenHash   string `json:"tokenHash,omitempty"`
+	ExpiresAt   int64  `json:"expiresAt"`
+}
+
+type backupManifestFile struct {
+	Path   string `json:"path"`
+	Size   uint64 `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+type backupManifest struct {
+	FormatVersion int                  `json:"formatVersion,omitempty"`
+	RestorePolicy string               `json:"restorePolicy,omitempty"`
+	DatabaseType  string               `json:"databaseType,omitempty"`
+	Files         []backupManifestFile `json:"files,omitempty"`
+	Config        json.RawMessage      `json:"config"`
+	Version       json.RawMessage      `json:"version"`
+	VersionCode   int64                `json:"versionCode"`
+}
+
+type managedDatabaseFile struct {
+	Name        string
+	Path        string
+	ArchivePath string
+}
+
+var (
+	restoreRename              = renameRestorePath
+	restoreRemove              = os.Remove
+	restoreRemoveAll           = os.RemoveAll
+	restoreSyncMutationParents = syncRestoreMutationParents
+	probeRestoreDiskSpace      = platformPackageDiskSpace
+	errEmptyRestoreJournal     = errors.New("恢复日志不含完整 begin 记录")
+)
+
+func mustMarshalJSON(value any) json.RawMessage {
+	data, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func newRestoreStatusToken() (string, error) {
+	raw := make([]byte, restoreStatusTokenBytes)
+	if _, err := cryptorand.Read(raw); err != nil {
+		return "", fmt.Errorf("生成恢复状态凭证: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func restoreStatusTokenMatches(token, encodedHash string) bool {
+	digest := sha256.Sum256([]byte(token))
+	return subtle.ConstantTimeCompare([]byte(strings.ToLower(encodedHash)), []byte(hex.EncodeToString(digest[:]))) == 1
+}
+
+func newRestoreStatusAuth(operationID string) (*restoreStatusAuth, error) {
+	token, err := newRestoreStatusToken()
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256([]byte(token))
+	return &restoreStatusAuth{
+		OperationID: operationID,
+		Token:       token,
+		TokenHash:   hex.EncodeToString(digest[:]),
+		ExpiresAt:   time.Now().Add(restoreStatusTokenValidDuration).Unix(),
+	}, nil
+}
+
+func restoreDir() string { return filepath.Join(BackupDir, restoreDirName) }
+
+func restorePendingPath() string { return filepath.Join(restoreDir(), restorePendingName) }
+
+func restoreStatusPath() string { return filepath.Join(restoreDir(), restoreStatusName) }
+
+func restoreJournalPath() string { return filepath.Join(restoreDir(), restoreJournalName) }
+
+func restoreLegacyJournalPath() string { return filepath.Join(restoreDir(), restoreLegacyJournalName) }
+
+func restoreStatusAuthPath() string { return filepath.Join(restoreDir(), restoreStatusAuthName) }
+
+func validateBackupDirectoryLocked() error {
+	info, err := os.Lstat(BackupDir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || isLinkedRestorePath(info) {
+		return errors.New("备份目录不是普通目录或为符号链接")
+	}
+	return nil
+}
+
+func ensureBackupDirectoryLocked() error {
+	if err := validateBackupDirectoryLocked(); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(BackupDir, 0o755); err != nil {
+		return err
+	}
+	return validateBackupDirectoryLocked()
+}
+
+func validateRestoreStorageLocked() error {
+	if err := validateBackupDirectoryLocked(); err != nil {
+		return err
+	}
+	info, err := os.Lstat(restoreDir())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || isLinkedRestorePath(info) {
+		return errors.New("恢复元数据目录不是普通目录或为符号链接")
+	}
+	return ensureNoLinkedPath(BackupDir, restoreDir(), false)
+}
+
+func HasPendingRestore() bool {
+	_, err := os.Stat(restorePendingPath())
+	return err == nil
+}
+
+func diskReserve(total uint64) uint64 {
+	reserve := total / 20
+	if reserve < minimumDiskReserve {
+		return minimumDiskReserve
+	}
+	return reserve
+}
+
+func ensureDiskSpace(filename string, required uint64) error {
+	space, err := probeRestoreDiskSpace(filename)
+	if err != nil {
+		return fmt.Errorf("检查磁盘空间失败: %w", err)
+	}
+	reserve := diskReserve(space.Total)
+	if space.Available < required || space.Available-required < reserve {
+		return fmt.Errorf("磁盘空间不足：需要 %d 字节并保留 %d 字节安全余量，当前可用 %d 字节", required, reserve, space.Available)
+	}
+	return nil
+}
+
+func parseManifestVersion(raw json.RawMessage) string {
+	var version string
+	if json.Unmarshal(raw, &version) == nil {
+		return version
+	}
+	return "旧版"
+}
+
+func selectionFromManifest(raw json.RawMessage) int64 {
+	var cfg struct {
+		Decks   bool `json:"decks"`
+		HelpDoc bool `json:"helpDoc"`
+		Censor  bool `json:"censor"`
+		Names   bool `json:"names"`
+		Images  bool `json:"images"`
+		Dices   map[string]struct {
+			JSScripts bool `json:"jsScripts"`
+		} `json:"dices"`
+	}
+	if json.Unmarshal(raw, &cfg) != nil {
+		return 0
+	}
+	var selection BackupSelection
+	if cfg.Decks {
+		selection |= BackupSelectionDecks
+	}
+	if cfg.HelpDoc {
+		selection |= BackupSelectionHelpDoc
+	}
+	if cfg.Censor {
+		selection |= BackupSelectionCensor
+	}
+	if cfg.Names {
+		selection |= BackupSelectionNames
+	}
+	if cfg.Images {
+		selection |= BackupSelectionImages
+	}
+	for _, diceConfig := range cfg.Dices {
+		if diceConfig.JSScripts {
+			selection |= BackupSelectionJS
+			break
+		}
+	}
+	return int64(selection)
+}
+
+func pathWithinRoot(root, target string) (string, error) {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	relative, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return "", fmt.Errorf("路径 %s 不在受管目录 %s 内", target, root)
+	}
+	return relative, nil
+}
+
+func ensureNoLinkedPath(root, target string, finalMayBeFile bool) error {
+	relative, err := pathWithinRoot(root, target)
+	if err != nil {
+		return err
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	parts := []string{"."}
+	if relative != "." {
+		parts = strings.Split(relative, string(filepath.Separator))
+	}
+	current := rootAbs
+	for index, part := range parts {
+		if part != "." {
+			current = filepath.Join(current, part)
+		}
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return nil
+		}
+		if statErr != nil {
+			return fmt.Errorf("检查路径 %s: %w", current, statErr)
+		}
+		if isLinkedRestorePath(info) {
+			return fmt.Errorf("路径包含符号链接或重解析点: %s", current)
+		}
+		resolved, resolveErr := filepath.EvalSymlinks(current)
+		if resolveErr == nil {
+			resolvedInfo, resolvedErr := os.Stat(resolved)
+			if resolvedErr != nil {
+				return resolvedErr
+			}
+			if !os.SameFile(info, resolvedInfo) {
+				return fmt.Errorf("路径包含符号链接或重解析点: %s", current)
+			}
+		}
+		last := index == len(parts)-1
+		if !last && !info.IsDir() {
+			return fmt.Errorf("路径父级不是目录: %s", current)
+		}
+		if last && finalMayBeFile && !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("路径不是普通文件: %s", current)
+		}
+	}
+	return nil
+}
+
+func managedDataRoot() (string, error) {
+	root, err := filepath.Abs("data")
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return "", fmt.Errorf("读取受管 data 根目录: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("受管 data 根目录不是普通目录或为符号链接")
+	}
+	if err = ensureNoLinkedPath(root, root, false); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func managedArchivePath(filename string) (string, error) {
+	root, err := managedDataRoot()
+	if err != nil {
+		return "", err
+	}
+	relative, err := pathWithinRoot(root, filename)
+	if err != nil {
+		return "", err
+	}
+	if relative == "." {
+		return "", errors.New("不能将 data 根目录作为备份文件")
+	}
+	if err = ensureNoLinkedPath(root, filename, true); err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(filepath.Join("data", relative)), nil
+}
+
+func managedSQLiteDatabaseFiles(dm *DiceManager, requireExisting bool) ([]managedDatabaseFile, error) {
+	if dm == nil || dm.Operator == nil || len(dm.Dice) == 0 {
+		return nil, errors.New("恢复要求非空的 SQLite DiceManager")
+	}
+	if dm.Operator.Type() != constant.SQLITE {
+		return nil, fmt.Errorf("备份恢复仅支持 SQLite，当前数据库类型为 %q", dm.Operator.Type())
+	}
+	root, err := managedDataRoot()
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range dm.Dice {
+		if d == nil || d.BaseConfig.Name == "" || d.BaseConfig.DataDir == "" {
+			return nil, errors.New("恢复要求所有 Dice 实例都具有非空名称和受管 DataDir")
+		}
+		if _, pathErr := pathWithinRoot(root, d.BaseConfig.DataDir); pathErr != nil {
+			return nil, fmt.Errorf("骰子 %q 的 DataDir 不在受管 data 根目录内: %w", d.BaseConfig.Name, pathErr)
+		}
+		if pathErr := ensureNoLinkedPath(root, d.BaseConfig.DataDir, false); pathErr != nil {
+			return nil, fmt.Errorf("骰子 %q 的 DataDir 不安全: %w", d.BaseConfig.Name, pathErr)
+		}
+	}
+	dataDir := os.Getenv("DATADIR")
+	if dataDir == "" {
+		dataDir = filepath.Join("data", "default")
+	}
+	dataDirAbs, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("解析 DATADIR: %w", err)
+	}
+	if _, err = pathWithinRoot(root, dataDirAbs); err != nil {
+		return nil, fmt.Errorf("环境变量 DATADIR 必须位于受管 data 根目录内: %w", err)
+	}
+	if err = ensureNoLinkedPath(root, dataDirAbs, false); err != nil {
+		return nil, fmt.Errorf("环境变量 DATADIR 不安全: %w", err)
+	}
+	if requireExisting {
+		info, statErr := os.Lstat(dataDirAbs)
+		if statErr != nil {
+			return nil, fmt.Errorf("读取 DATADIR: %w", statErr)
+		}
+		if !info.IsDir() {
+			return nil, errors.New("环境变量 DATADIR 指向的路径不是目录")
+		}
+	}
+	result := make([]managedDatabaseFile, 0, 3)
+	for _, name := range []string{"data.db", "data-logs.db", "data-censor.db"} {
+		filename := filepath.Join(dataDirAbs, name)
+		archiveName, archiveErr := managedArchivePath(filename)
+		if archiveErr != nil {
+			return nil, fmt.Errorf("数据库文件 %s 不在受管 data 根目录内: %w", name, archiveErr)
+		}
+		info, statErr := os.Lstat(filename)
+		if statErr != nil {
+			if requireExisting || !errors.Is(statErr, os.ErrNotExist) {
+				return nil, fmt.Errorf("读取数据库文件 %s: %w", name, statErr)
+			}
+		} else if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("数据库文件 %s 不是普通文件或为符号链接", name)
+		}
+		result = append(result, managedDatabaseFile{Name: name, Path: filename, ArchivePath: archiveName})
+	}
+	return result, nil
+}
+
+func isWindowsReservedName(segment string) bool {
+	base := strings.ToUpper(strings.TrimRight(strings.SplitN(segment, ".", 2)[0], " ."))
+	if base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" || base == "CONIN$" || base == "CONOUT$" || base == "CLOCK$" {
+		return true
+	}
+	if strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT") {
+		suffix := base[3:]
+		return (len(suffix) == 1 && suffix[0] >= '1' && suffix[0] <= '9') || suffix == "¹" || suffix == "²" || suffix == "³"
+	}
+	return false
+}
+
+func normalizeBackupEntryName(name string, isDir bool) (string, error) {
+	if name == "" || !utf8.ValidString(name) {
+		return "", errors.New("压缩包包含空路径或非法 UTF-8 路径")
+	}
+	if len(name) > maxBackupEntryPathBytes {
+		return "", fmt.Errorf("压缩包路径超过 %d 字节限制", maxBackupEntryPathBytes)
+	}
+	normalized := strings.ReplaceAll(name, "\\", "/")
+	if strings.HasPrefix(normalized, "/") || strings.HasPrefix(normalized, "//") || path.IsAbs(normalized) || filepath.VolumeName(name) != "" ||
+		(len(normalized) >= 2 && normalized[1] == ':') {
+		return "", fmt.Errorf("压缩包包含绝对路径 %q", name)
+	}
+	trimmed := strings.TrimSuffix(normalized, "/")
+	clean := path.Clean(trimmed)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || clean != trimmed {
+		return "", fmt.Errorf("压缩包包含非法路径 %q", name)
+	}
+	for _, segment := range strings.Split(clean, "/") {
+		if segment == "" || strings.HasSuffix(segment, ".") || strings.HasSuffix(segment, " ") || strings.ContainsAny(segment, `:<>"|?*`) || isWindowsReservedName(segment) {
+			return "", fmt.Errorf("压缩包包含 Windows 不安全路径 %q", name)
+		}
+		for _, char := range segment {
+			if char < 0x20 {
+				return "", fmt.Errorf("压缩包路径包含控制字符 %q", name)
+			}
+		}
+	}
+	if isDir && normalized != trimmed+"/" && normalized != trimmed {
+		return "", fmt.Errorf("压缩包包含非法目录路径 %q", name)
+	}
+	return clean, nil
+}
+
+func isSQLiteSidecarPath(filename string) bool {
+	lower := strings.ToLower(filename)
+	return strings.HasSuffix(lower, ".db-wal") || strings.HasSuffix(lower, ".db-shm") || strings.HasSuffix(lower, ".db-journal")
+}
+
+func checkCompressionRatio(name string, compressed, uncompressed uint64) error {
+	if uncompressed <= compressionRatioMinimumSize {
+		return nil
+	}
+	if compressed == 0 || uncompressed/compressed > maxBackupCompressionRatio {
+		return fmt.Errorf("压缩包条目 %q 的压缩比异常", name)
+	}
+	return nil
+}
+
+type zipDirectoryMetadata struct {
+	records   uint64
+	size      uint64
+	offset    uint64
+	endOffset int64
+	zip64     bool
+}
+
+func readZIPDirectoryMetadata(file *os.File, size int64) (zipDirectoryMetadata, error) {
+	if size < 22 {
+		return zipDirectoryMetadata{}, errors.New("zip 文件过短")
+	}
+	tailSize := int64(22 + 1<<16)
+	if tailSize > size {
+		tailSize = size
+	}
+	tail := make([]byte, int(tailSize))
+	if _, err := file.ReadAt(tail, size-tailSize); err != nil {
+		return zipDirectoryMetadata{}, err
+	}
+	eocdIndex := -1
+	for index := len(tail) - 22; index >= 0; index-- {
+		if binary.LittleEndian.Uint32(tail[index:index+4]) != 0x06054b50 {
+			continue
+		}
+		commentLength := int(binary.LittleEndian.Uint16(tail[index+20 : index+22]))
+		if index+22+commentLength == len(tail) {
+			eocdIndex = index
+			break
+		}
+	}
+	if eocdIndex < 0 {
+		return zipDirectoryMetadata{}, errors.New("zip 缺少有效中央目录结束记录")
+	}
+	eocd := tail[eocdIndex : eocdIndex+22]
+	disk := binary.LittleEndian.Uint16(eocd[4:6])
+	directoryDisk := binary.LittleEndian.Uint16(eocd[6:8])
+	recordsOnDisk := binary.LittleEndian.Uint16(eocd[8:10])
+	records := binary.LittleEndian.Uint16(eocd[10:12])
+	metadata := zipDirectoryMetadata{
+		records:   uint64(records),
+		size:      uint64(binary.LittleEndian.Uint32(eocd[12:16])),
+		offset:    uint64(binary.LittleEndian.Uint32(eocd[16:20])),
+		endOffset: size - tailSize + int64(eocdIndex),
+	}
+	if disk != 0 || directoryDisk != 0 || recordsOnDisk != records {
+		return zipDirectoryMetadata{}, errors.New("不支持分卷 zip")
+	}
+	needsZIP64 := records == math.MaxUint16 || metadata.size == math.MaxUint32 || metadata.offset == math.MaxUint32
+	if !needsZIP64 {
+		return metadata, nil
+	}
+	locatorOffset := metadata.endOffset - 20
+	if locatorOffset < 0 {
+		return zipDirectoryMetadata{}, errors.New("zip64 缺少中央目录定位记录")
+	}
+	locator := make([]byte, 20)
+	if _, err := file.ReadAt(locator, locatorOffset); err != nil {
+		return zipDirectoryMetadata{}, err
+	}
+	if binary.LittleEndian.Uint32(locator[:4]) != 0x07064b50 || binary.LittleEndian.Uint32(locator[4:8]) != 0 ||
+		binary.LittleEndian.Uint32(locator[16:20]) != 1 {
+		return zipDirectoryMetadata{}, errors.New("zip64 中央目录定位记录非法")
+	}
+	zip64Offset := binary.LittleEndian.Uint64(locator[8:16])
+	if zip64Offset > math.MaxInt64 || int64(zip64Offset) > size-56 {
+		return zipDirectoryMetadata{}, errors.New("zip64 中央目录结束记录越界")
+	}
+	header := make([]byte, 56)
+	if _, err := file.ReadAt(header, int64(zip64Offset)); err != nil {
+		return zipDirectoryMetadata{}, err
+	}
+	if binary.LittleEndian.Uint32(header[:4]) != 0x06064b50 || binary.LittleEndian.Uint64(header[4:12]) < 44 {
+		return zipDirectoryMetadata{}, errors.New("zip64 中央目录结束记录非法")
+	}
+	disk64 := binary.LittleEndian.Uint32(header[16:20])
+	directoryDisk64 := binary.LittleEndian.Uint32(header[20:24])
+	recordsOnDisk64 := binary.LittleEndian.Uint64(header[24:32])
+	metadata.records = binary.LittleEndian.Uint64(header[32:40])
+	metadata.size = binary.LittleEndian.Uint64(header[40:48])
+	metadata.offset = binary.LittleEndian.Uint64(header[48:56])
+	metadata.endOffset = int64(zip64Offset)
+	metadata.zip64 = true
+	if disk64 != 0 || directoryDisk64 != 0 || recordsOnDisk64 != metadata.records {
+		return zipDirectoryMetadata{}, errors.New("不支持分卷 zip64")
+	}
+	return metadata, nil
+}
+
+func preflightZIPCentralDirectory(filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	metadata, err := readZIPDirectoryMetadata(file, info.Size())
+	if err != nil {
+		return err
+	}
+	if metadata.records > maxBackupEntries {
+		return fmt.Errorf("压缩包条目超过 %d 个", maxBackupEntries)
+	}
+	if metadata.size > maxBackupCentralDirectorySize || metadata.size > math.MaxInt64 {
+		return errors.New("zip 中央目录超过大小限制")
+	}
+	if metadata.offset > math.MaxInt64 {
+		return errors.New("zip 中央目录偏移越界")
+	}
+	baseOffset := metadata.endOffset - int64(metadata.size) - int64(metadata.offset)
+	start := baseOffset + int64(metadata.offset)
+	if baseOffset > 0 {
+		var signature [4]byte
+		if _, readErr := file.ReadAt(signature[:], int64(metadata.offset)); readErr == nil && binary.LittleEndian.Uint32(signature[:]) == 0x02014b50 {
+			start = int64(metadata.offset)
+		}
+	}
+	if start < 0 || int64(metadata.size) > info.Size()-start {
+		return errors.New("zip 中央目录范围越界")
+	}
+	position := start
+	end := start + int64(metadata.size)
+	var actualRecords uint64
+	var header [46]byte
+	for position < end {
+		if end-position < int64(len(header)) {
+			break
+		}
+		if _, err = file.ReadAt(header[:], position); err != nil {
+			return err
+		}
+		if binary.LittleEndian.Uint32(header[:4]) != 0x02014b50 {
+			break
+		}
+		nameLength := uint64(binary.LittleEndian.Uint16(header[28:30]))
+		extraLength := uint64(binary.LittleEndian.Uint16(header[30:32]))
+		commentLength := uint64(binary.LittleEndian.Uint16(header[32:34]))
+		if nameLength > maxBackupEntryPathBytes {
+			return fmt.Errorf("zip 中央目录路径超过 %d 字节限制", maxBackupEntryPathBytes)
+		}
+		recordSize, overflow := addUint64Checked(uint64(len(header)), nameLength, extraLength, commentLength)
+		if overflow || recordSize > uint64(end-position) {
+			return errors.New("zip 中央目录条目越界")
+		}
+		position += int64(recordSize)
+		actualRecords++
+		if actualRecords > maxBackupEntries {
+			return fmt.Errorf("压缩包条目超过 %d 个", maxBackupEntries)
+		}
+	}
+	if position != end {
+		var signatureHeader [6]byte
+		if end-position < int64(len(signatureHeader)) {
+			return errors.New("zip 中央目录尾部非法")
+		}
+		if _, err = file.ReadAt(signatureHeader[:], position); err != nil {
+			return err
+		}
+		signatureSize := int64(binary.LittleEndian.Uint16(signatureHeader[4:6]))
+		if binary.LittleEndian.Uint32(signatureHeader[:4]) != 0x05054b50 || position+6+signatureSize != end {
+			return errors.New("zip 中央目录包含非法尾部记录")
+		}
+	}
+	if metadata.zip64 {
+		if actualRecords != metadata.records {
+			return errors.New("zip64 中央目录条目数不一致")
+		}
+	} else if uint16(actualRecords) != uint16(metadata.records) { //nolint:gosec // ZIP32 stores the count modulo 65536.
+		return errors.New("zip 中央目录条目数不一致")
+	}
+	return nil
+}
+
+func inspectBackupArchive(filename string) (*BackupArchiveInfo, map[string]struct{}, error) {
+	info, entries, _, err := inspectBackupArchiveDetailed(filename)
+	return info, entries, err
+}
+
+func inspectBackupArchiveDetailed(filename string) (*BackupArchiveInfo, map[string]struct{}, backupManifest, error) {
+	var emptyManifest backupManifest
+	stat, err := os.Lstat(filename)
+	if err != nil {
+		return nil, nil, emptyManifest, err
+	}
+	if !stat.Mode().IsRegular() {
+		return nil, nil, emptyManifest, errors.New("备份文件不是普通文件或为符号链接")
+	}
+	if err = preflightZIPCentralDirectory(filename); err != nil {
+		return nil, nil, emptyManifest, fmt.Errorf("zip 中央目录预检失败: %w", err)
+	}
+	reader, err := zip.OpenReader(filename)
+	if err != nil {
+		return nil, nil, emptyManifest, fmt.Errorf("不是有效的 ZIP 文件: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if len(reader.File) > maxBackupEntries {
+		return nil, nil, emptyManifest, fmt.Errorf("压缩包条目超过 %d 个", maxBackupEntries)
+	}
+
+	entries := make(map[string]struct{}, len(reader.File))
+	entryKinds := make(map[string]bool, len(reader.File))
+	requiredDirs := make(map[string]struct{}, len(reader.File))
+	regularSizes := make(map[string]uint64, len(reader.File))
+	var manifest backupManifest
+	manifestFound := false
+	dataConfigFound := false
+	processOwnedPath := ""
+	var uncompressed uint64
+	var compressed uint64
+	for _, item := range reader.File {
+		clean, cleanErr := normalizeBackupEntryName(item.Name, item.FileInfo().IsDir())
+		if cleanErr != nil {
+			return nil, nil, emptyManifest, cleanErr
+		}
+		mode := item.Mode()
+		if mode&os.ModeSymlink != 0 || (!item.FileInfo().IsDir() && !mode.IsRegular()) {
+			return nil, nil, emptyManifest, fmt.Errorf("压缩包包含不支持的文件类型 %q", item.Name)
+		}
+		if clean != "backup_info.json" && clean != "data" && !strings.HasPrefix(clean, "data/") {
+			return nil, nil, emptyManifest, fmt.Errorf("压缩包包含 data 目录外的文件 %q", item.Name)
+		}
+		if !item.FileInfo().IsDir() && isSQLiteSidecarPath(clean) {
+			return nil, nil, emptyManifest, fmt.Errorf("压缩包不得包含 SQLite 临时文件 %q", item.Name)
+		}
+		if !item.FileInfo().IsDir() && processOwnedPath == "" && isProcessOwnedRestorePath(clean) {
+			processOwnedPath = clean
+		}
+		folded := strings.ToLower(clean)
+		if _, exists := entryKinds[folded]; exists {
+			return nil, nil, emptyManifest, fmt.Errorf("压缩包包含重复或大小写冲突路径 %q", item.Name)
+		}
+		if !item.FileInfo().IsDir() {
+			if _, neededAsDir := requiredDirs[folded]; neededAsDir {
+				return nil, nil, emptyManifest, fmt.Errorf("压缩包路径同时作为文件和目录 %q", item.Name)
+			}
+		}
+		parts := strings.Split(clean, "/")
+		for index := 1; index < len(parts); index++ {
+			ancestor := strings.ToLower(strings.Join(parts[:index], "/"))
+			if isDir, exists := entryKinds[ancestor]; exists && !isDir {
+				return nil, nil, emptyManifest, fmt.Errorf("压缩包路径的父级是文件 %q", item.Name)
+			}
+			requiredDirs[ancestor] = struct{}{}
+		}
+		entries[clean] = struct{}{}
+		entryKinds[folded] = item.FileInfo().IsDir()
+		if item.UncompressedSize64 > maxBackupEntryUncompressedSize {
+			return nil, nil, emptyManifest, fmt.Errorf("压缩包条目 %q 解压后过大", item.Name)
+		}
+		if err = checkCompressionRatio(item.Name, item.CompressedSize64, item.UncompressedSize64); err != nil {
+			return nil, nil, emptyManifest, err
+		}
+		if math.MaxUint64-uncompressed < item.UncompressedSize64 || math.MaxUint64-compressed < item.CompressedSize64 {
+			return nil, nil, emptyManifest, errors.New("压缩包大小计算溢出")
+		}
+		uncompressed += item.UncompressedSize64
+		compressed += item.CompressedSize64
+		if uncompressed > maxBackupTotalUncompressedSize {
+			return nil, nil, emptyManifest, errors.New("压缩包总解压大小超过限制")
+		}
+		if clean == "data/dice.yaml" && !item.FileInfo().IsDir() {
+			dataConfigFound = true
+		}
+		if !item.FileInfo().IsDir() && clean != "backup_info.json" {
+			regularSizes[clean] = item.UncompressedSize64
+		}
+		if clean == "backup_info.json" {
+			if item.FileInfo().IsDir() || item.UncompressedSize64 > 1<<20 {
+				return nil, nil, emptyManifest, errors.New("backup_info.json 类型非法或过大")
+			}
+			rc, openErr := item.Open()
+			if openErr != nil {
+				return nil, nil, emptyManifest, fmt.Errorf("读取 backup_info.json 失败: %w", openErr)
+			}
+			decoder := json.NewDecoder(io.LimitReader(rc, 1<<20))
+			decodeErr := decoder.Decode(&manifest)
+			closeErr := rc.Close()
+			if decodeErr != nil {
+				return nil, nil, emptyManifest, fmt.Errorf("解析 backup_info.json 失败: %w", decodeErr)
+			}
+			if closeErr != nil {
+				return nil, nil, emptyManifest, fmt.Errorf("校验 backup_info.json 失败: %w", closeErr)
+			}
+			manifestFound = true
+		}
+	}
+	if err = checkCompressionRatio("整个压缩包", compressed, uncompressed); err != nil {
+		return nil, nil, emptyManifest, err
+	}
+	if !manifestFound || manifest.VersionCode <= 0 {
+		return nil, nil, emptyManifest, errors.New("缺少有效的 backup_info.json")
+	}
+	if !dataConfigFound {
+		return nil, nil, emptyManifest, errors.New("备份缺少 data/dice.yaml")
+	}
+	if manifest.VersionCode > VERSION_CODE {
+		return nil, nil, emptyManifest, fmt.Errorf("备份版本 %d 高于当前程序版本 %d", manifest.VersionCode, VERSION_CODE)
+	}
+	restorable := true
+	if manifest.FormatVersion > backupManifestFormatVersion {
+		return nil, nil, emptyManifest, fmt.Errorf("备份格式版本 %d 高于支持版本 %d", manifest.FormatVersion, backupManifestFormatVersion)
+	}
+	if manifest.FormatVersion != 0 && manifest.FormatVersion != backupManifestFormatVersion {
+		return nil, nil, emptyManifest, fmt.Errorf("不支持的备份格式版本 %d", manifest.FormatVersion)
+	}
+	if manifest.FormatVersion == backupManifestFormatVersion {
+		if manifest.RestorePolicy != backupRestorePolicyOverlay {
+			return nil, nil, emptyManifest, fmt.Errorf("不支持的恢复策略 %q", manifest.RestorePolicy)
+		}
+		if manifest.DatabaseType == "" {
+			return nil, nil, emptyManifest, errors.New("v2 备份缺少 databaseType")
+		}
+		restorable = manifest.DatabaseType == constant.SQLITE
+		manifestPaths := make(map[string]struct{}, len(manifest.Files))
+		for _, file := range manifest.Files {
+			clean, pathErr := normalizeBackupEntryName(file.Path, false)
+			if pathErr != nil || clean != file.Path || strings.Contains(file.Path, "\\") || clean == "backup_info.json" {
+				return nil, nil, emptyManifest, fmt.Errorf("v2 清单包含非法文件路径 %q", file.Path)
+			}
+			folded := strings.ToLower(clean)
+			if _, exists := manifestPaths[folded]; exists {
+				return nil, nil, emptyManifest, fmt.Errorf("v2 清单包含重复或大小写冲突路径 %q", file.Path)
+			}
+			digest, hashErr := hex.DecodeString(file.SHA256)
+			if hashErr != nil || len(digest) != sha256.Size {
+				return nil, nil, emptyManifest, fmt.Errorf("v2 清单包含非法 SHA-256: %s", file.Path)
+			}
+			archiveSize, exists := regularSizes[clean]
+			if !exists || archiveSize != file.Size {
+				return nil, nil, emptyManifest, fmt.Errorf("v2 清单与 ZIP 条目不一致: %s", file.Path)
+			}
+			manifestPaths[folded] = struct{}{}
+		}
+		if len(manifestPaths) != len(regularSizes) {
+			return nil, nil, emptyManifest, errors.New("v2 清单没有完整覆盖 ZIP 文件")
+		}
+	}
+	restoreError := ""
+	if processOwnedPath != "" {
+		restorable = false
+		restoreError = fmt.Sprintf("备份包含进程级占用文件 %s", processOwnedPath)
+	}
+	return &BackupArchiveInfo{
+		Name:             filepath.Base(filename),
+		FileSize:         stat.Size(),
+		Selection:        selectionFromManifest(manifest.Config),
+		Version:          parseManifestVersion(manifest.Version),
+		VersionCode:      manifest.VersionCode,
+		FormatVersion:    manifest.FormatVersion,
+		DatabaseType:     manifest.DatabaseType,
+		Valid:            true,
+		Restorable:       restorable,
+		RestoreError:     restoreError,
+		UncompressedSize: uncompressed,
+	}, entries, manifest, nil
+}
+
+func InspectBackupArchive(filename string) *BackupArchiveInfo {
+	info, _, err := inspectBackupArchive(filename)
+	if err == nil {
+		return info
+	}
+	stat, statErr := os.Stat(filename)
+	item := &BackupArchiveInfo{Name: filepath.Base(filename), Selection: -1, Error: err.Error()}
+	if statErr == nil {
+		item.FileSize = stat.Size()
+	}
+	return item
+}
+
+func validateBackupData(filename string) error {
+	_, _, manifest, err := inspectBackupArchiveDetailed(filename)
+	if err != nil {
+		return err
+	}
+	expected := make(map[string]backupManifestFile, len(manifest.Files))
+	if manifest.FormatVersion == backupManifestFormatVersion {
+		for _, file := range manifest.Files {
+			expected[file.Path] = file
+		}
+	}
+	reader, err := zip.OpenReader(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+	seen := make(map[string]struct{}, len(expected))
+	var archivedDiceConfig []byte
+	for _, item := range reader.File {
+		if item.FileInfo().IsDir() {
+			continue
+		}
+		clean, cleanErr := normalizeBackupEntryName(item.Name, false)
+		if cleanErr != nil {
+			return cleanErr
+		}
+		rc, openErr := item.Open()
+		if openErr != nil {
+			return openErr
+		}
+		hasher := sha256.New()
+		destination := io.Writer(hasher)
+		var diceConfig bytes.Buffer
+		if clean == "data/dice.yaml" {
+			if item.UncompressedSize64 > maxRestoreDiceConfigSize {
+				_ = rc.Close()
+				return fmt.Errorf("data/dice.yaml 超过 %d 字节限制", maxRestoreDiceConfigSize)
+			}
+			destination = io.MultiWriter(hasher, &diceConfig)
+		}
+		written, copyErr := io.Copy(destination, rc)
+		closeErr := rc.Close()
+		if copyErr != nil || closeErr != nil || uint64(written) != item.UncompressedSize64 {
+			return fmt.Errorf("校验 %s 失败", item.Name)
+		}
+		if clean == "backup_info.json" || manifest.FormatVersion != backupManifestFormatVersion {
+			if clean == "data/dice.yaml" {
+				archivedDiceConfig = append([]byte(nil), diceConfig.Bytes()...)
+			}
+			continue
+		}
+		expectedFile, exists := expected[clean]
+		if !exists || expectedFile.Size != uint64(written) || !strings.EqualFold(expectedFile.SHA256, hex.EncodeToString(hasher.Sum(nil))) {
+			return fmt.Errorf("v2 文件校验失败: %s", clean)
+		}
+		seen[clean] = struct{}{}
+		if clean == "data/dice.yaml" {
+			archivedDiceConfig = append([]byte(nil), diceConfig.Bytes()...)
+		}
+	}
+	if len(seen) != len(expected) {
+		return errors.New("v2 文件清单校验不完整")
+	}
+	var config struct {
+		DiceConfigs []BaseConfig `yaml:"diceConfigs"`
+	}
+	if err = yaml.Unmarshal(archivedDiceConfig, &config); err != nil {
+		return fmt.Errorf("解析 data/dice.yaml 失败: %w", err)
+	}
+	if err = ValidateDiceConfigNames(config.DiceConfigs); err != nil {
+		return fmt.Errorf("data/dice.yaml 包含不安全的骰子名称: %w", err)
+	}
+	return nil
+}
+
+func copyFileSynced(source, target string) error {
+	src, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = src.Close() }()
+	dst, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		return err
+	}
+	if err = dst.Sync(); err != nil {
+		_ = dst.Close()
+		return err
+	}
+	return dst.Close()
+}
+
+func syncDirectory(directory string) error {
+	return syncRestoreDirectoryPath(directory)
+}
+
+func syncRestoreMutationParents(rootAndFiles ...string) error {
+	if len(rootAndFiles)%2 != 0 {
+		return errors.New("恢复目录同步参数不成对")
+	}
+	seen := make(map[string]struct{}, len(rootAndFiles))
+	for index := 0; index < len(rootAndFiles); index += 2 {
+		rootAbs, err := filepath.Abs(rootAndFiles[index])
+		if err != nil {
+			return err
+		}
+		filenameAbs, err := filepath.Abs(rootAndFiles[index+1])
+		if err != nil {
+			return err
+		}
+		if _, err = pathWithinRoot(rootAbs, filenameAbs); err != nil {
+			return err
+		}
+		current := filepath.Dir(filenameAbs)
+		for {
+			key := strings.ToLower(filepath.Clean(current))
+			if _, exists := seen[key]; !exists {
+				if err = syncRestoreDirectoryPath(current); err != nil {
+					return fmt.Errorf("同步恢复目录 %s: %w", current, err)
+				}
+				seen[key] = struct{}{}
+			}
+			if filepath.Clean(current) == filepath.Clean(rootAbs) {
+				break
+			}
+			parent := filepath.Dir(current)
+			if parent == current {
+				return fmt.Errorf("同步路径 %s 未到达受管根 %s", filenameAbs, rootAbs)
+			}
+			current = parent
+		}
+	}
+	return nil
+}
+
+func writeJSONAtomic(filename string, value any) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if err = os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(filename), "."+filepath.Base(filename)+"-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if err = tmp.Chmod(0o600); err == nil {
+		_, err = tmp.Write(data)
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	closeErr := tmp.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if err = replaceFileAtomic(tmpName, filename); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(filename))
+}
+
+func setRestoreStatus(status RestoreStatus) error {
+	status.UpdatedAt = time.Now().Unix()
+	return writeJSONAtomic(restoreStatusPath(), status)
+}
+
+func GetRestoreStatus() RestoreStatus {
+	data, err := os.ReadFile(restoreStatusPath())
+	if err != nil {
+		return RestoreStatus{State: "idle"}
+	}
+	var status RestoreStatus
+	if json.Unmarshal(data, &status) != nil {
+		return RestoreStatus{State: "failed", Message: "恢复状态文件损坏"}
+	}
+	return status
+}
+
+func UpdateRestoreStatusState(state, message string) error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		return err
+	}
+	pending, err := readPendingRestore()
+	if err != nil {
+		return err
+	}
+	if pending.OperationID == "" {
+		return errors.New("恢复任务缺少 operationID")
+	}
+	return setRestoreStatus(RestoreStatus{
+		State:            state,
+		OperationID:      pending.OperationID,
+		SourceName:       pending.SourceName,
+		SafetyBackupName: pending.SafetyBackupName,
+		Message:          message,
+	})
+}
+
+func backupInUseLocked(name string) (bool, error) {
+	pending, err := readPendingRestore()
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("读取恢复任务以确认备份占用: %w", err)
+	}
+	return strings.EqualFold(name, pending.SourceName) || strings.EqualFold(name, pending.SafetyBackupName), nil
+}
+
+func BackupInUse(name string) bool {
+	inUse, err := backupInUseLocked(name)
+	return err != nil || inUse
+}
+
+func validBackupFilename(name string) bool {
+	if filepath.Base(name) != name || strings.ToLower(filepath.Ext(name)) != ".zip" || strings.HasSuffix(name, ".") || strings.HasSuffix(name, " ") {
+		return false
+	}
+	_, err := normalizeBackupEntryName("data/"+name, false)
+	return err == nil
+}
+
+func backupArchiveFileLocked(name string) (string, os.FileInfo, error) {
+	if !validBackupFilename(name) {
+		return "", nil, errors.New("备份文件名非法")
+	}
+	if err := validateBackupDirectoryLocked(); err != nil {
+		return "", nil, err
+	}
+	target := filepath.Join(BackupDir, name)
+	if _, err := pathWithinRoot(BackupDir, target); err != nil {
+		return "", nil, err
+	}
+	info, err := os.Lstat(target)
+	if err != nil {
+		return "", nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, errors.New("备份目标不是普通文件或为符号链接")
+	}
+	return target, info, nil
+}
+
+func backupArchivePathLocked(name string) (string, error) {
+	target, _, err := backupArchiveFileLocked(name)
+	return target, err
+}
+
+// BackupArchivePath 返回经过文件名、边界和普通文件校验的备份路径。
+func BackupArchivePath(name string) (string, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	return backupArchivePathLocked(name)
+}
+
+// OpenBackupArchive 在同一临界区内校验并打开备份，返回的句柄不受后续路径替换影响。
+func OpenBackupArchive(name string) (*os.File, os.FileInfo, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	target, expected, err := backupArchiveFileLocked(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	file, err := os.Open(target)
+	if err != nil {
+		return nil, nil, err
+	}
+	actual, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, nil, err
+	}
+	if !actual.Mode().IsRegular() || !os.SameFile(expected, actual) {
+		_ = file.Close()
+		return nil, nil, errors.New("打开的备份文件与已校验目标不一致")
+	}
+	return file, actual, nil
+}
+
+func deleteBackupLocked(name string) error {
+	inUse, err := backupInUseLocked(name)
+	if err != nil {
+		return err
+	}
+	if inUse {
+		return fmt.Errorf("备份 %s 正被恢复事务使用，不能删除", name)
+	}
+	target, err := backupArchivePathLocked(name)
+	if err != nil {
+		return err
+	}
+	return os.Remove(target)
+}
+
+func DeleteBackup(name string) error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	return deleteBackupLocked(name)
+}
+
+func DeleteBackups(names []string) error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	var resultErr error
+	for _, name := range names {
+		if err := deleteBackupLocked(name); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("删除 %s: %w", name, err))
+		}
+	}
+	return resultErr
+}
+
+func fileSHA256(filename string) ([sha256.Size]byte, error) {
+	info, err := os.Lstat(filename)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return [sha256.Size]byte{}, errors.New("哈希目标不是普通文件或为符号链接")
+	}
+	file, err := os.Open(filename)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	defer func() { _ = file.Close() }()
+	hasher := sha256.New()
+	if _, err = io.Copy(hasher, file); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], hasher.Sum(nil))
+	return digest, nil
+}
+
+func ImportBackup(reader io.Reader) (*BackupArchiveInfo, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := ensureBackupDirectoryLocked(); err != nil {
+		return nil, err
+	}
+	tmp, err := os.CreateTemp(BackupDir, ".upload-*.part")
+	if err != nil {
+		return nil, err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	hash := sha256.New()
+	buffer := make([]byte, 4<<20)
+	var uploaded uint64
+	emptyReads := 0
+	for {
+		count, readErr := reader.Read(buffer)
+		if count > 0 {
+			emptyReads = 0
+			if uint64(count) > maxImportedBackupSize-uploaded {
+				_ = tmp.Close()
+				return nil, fmt.Errorf("上传备份超过 %d 字节限制", maxImportedBackupSize)
+			}
+			if err = ensureDiskSpace(BackupDir, uint64(count)); err != nil {
+				_ = tmp.Close()
+				return nil, err
+			}
+			if _, err = tmp.Write(buffer[:count]); err != nil {
+				_ = tmp.Close()
+				return nil, err
+			}
+			_, _ = hash.Write(buffer[:count])
+			uploaded += uint64(count)
+		} else if readErr == nil {
+			emptyReads++
+			if emptyReads >= 100 {
+				_ = tmp.Close()
+				return nil, io.ErrNoProgress
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			_ = tmp.Close()
+			return nil, readErr
+		}
+	}
+	if err = tmp.Sync(); err == nil {
+		err = tmp.Close()
+	} else {
+		_ = tmp.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	info, _, err := inspectBackupArchive(tmpName)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateBackupData(tmpName); err != nil {
+		return nil, fmt.Errorf("备份内容校验失败: %w", err)
+	}
+	var uploadedDigest [sha256.Size]byte
+	copy(uploadedDigest[:], hash.Sum(nil))
+	digest := hex.EncodeToString(uploadedDigest[:])[:8]
+	existing, _ := filepath.Glob(filepath.Join(BackupDir, "import_*_"+digest+".zip"))
+	for _, candidate := range existing {
+		candidateDigest, hashErr := fileSHA256(candidate)
+		if hashErr != nil || candidateDigest != uploadedDigest {
+			continue
+		}
+		item := InspectBackupArchive(candidate)
+		item.Reused = true
+		return item, nil
+	}
+	name := fmt.Sprintf("import_%s_%s.zip", time.Now().Format("060102_150405"), digest)
+	target := filepath.Join(BackupDir, name)
+	if err = renameRestorePath(tmpName, target); err != nil {
+		return nil, err
+	}
+	if err = syncDirectory(BackupDir); err != nil {
+		return nil, err
+	}
+	info.Name = name
+	return info, nil
+}
+
+func validateSafetyBackup(filename string, dm *DiceManager) error {
+	info, entries, err := inspectBackupArchive(filename)
+	if err != nil {
+		return err
+	}
+	if info.FormatVersion != backupManifestFormatVersion || info.DatabaseType != constant.SQLITE {
+		return errors.New("安全备份不是 SQLite v2 备份")
+	}
+	if err = validateBackupData(filename); err != nil {
+		return err
+	}
+	databaseFiles, err := managedSQLiteDatabaseFiles(dm, true)
+	if err != nil {
+		return err
+	}
+	required := []string{"data/dice.yaml"}
+	for _, d := range dm.Dice {
+		if d == nil || d.BaseConfig.Name == "" {
+			return errors.New("安全备份包含空骰子实例")
+		}
+		archiveName, pathErr := managedArchivePath(filepath.Join(d.BaseConfig.DataDir, "serve.yaml"))
+		if pathErr != nil {
+			return fmt.Errorf("安全备份实例配置路径不安全: %w", pathErr)
+		}
+		required = append(required, archiveName)
+	}
+	for _, databaseFile := range databaseFiles {
+		required = append(required, databaseFile.ArchivePath)
+	}
+	for _, filename := range required {
+		if _, ok := entries[filepath.ToSlash(filename)]; !ok {
+			return fmt.Errorf("安全备份缺少 %s", filename)
+		}
+	}
+	return nil
+}
+
+func directorySize(root string) (uint64, error) {
+	var total uint64
+	err := filepath.WalkDir(root, func(filename string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("目录包含符号链接: %s", filename)
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.Size() < 0 || math.MaxUint64-total < uint64(info.Size()) {
+			return errors.New("目录大小计算溢出")
+		}
+		total += uint64(info.Size())
+		return nil
+	})
+	return total, err
+}
+
+func readPendingRestore() (*restorePending, error) {
+	data, err := os.ReadFile(restorePendingPath())
+	if err != nil {
+		return nil, err
+	}
+	var pending restorePending
+	if err = json.Unmarshal(data, &pending); err != nil {
+		return nil, err
+	}
+	return &pending, nil
+}
+
+func readRestoreStatusAuth() (*restoreStatusAuth, error) {
+	data, err := os.ReadFile(restoreStatusAuthPath())
+	if err != nil {
+		return nil, err
+	}
+	var auth restoreStatusAuth
+	if err = json.Unmarshal(data, &auth); err != nil {
+		return nil, err
+	}
+	return &auth, nil
+}
+
+func rebuildMissingRestoreAuth(pending *restorePending) (*restoreStatusAuth, error) {
+	if pending.Phase != "scheduled" && pending.Phase != "prepared" {
+		return nil, fmt.Errorf("恢复授权缺失且 pending 处于不安全阶段 %q", pending.Phase)
+	}
+	if _, journalErr := os.Stat(restoreJournalPath()); journalErr == nil {
+		return nil, errors.New("恢复授权缺失但 journal 已存在，无法无歧义重建")
+	} else if !errors.Is(journalErr, os.ErrNotExist) {
+		return nil, journalErr
+	}
+	if _, _, err := inspectBackupArchive(filepath.Join(restoreDir(), restoreSourceName)); err != nil {
+		return nil, fmt.Errorf("恢复授权缺失且排队源文件无法确认: %w", err)
+	}
+	auth, err := newRestoreStatusAuth(pending.OperationID)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeJSONAtomic(restoreStatusAuthPath(), auth); err != nil {
+		return nil, err
+	}
+	pending.StatusTokenHash = auth.TokenHash
+	pending.ExpiresAt = auth.ExpiresAt
+	if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return nil, err
+	}
+	return auth, nil
+}
+
+func refreshRestoreStatusAuth(pending *restorePending, auth *restoreStatusAuth) (*restoreStatusAuth, error) {
+	if auth == nil || auth.OperationID == "" {
+		return nil, errors.New("恢复授权不完整")
+	}
+	now := time.Now().Unix()
+	if auth.ExpiresAt > now {
+		if !restoreStatusTokenMatches(auth.Token, auth.TokenHash) {
+			return nil, errors.New("恢复授权 token 与哈希不一致")
+		}
+		if pending != nil && (pending.ExpiresAt != auth.ExpiresAt ||
+			subtle.ConstantTimeCompare([]byte(strings.ToLower(pending.StatusTokenHash)), []byte(strings.ToLower(auth.TokenHash))) != 1) {
+			pending.StatusTokenHash = auth.TokenHash
+			pending.ExpiresAt = auth.ExpiresAt
+			if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+				return nil, fmt.Errorf("修复恢复任务授权元数据: %w", err)
+			}
+		}
+		return auth, nil
+	}
+
+	refreshed, err := newRestoreStatusAuth(auth.OperationID)
+	if err != nil {
+		return nil, err
+	}
+	if err = writeJSONAtomic(restoreStatusAuthPath(), refreshed); err != nil {
+		return nil, err
+	}
+	if pending != nil {
+		pending.StatusTokenHash = refreshed.TokenHash
+		pending.ExpiresAt = refreshed.ExpiresAt
+		if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+			return nil, err
+		}
+	}
+	return refreshed, nil
+}
+
+func safePendingRestoreForReuse(pending *restorePending) (bool, error) {
+	if pending.Phase != "scheduled" && pending.Phase != "prepared" {
+		return false, nil
+	}
+	journal, err := readRestoreJournal()
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if errors.Is(err, errEmptyRestoreJournal) {
+		if discardErr := discardEmptyRestoreJournal(); discardErr != nil {
+			return false, discardErr
+		}
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if journal.OperationID != pending.OperationID {
+		return false, errors.New("可重试任务的 pending/journal operationID 不一致")
+	}
+	return journal.State == "rolled_back", nil
+}
+
+func restoreStatusForPending(pending *restorePending) RestoreStatus {
+	status := RestoreStatus{
+		State:            "pending",
+		OperationID:      pending.OperationID,
+		SourceName:       pending.SourceName,
+		SafetyBackupName: pending.SafetyBackupName,
+		Message:          "恢复任务已重新确认",
+	}
+	if pending.Phase == "prepared" {
+		status.State = "quiescing"
+		status.Message = "恢复前安全备份已完成，等待关闭数据库"
+	}
+	return status
+}
+
+func restoreOperationFromPending(name, requestID string, pending *restorePending, status RestoreStatus) (*RestoreOperation, bool, error) {
+	if pending.OperationID != requestID {
+		auth, authErr := readRestoreStatusAuth()
+		if authErr == nil && auth.OperationID == requestID {
+			return nil, false, errors.New("恢复授权与当前 pending 指向不同 operationID")
+		}
+		return nil, false, nil
+	}
+	if pending.SourceName != name {
+		return nil, false, fmt.Errorf("requestId %q 已用于另一个备份 %q", requestID, pending.SourceName)
+	}
+	if status.OperationID != "" && status.OperationID != requestID {
+		return nil, false, errors.New("已有恢复任务的 pending/status operationID 不一致")
+	}
+	if pending.Phase == "prepared" {
+		if pending.SafetyBackupName == "" {
+			return nil, false, errors.New("prepared 恢复任务缺少安全备份名")
+		}
+		if _, err := backupArchivePathLocked(pending.SafetyBackupName); err != nil {
+			return nil, false, fmt.Errorf("prepared 恢复任务的安全备份无效: %w", err)
+		}
+	}
+	auth, authErr := readRestoreStatusAuth()
+	if errors.Is(authErr, os.ErrNotExist) {
+		auth, authErr = rebuildMissingRestoreAuth(pending)
+	}
+	if authErr != nil {
+		return nil, false, fmt.Errorf("读取或重建恢复授权失败: %w", authErr)
+	}
+	if auth.OperationID != requestID {
+		return nil, false, errors.New("同一 requestId 的恢复授权不完整或 operationID 不一致")
+	}
+	auth, authErr = refreshRestoreStatusAuth(pending, auth)
+	if authErr != nil {
+		return nil, false, fmt.Errorf("刷新恢复授权失败: %w", authErr)
+	}
+	resetStatus := status.OperationID == "" || status.State == "failed" || status.State == "rolled_back" || status.State == "degraded"
+	if resetStatus {
+		safe, safeErr := safePendingRestoreForReuse(pending)
+		if safeErr != nil {
+			return nil, false, fmt.Errorf("确认恢复任务可重试: %w", safeErr)
+		}
+		if !safe {
+			return nil, false, fmt.Errorf("恢复状态为 %q，但 pending 阶段 %q 不能安全重置", status.State, pending.Phase)
+		}
+		if err := setRestoreStatus(restoreStatusForPending(pending)); err != nil {
+			return nil, false, err
+		}
+	}
+	return &RestoreOperation{
+		OperationID: requestID, StatusToken: auth.Token, ExpiresAt: auth.ExpiresAt,
+		SafetyBackupName: pending.SafetyBackupName, Reused: true,
+	}, true, nil
+}
+
+func restoreOperationFromExisting(name, requestID string) (*RestoreOperation, bool, error) {
+	pending, pendingErr := readPendingRestore()
+	status := GetRestoreStatus()
+	if pendingErr == nil {
+		return restoreOperationFromPending(name, requestID, pending, status)
+	}
+	if !errors.Is(pendingErr, os.ErrNotExist) {
+		return nil, false, fmt.Errorf("读取已有恢复任务失败: %w", pendingErr)
+	}
+	auth, authErr := readRestoreStatusAuth()
+	if errors.Is(authErr, os.ErrNotExist) || (authErr == nil && auth.OperationID != requestID) {
+		return nil, false, nil
+	}
+	if authErr != nil {
+		return nil, false, fmt.Errorf("读取已有恢复授权失败: %w", authErr)
+	}
+	if status.OperationID != requestID || status.SourceName != name {
+		return nil, false, errors.New("恢复授权存在但 pending/status 无法确认同一 requestId 和备份源")
+	}
+	auth, authErr = refreshRestoreStatusAuth(nil, auth)
+	if authErr != nil {
+		return nil, false, fmt.Errorf("刷新终态恢复授权失败: %w", authErr)
+	}
+	return &RestoreOperation{
+		OperationID:      requestID,
+		StatusToken:      auth.Token,
+		ExpiresAt:        auth.ExpiresAt,
+		SafetyBackupName: status.SafetyBackupName,
+		Reused:           true,
+	}, true, nil
+}
+
+func releaseRetryablePendingRestore() error {
+	pending, err := readPendingRestore()
+	if errors.Is(err, os.ErrNotExist) {
+		if _, journalErr := os.Stat(restoreJournalPath()); journalErr == nil {
+			return errors.New("恢复日志存在但 pending 缺失，无法无歧义释放")
+		} else if !errors.Is(journalErr, os.ErrNotExist) {
+			return journalErr
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("读取已有恢复任务: %w", err)
+	}
+	status := GetRestoreStatus()
+	if pending.OperationID == "" || (status.OperationID != "" && status.OperationID != pending.OperationID) {
+		return errors.New("已有恢复任务的 pending/status operationID 不一致")
+	}
+	terminal := status.State == "failed" || status.State == "rolled_back" || status.State == "degraded" || status.State == "succeeded" ||
+		(status.State == "idle" && (pending.Phase == "scheduled" || pending.Phase == "prepared"))
+	if !terminal {
+		return errors.New("已有恢复任务正在等待执行")
+	}
+	legacyOldData := filepath.Join(restoreDir(), restoreLegacyOldDataName)
+	if _, err = os.Stat(legacyOldData); err == nil {
+		return fmt.Errorf("已有恢复任务保留了旧数据目录 %s，拒绝自动清除", legacyOldData)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("检查旧版恢复遗留目录: %w", err)
+	}
+	journal, journalErr := readRestoreJournal()
+	if journalErr == nil && journal.OperationID != pending.OperationID {
+		return errors.New("已有恢复任务的 pending/journal operationID 不一致")
+	}
+	if journalErr == nil {
+		switch journal.State {
+		case "rolled_back":
+			return nil
+		case "committed":
+			if status.State == "succeeded" {
+				return nil
+			}
+			return errors.New("已有恢复事务已经提交但尚未发布成功，不能覆盖")
+		default:
+			return fmt.Errorf("已有恢复事务尚未安全结束，当前状态为 %s", journal.State)
+		}
+	}
+	if errors.Is(journalErr, errEmptyRestoreJournal) {
+		if pending.Phase != "scheduled" && pending.Phase != "prepared" {
+			return fmt.Errorf("空恢复日志对应不安全阶段 %q", pending.Phase)
+		}
+		return discardEmptyRestoreJournal()
+	}
+	if !errors.Is(journalErr, os.ErrNotExist) {
+		return fmt.Errorf("检查已有恢复事务: %w", journalErr)
+	}
+	if pending.Phase != "scheduled" && pending.Phase != "prepared" {
+		return fmt.Errorf("无日志恢复任务处于不安全阶段 %q，不能覆盖", pending.Phase)
+	}
+	return nil
+}
+
+func validRestoreRequestID(requestID string) bool {
+	return requestID != "" && requestID == strings.TrimSpace(requestID) && len(requestID) <= maxRestoreRequestIDBytes && utf8.ValidString(requestID) &&
+		!strings.ContainsAny(requestID, "\r\n\x00")
+}
+
+func ensureRestoreVolumesMatch() error {
+	dataSpace, err := probeRestoreDiskSpace("data")
+	if err != nil {
+		return fmt.Errorf("检查 data 所在卷: %w", err)
+	}
+	restoreSpace, err := probeRestoreDiskSpace(BackupDir)
+	if err != nil {
+		return fmt.Errorf("检查 backups 所在卷: %w", err)
+	}
+	if dataSpace.Volume != restoreSpace.Volume {
+		return errors.New("data 与 backups 必须位于同一文件系统，才能保证恢复事务使用原子 rename")
+	}
+	return nil
+}
+
+func (dm *DiceManager) ScheduleRestore(name, requestID string) (*RestoreOperation, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if !validBackupFilename(name) {
+		return nil, errors.New("备份文件名非法")
+	}
+	if !validRestoreRequestID(requestID) {
+		return nil, errors.New("requestId 为空、过长或包含非法字符")
+	}
+	if err := validateRestoreStorageLocked(); err != nil {
+		return nil, err
+	}
+	if _, err := managedSQLiteDatabaseFiles(dm, true); err != nil {
+		return nil, err
+	}
+	if operation, reused, err := restoreOperationFromExisting(name, requestID); err != nil {
+		return nil, err
+	} else if reused {
+		return operation, nil
+	}
+	if err := releaseRetryablePendingRestore(); err != nil {
+		return nil, err
+	}
+	if err := restoreRemoveAll(restoreDir()); err != nil {
+		return nil, fmt.Errorf("清理旧恢复目录: %w", err)
+	}
+	if err := os.MkdirAll(restoreDir(), 0o700); err != nil {
+		return nil, err
+	}
+	if err := syncDirectory(BackupDir); err != nil {
+		return nil, err
+	}
+	if err := ensureRestoreVolumesMatch(); err != nil {
+		return nil, err
+	}
+	source, err := backupArchivePathLocked(name)
+	if err != nil {
+		return nil, err
+	}
+	info, entries, err := inspectBackupArchive(source)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Restorable {
+		if info.RestoreError != "" {
+			return nil, errors.New(info.RestoreError)
+		}
+		if info.DatabaseType != "" && info.DatabaseType != constant.SQLITE {
+			return nil, fmt.Errorf("备份数据库类型为 %q，不能恢复到 SQLite", info.DatabaseType)
+		}
+		return nil, errors.New("该备份包含不能由 Runtime 恢复的进程级文件")
+	}
+	if processPath := firstProcessOwnedRestorePath(entries); processPath != "" {
+		return nil, fmt.Errorf("备份包含进程级占用文件 %s，不能安全恢复", processPath)
+	}
+	if err = validateBackupData(source); err != nil {
+		return nil, fmt.Errorf("备份内容校验失败: %w", err)
+	}
+	dataSize, err := directorySize("data")
+	if err != nil {
+		return nil, err
+	}
+	required, overflow := addUint64Checked(dataSize, dataSize, info.UncompressedSize, uint64(info.FileSize))
+	if overflow {
+		return nil, errors.New("恢复所需磁盘空间计算溢出")
+	}
+	if err = ensureDiskSpace(BackupDir, required); err != nil {
+		return nil, err
+	}
+	sourceDigest, err := fileSHA256(source)
+	if err != nil {
+		return nil, err
+	}
+	queuedSource := filepath.Join(restoreDir(), restoreSourceName)
+	if err = copyFileSynced(source, queuedSource); err != nil {
+		return nil, err
+	}
+	queuedDigest, err := fileSHA256(queuedSource)
+	if err != nil || queuedDigest != sourceDigest {
+		return nil, errors.New("排队恢复源文件复制校验失败")
+	}
+	auth, err := newRestoreStatusAuth(requestID)
+	if err != nil {
+		return nil, err
+	}
+	pending := restorePending{
+		Phase:           "scheduled",
+		OperationID:     requestID,
+		StatusTokenHash: auth.TokenHash,
+		ExpiresAt:       auth.ExpiresAt,
+		SourceName:      name,
+	}
+	if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return nil, err
+	}
+	if err = writeJSONAtomic(restoreStatusAuthPath(), auth); err != nil {
+		return nil, err
+	}
+	if err = setRestoreStatus(RestoreStatus{State: "pending", OperationID: requestID, SourceName: name}); err != nil {
+		return nil, err
+	}
+	return &RestoreOperation{OperationID: requestID, StatusToken: auth.Token, ExpiresAt: auth.ExpiresAt}, nil
+}
+
+func addUint64Checked(values ...uint64) (uint64, bool) {
+	var result uint64
+	for _, value := range values {
+		if math.MaxUint64-result < value {
+			return 0, true
+		}
+		result += value
+	}
+	return result, false
+}
+
+func validateRestoreStatusTokenLocked(operationID, token string) bool {
+	if operationID == "" || token == "" {
+		return false
+	}
+	auth, err := readRestoreStatusAuth()
+	if err != nil || auth.OperationID != operationID || time.Now().Unix() > auth.ExpiresAt {
+		return false
+	}
+	return restoreStatusTokenMatches(token, auth.TokenHash)
+}
+
+func ValidateRestoreStatusToken(operationID, token string) bool {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if validateRestoreStorageLocked() != nil {
+		return false
+	}
+	return validateRestoreStatusTokenLocked(operationID, token)
+}
+
+// GetRestoreStatusAuthorized 在同一临界区内验证 bearer 并读取其绑定的恢复状态。
+func GetRestoreStatusAuthorized(operationID, token string) (RestoreStatus, bool) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if validateRestoreStorageLocked() != nil {
+		return RestoreStatus{}, false
+	}
+	if !validateRestoreStatusTokenLocked(operationID, token) {
+		return RestoreStatus{}, false
+	}
+	status := GetRestoreStatus()
+	if status.OperationID != operationID {
+		return RestoreStatus{}, false
+	}
+	return status, true
+}
+
+func PrepareScheduledRestore(dm *DiceManager) error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		return err
+	}
+	pending, err := readPendingRestore()
+	if err != nil {
+		return fmt.Errorf("读取恢复任务: %w", err)
+	}
+	if pending.OperationID == "" {
+		return errors.New("恢复任务缺少 operationID")
+	}
+	if _, err = managedSQLiteDatabaseFiles(dm, true); err != nil {
+		return err
+	}
+	if pending.Phase == "prepared" {
+		if pending.SafetyBackupName == "" {
+			return errors.New("prepared 恢复任务缺少安全备份名")
+		}
+		if err = validateSafetyBackup(filepath.Join(BackupDir, pending.SafetyBackupName), dm); err != nil {
+			return fmt.Errorf("复用安全备份失败: %w", err)
+		}
+		return setRestoreStatus(RestoreStatus{State: "quiescing", OperationID: pending.OperationID, SourceName: pending.SourceName, SafetyBackupName: pending.SafetyBackupName, Message: "恢复前安全备份已完成，等待关闭数据库"})
+	}
+	if pending.Phase != "scheduled" {
+		return fmt.Errorf("恢复任务不能从阶段 %q 准备", pending.Phase)
+	}
+	status := GetRestoreStatus()
+	if status.OperationID != "" && status.OperationID != pending.OperationID {
+		return errors.New("pending 与 status 的 operationID 不一致")
+	}
+	source := filepath.Join(restoreDir(), restoreSourceName)
+	info, _, err := inspectBackupArchive(source)
+	if err != nil {
+		return fmt.Errorf("检查排队恢复源: %w", err)
+	}
+	if err = validateBackupData(source); err != nil {
+		return fmt.Errorf("校验排队恢复源: %w", err)
+	}
+	dataSize, err := directorySize("data")
+	if err != nil {
+		return err
+	}
+	required, overflow := addUint64Checked(dataSize, dataSize, info.UncompressedSize, uint64(info.FileSize))
+	if overflow {
+		return errors.New("恢复所需磁盘空间计算溢出")
+	}
+	if err = ensureDiskSpace(BackupDir, required); err != nil {
+		return err
+	}
+	logger.M().Infow("[备份恢复] 正在创建恢复前安全备份", "operationId", pending.OperationID, "source", pending.SourceName)
+	safetyPath, err := dm.backupStrict(BackupSelectionAll)
+	if err != nil {
+		return fmt.Errorf("创建恢复前安全备份失败: %w", err)
+	}
+	if err = validateSafetyBackup(safetyPath, dm); err != nil {
+		return fmt.Errorf("恢复前安全备份不完整: %w", err)
+	}
+	pending.SafetyBackupName = filepath.Base(safetyPath)
+	pending.Phase = "prepared"
+	if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return err
+	}
+	if err = setRestoreStatus(RestoreStatus{
+		State:            "quiescing",
+		OperationID:      pending.OperationID,
+		SourceName:       pending.SourceName,
+		SafetyBackupName: pending.SafetyBackupName,
+		Message:          "恢复前安全备份已创建并校验",
+	}); err != nil {
+		return err
+	}
+	logger.M().Infow("[备份恢复] 恢复前安全备份已创建并校验", "operationId", pending.OperationID, "safetyBackup", pending.SafetyBackupName)
+	return nil
+}
+
+func isProcessOwnedRestorePath(filename string) bool {
+	lower := strings.ToLower(filepath.ToSlash(filename))
+	if lower == "data/main.log" || lower == "data/panic.log" {
+		return true
+	}
+	base := path.Base(lower)
+	return strings.HasSuffix(base, ".lock") || base == "sealdice-lock.lock"
+}
+
+func firstProcessOwnedRestorePath(entries map[string]struct{}) string {
+	paths := make([]string, 0)
+	for filename := range entries {
+		if isProcessOwnedRestorePath(filename) {
+			paths = append(paths, filename)
+		}
+	}
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[0]
+}
+
+func extractBackupTo(source, destination string) error {
+	reader, err := zip.OpenReader(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+	for _, item := range reader.File {
+		clean, cleanErr := normalizeBackupEntryName(item.Name, item.FileInfo().IsDir())
+		if cleanErr != nil {
+			return cleanErr
+		}
+		if clean == "backup_info.json" || clean == "data" {
+			continue
+		}
+		if isProcessOwnedRestorePath(clean) {
+			return fmt.Errorf("不能恢复进程级占用文件 %s", clean)
+		}
+		target := filepath.Join(destination, filepath.FromSlash(clean))
+		if _, err = pathWithinRoot(destination, target); err != nil {
+			return err
+		}
+		if item.FileInfo().IsDir() {
+			if err = os.MkdirAll(target, 0o700); err != nil {
+				return err
+			}
+			if err = ensureNoLinkedPath(destination, target, false); err != nil {
+				return err
+			}
+			continue
+		}
+		if err = os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return err
+		}
+		if err = ensureNoLinkedPath(destination, filepath.Dir(target), false); err != nil {
+			return err
+		}
+		rc, openErr := item.Open()
+		if openErr != nil {
+			return openErr
+		}
+		dst, createErr := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
+		if createErr != nil {
+			_ = rc.Close()
+			return createErr
+		}
+		written, copyErr := io.Copy(dst, rc)
+		if copyErr == nil {
+			copyErr = dst.Sync()
+		}
+		closeDstErr := dst.Close()
+		closeSrcErr := rc.Close()
+		if copyErr != nil || closeDstErr != nil || closeSrcErr != nil || uint64(written) != item.UncompressedSize64 {
+			return fmt.Errorf("解压 %s 失败或大小不匹配", item.Name)
+		}
+	}
+	return nil
+}
+
+func appendJournalRecordFile(file *os.File, record restoreJournalRecord) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Size() < 0 || int64(len(data)) > maxRestoreJournalSize-info.Size() {
+		return errors.New("恢复日志将超过大小限制")
+	}
+	written, err := file.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return file.Sync()
+}
+
+func estimateRestoreJournalMaximum(journal *restoreJournal) (uint64, bool) {
+	estimate := uint64(1024 + len(journal.OperationID)*12)
+	recordSize := uint64(256 + len(journal.OperationID)*6)
+	for _, entry := range journal.Entries {
+		pathBytes, overflow := addUint64Checked(uint64(len(entry.Target)), uint64(len(entry.Rollback)), uint64(len(entry.Staged)))
+		if overflow || pathBytes > (math.MaxUint64-512)/6 {
+			return 0, true
+		}
+		entrySize := uint64(512) + pathBytes*6
+		records := uint64(4) // backup intent/done and conservative state overhead.
+		if entry.Staged != "" {
+			records += 4 // install and remove intent/done.
+		} else {
+			records += 2 // rollback-only cleanup intent/done.
+		}
+		if entry.HadOriginal {
+			records += 2 // restore-original intent/done.
+		}
+		recordBytes, recordOverflow := addUint64Checked(entrySize, records*recordSize)
+		if recordOverflow || math.MaxUint64-estimate < recordBytes {
+			return 0, true
+		}
+		estimate += recordBytes
+	}
+	return estimate, false
+}
+
+func appendRestoreJournalRecord(record restoreJournalRecord) error {
+	file, err := os.OpenFile(restoreJournalPath(), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	writeErr := appendJournalRecordFile(file, record)
+	closeErr := file.Close()
+	return errors.Join(writeErr, closeErr)
+}
+
+func createRestoreJournal(journal *restoreJournal) error {
+	if journal == nil || journal.OperationID == "" {
+		return errors.New("不能创建缺少 operationID 的恢复日志")
+	}
+	if journal.State == "" {
+		journal.State = "planned"
+	}
+	if journal.State != "planned" {
+		return fmt.Errorf("不能从状态 %q 创建恢复日志", journal.State)
+	}
+	estimatedSize, overflow := estimateRestoreJournalMaximum(journal)
+	if overflow || estimatedSize > uint64(maxRestoreJournalSize) {
+		return fmt.Errorf("恢复日志最坏情况将超过 %d 字节限制", maxRestoreJournalSize)
+	}
+	file, err := os.OpenFile(restoreJournalPath(), os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	record := restoreJournalRecord{OperationID: journal.OperationID, Type: "begin", Entries: journal.Entries}
+	writeErr := appendJournalRecordFile(file, record)
+	closeErr := file.Close()
+	if err = errors.Join(writeErr, closeErr); err != nil {
+		return err
+	}
+	if err = syncDirectory(filepath.Dir(restoreJournalPath())); err != nil {
+		return err
+	}
+	return appendJournalState(journal, "applying")
+}
+
+func applyJournalRecordStep(entry *restoreJournalEntry, record restoreJournalRecord) error {
+	if record.Phase != "intent" && record.Phase != "done" {
+		return fmt.Errorf("非法日志阶段 %q", record.Phase)
+	}
+	intent := record.Phase == "intent"
+	switch record.Step {
+	case "backup-original":
+		if intent {
+			entry.backupIntent = true
+			entry.State = "backing_up"
+		} else {
+			if !entry.backupIntent {
+				return errors.New("backup-original done 缺少 intent")
+			}
+			entry.backupDone = true
+			entry.State = "backed_up"
+		}
+	case "install-staged":
+		if intent {
+			if !entry.backupDone {
+				return errors.New("install-staged intent 早于 backup-original done")
+			}
+			entry.installIntent = true
+			entry.State = "installing"
+		} else {
+			if !entry.installIntent {
+				return errors.New("install-staged done 缺少 intent")
+			}
+			entry.installDone = true
+			entry.State = "applied"
+		}
+	case "remove-installed":
+		if intent {
+			entry.removeIntent = true
+		} else {
+			if !entry.removeIntent {
+				return errors.New("remove-installed done 缺少 intent")
+			}
+			entry.removeDone = true
+		}
+	case "restore-original":
+		if intent {
+			entry.restoreIntent = true
+		} else {
+			if !entry.restoreIntent {
+				return errors.New("restore-original done 缺少 intent")
+			}
+			entry.restoreDone = true
+			entry.State = "rolled_back"
+		}
+	default:
+		return fmt.Errorf("非法日志步骤 %q", record.Step)
+	}
+	return nil
+}
+
+func validJournalStateTransition(current, next string) bool {
+	switch current {
+	case "planned":
+		return next == "applying" || next == "rolling_back"
+	case "applying":
+		return next == "applied" || next == "rolling_back"
+	case "applied":
+		return next == "committed" || next == "rolling_back"
+	case "rolling_back":
+		return next == "rolled_back" || next == "rollback_failed"
+	case "rollback_failed":
+		return next == "rolling_back"
+	default:
+		return false
+	}
+}
+
+func truncateTornRestoreJournal(expected os.FileInfo, size int64) error {
+	file, err := os.OpenFile(restoreJournalPath(), os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	actual, statErr := file.Stat()
+	if statErr != nil || !os.SameFile(expected, actual) {
+		_ = file.Close()
+		if statErr != nil {
+			return statErr
+		}
+		return errors.New("截断恢复日志时目标文件已变化")
+	}
+	truncateErr := file.Truncate(size)
+	var syncErr error
+	if truncateErr == nil {
+		syncErr = file.Sync()
+	}
+	closeErr := file.Close()
+	return errors.Join(truncateErr, syncErr, closeErr)
+}
+
+func readRestoreJournal() (*restoreJournal, error) {
+	info, err := os.Lstat(restoreJournalPath())
+	if errors.Is(err, os.ErrNotExist) {
+		if _, legacyErr := os.Stat(restoreLegacyJournalPath()); legacyErr == nil {
+			return nil, errors.New("检测到旧版可覆写恢复日志 journal.json，无法无歧义自动恢复")
+		} else if !errors.Is(legacyErr, os.ErrNotExist) {
+			return nil, legacyErr
+		}
+		return nil, err
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.New("恢复日志不是普通文件或为符号链接")
+	}
+	if info.Size() < 0 || info.Size() > maxRestoreJournalSize {
+		return nil, errors.New("恢复日志超过大小限制")
+	}
+	file, err := os.Open(restoreJournalPath())
+	if err != nil {
+		return nil, err
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, maxRestoreJournalSize+1))
+	closeErr := file.Close()
+	if err = errors.Join(readErr, closeErr); err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxRestoreJournalSize {
+		return nil, errors.New("恢复日志超过大小限制")
+	}
+	var journal *restoreJournal
+	lineNumber := 0
+	position := 0
+	truncatedTail := false
+	for position < len(data) {
+		lineNumber++
+		relativeEnd := bytes.IndexByte(data[position:], '\n')
+		if relativeEnd < 0 {
+			if err = truncateTornRestoreJournal(info, int64(position)); err != nil {
+				return nil, fmt.Errorf("截断恢复日志残片: %w", err)
+			}
+			truncatedTail = true
+			break
+		}
+		line := data[position : position+relativeEnd]
+		position += relativeEnd + 1
+		if len(line) == 0 {
+			continue
+		}
+		var record restoreJournalRecord
+		if err = json.Unmarshal(line, &record); err != nil {
+			return nil, fmt.Errorf("解析恢复日志第 %d 行: %w", lineNumber, err)
+		}
+		if record.OperationID == "" {
+			return nil, fmt.Errorf("恢复日志第 %d 行缺少 operationID", lineNumber)
+		}
+		if journal == nil {
+			if record.Type != "begin" || len(record.Entries) == 0 {
+				return nil, errors.New("恢复日志缺少有效 begin 记录")
+			}
+			journal = &restoreJournal{OperationID: record.OperationID, State: "planned", Entries: record.Entries}
+			continue
+		}
+		if record.OperationID != journal.OperationID {
+			return nil, errors.New("恢复日志包含多个 operationID")
+		}
+		switch record.Type {
+		case "state":
+			if !validJournalStateTransition(journal.State, record.State) {
+				return nil, fmt.Errorf("恢复日志包含非法状态转换 %s -> %s", journal.State, record.State)
+			}
+			journal.State = record.State
+		case "step":
+			if journal.State == "committed" || journal.State == "rolled_back" {
+				return nil, fmt.Errorf("恢复日志在终态 %s 后仍包含文件步骤", journal.State)
+			}
+			if record.Index < 0 || record.Index >= len(journal.Entries) {
+				return nil, errors.New("恢复日志包含越界条目索引")
+			}
+			if err = applyJournalRecordStep(&journal.Entries[record.Index], record); err != nil {
+				return nil, fmt.Errorf("恢复日志第 %d 行: %w", lineNumber, err)
+			}
+		default:
+			return nil, fmt.Errorf("恢复日志包含非法记录类型 %q", record.Type)
+		}
+	}
+	if journal == nil {
+		if len(data) == 0 || truncatedTail {
+			return nil, errEmptyRestoreJournal
+		}
+		return nil, errors.New("恢复日志为空或只包含不完整记录")
+	}
+	return journal, nil
+}
+
+func discardEmptyRestoreJournal() error {
+	if err := restoreRemove(restoreJournalPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return syncDirectory(restoreDir())
+}
+
+func appendJournalState(journal *restoreJournal, state string) error {
+	if !validJournalStateTransition(journal.State, state) {
+		return fmt.Errorf("非法恢复日志状态转换 %s -> %s", journal.State, state)
+	}
+	record := restoreJournalRecord{OperationID: journal.OperationID, Type: "state", State: state}
+	if err := appendRestoreJournalRecord(record); err != nil {
+		return err
+	}
+	journal.State = state
+	return nil
+}
+
+func appendJournalStep(journal *restoreJournal, index int, step, phase string) error {
+	if index < 0 || index >= len(journal.Entries) {
+		return errors.New("恢复日志条目索引越界")
+	}
+	record := restoreJournalRecord{OperationID: journal.OperationID, Type: "step", Index: index, Step: step, Phase: phase}
+	if err := appendRestoreJournalRecord(record); err != nil {
+		return err
+	}
+	return applyJournalRecordStep(&journal.Entries[index], record)
+}
+
+func ensureRestoreTargetSafe(target string) error {
+	root, err := managedDataRoot()
+	if err != nil {
+		return err
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+	if _, err = pathWithinRoot(root, targetAbs); err != nil {
+		return fmt.Errorf("恢复目标不在 data 目录内: %s", target)
+	}
+	if err = ensureNoLinkedPath(root, targetAbs, true); err != nil {
+		return fmt.Errorf("恢复目标不安全 %s: %w", target, err)
+	}
+	if info, statErr := os.Lstat(targetAbs); statErr == nil && info.IsDir() {
+		return fmt.Errorf("恢复目标是目录: %s", target)
+	} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
+	return nil
+}
+
+func ensureRestorePrivatePath(root, target string) error {
+	if _, err := pathWithinRoot(root, target); err != nil {
+		return err
+	}
+	return ensureNoLinkedPath(root, target, true)
+}
+
+func buildRestoreJournal(operationID, staging string) (*restoreJournal, error) {
+	if operationID == "" {
+		return nil, errors.New("恢复事务缺少 operationID")
+	}
+	journal := &restoreJournal{OperationID: operationID, State: "planned"}
+	targets := map[string]struct{}{}
+	stagingData := filepath.Join(staging, "data")
+	err := filepath.WalkDir(stagingData, func(stagedPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("暂存目录包含符号链接: %s", stagedPath)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("暂存目录包含特殊文件: %s", stagedPath)
+		}
+		relative, relErr := filepath.Rel(staging, stagedPath)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Clean(relative)
+		if isProcessOwnedRestorePath(filepath.ToSlash(target)) {
+			return fmt.Errorf("不能恢复进程级占用文件 %s", target)
+		}
+		if targetErr := ensureRestoreTargetSafe(target); targetErr != nil {
+			return targetErr
+		}
+		rollback := filepath.Join(restoreDir(), restoreRollbackName, relative)
+		if rollbackErr := ensureRestorePrivatePath(filepath.Join(restoreDir(), restoreRollbackName), rollback); rollbackErr != nil {
+			return rollbackErr
+		}
+		_, statErr := os.Lstat(target)
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return statErr
+		}
+		targets[strings.ToLower(filepath.ToSlash(target))] = struct{}{}
+		journal.Entries = append(journal.Entries, restoreJournalEntry{
+			Target:      target,
+			Rollback:    rollback,
+			Staged:      stagedPath,
+			HadOriginal: statErr == nil,
+			State:       "planned",
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	entries := append([]restoreJournalEntry(nil), journal.Entries...)
+	for _, entry := range entries {
+		if !strings.HasSuffix(strings.ToLower(entry.Target), ".db") {
+			continue
+		}
+		for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+			sidecar := entry.Target + suffix
+			if _, exists := targets[strings.ToLower(filepath.ToSlash(sidecar))]; exists {
+				continue
+			}
+			if err = ensureRestoreTargetSafe(sidecar); err != nil {
+				return nil, err
+			}
+			hadOriginal := false
+			if info, statErr := os.Lstat(sidecar); statErr == nil {
+				if !info.Mode().IsRegular() {
+					return nil, fmt.Errorf("sqlite sidecar 不是普通文件: %s", sidecar)
+				}
+				hadOriginal = true
+			} else if !errors.Is(statErr, os.ErrNotExist) {
+				return nil, statErr
+			}
+			journal.Entries = append(journal.Entries, restoreJournalEntry{
+				Target:      sidecar,
+				Rollback:    filepath.Join(restoreDir(), restoreRollbackName, sidecar),
+				HadOriginal: hadOriginal,
+				State:       "planned",
+			})
+		}
+	}
+	sort.Slice(journal.Entries, func(i, j int) bool {
+		return strings.ToLower(filepath.ToSlash(journal.Entries[i].Target)) < strings.ToLower(filepath.ToSlash(journal.Entries[j].Target))
+	})
+	return journal, nil
+}
+
+func pathExists(filename string) (bool, error) {
+	_, err := os.Lstat(filename)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func applyRestoreJournal(journal *restoreJournal) (resultErr error) {
+	defer func() {
+		if resultErr != nil {
+			if reloaded, reloadErr := readRestoreJournal(); reloadErr == nil {
+				if reloaded.OperationID != journal.OperationID {
+					resultErr = errors.Join(resultErr, errors.New("失败后的 journal operationID 发生变化"))
+					return
+				}
+				journal = reloaded
+			} else {
+				resultErr = errors.Join(resultErr, fmt.Errorf("失败后重读 journal: %w", reloadErr))
+			}
+			resultErr = errors.Join(resultErr, rollbackRestoreJournal(journal))
+		}
+	}()
+	for index := range journal.Entries {
+		entry := &journal.Entries[index]
+		if err := ensureRestoreTargetSafe(entry.Target); err != nil {
+			return err
+		}
+		if !entry.backupIntent {
+			if err := appendJournalStep(journal, index, "backup-original", "intent"); err != nil {
+				return err
+			}
+		}
+		if !entry.backupDone {
+			if entry.HadOriginal {
+				if err := os.MkdirAll(filepath.Dir(entry.Rollback), 0o700); err != nil {
+					return err
+				}
+				if err := ensureRestorePrivatePath(filepath.Join(restoreDir(), restoreRollbackName), entry.Rollback); err != nil {
+					return err
+				}
+				if err := restoreRename(entry.Target, entry.Rollback); err != nil {
+					return fmt.Errorf("暂存原文件 %s: %w", entry.Target, err)
+				}
+				if err := restoreSyncMutationParents("data", entry.Target, restoreDir(), entry.Rollback); err != nil {
+					return err
+				}
+			}
+			if err := appendJournalStep(journal, index, "backup-original", "done"); err != nil {
+				return err
+			}
+		}
+		if entry.Staged == "" {
+			entry.State = "applied"
+			continue
+		}
+		if !entry.installIntent {
+			if err := appendJournalStep(journal, index, "install-staged", "intent"); err != nil {
+				return err
+			}
+		}
+		if !entry.installDone {
+			if err := os.MkdirAll(filepath.Dir(entry.Target), 0o700); err != nil {
+				return err
+			}
+			if err := restoreRename(entry.Staged, entry.Target); err != nil {
+				return fmt.Errorf("应用恢复文件 %s: %w", entry.Target, err)
+			}
+			if err := restoreSyncMutationParents(restoreDir(), entry.Staged, "data", entry.Target); err != nil {
+				return err
+			}
+			if err := appendJournalStep(journal, index, "install-staged", "done"); err != nil {
+				return err
+			}
+		}
+	}
+	return appendJournalState(journal, "applied")
+}
+
+func rollbackRestoreOnlyJournalEntry(journal *restoreJournal, index int, entry *restoreJournalEntry) error {
+	if entry.restoreDone {
+		entry.State = "rolled_back"
+		return nil
+	}
+	backedUp := entry.backupDone
+	if entry.HadOriginal && entry.backupIntent && !entry.backupDone {
+		rollbackExists, rollbackErr := pathExists(entry.Rollback)
+		targetExists, targetErr := pathExists(entry.Target)
+		if rollbackErr != nil || targetErr != nil {
+			return errors.Join(rollbackErr, targetErr)
+		}
+		switch {
+		case rollbackExists && !targetExists:
+			if err := restoreSyncMutationParents("data", entry.Target, restoreDir(), entry.Rollback); err != nil {
+				return err
+			}
+			backedUp = true
+		case !rollbackExists && targetExists:
+			backedUp = false
+		default:
+			return fmt.Errorf("无法判断原文件 %s 是否已移入 rollback", entry.Target)
+		}
+	}
+	if !backedUp {
+		entry.State = "rolled_back"
+		return nil
+	}
+	if entry.restoreIntent && !entry.restoreDone {
+		rollbackExists, rollbackErr := pathExists(entry.Rollback)
+		targetExists, targetErr := pathExists(entry.Target)
+		if rollbackErr != nil || targetErr != nil {
+			return errors.Join(rollbackErr, targetErr)
+		}
+		if !rollbackExists && targetExists {
+			if err := restoreSyncMutationParents(restoreDir(), entry.Rollback, "data", entry.Target); err != nil {
+				return err
+			}
+			return appendJournalStep(journal, index, "restore-original", "done")
+		}
+		if !rollbackExists || targetExists {
+			return fmt.Errorf("无法判断原文件 %s 是否已恢复", entry.Target)
+		}
+	}
+
+	if !entry.removeIntent {
+		if err := appendJournalStep(journal, index, "remove-installed", "intent"); err != nil {
+			return err
+		}
+	}
+	if err := restoreRemove(entry.Target); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("移除恢复期间生成的 SQLite sidecar %s: %w", entry.Target, err)
+	}
+	if err := restoreSyncMutationParents("data", entry.Target); err != nil {
+		return err
+	}
+	if !entry.removeDone {
+		if err := appendJournalStep(journal, index, "remove-installed", "done"); err != nil {
+			return err
+		}
+	}
+	if !entry.HadOriginal {
+		entry.State = "rolled_back"
+		return nil
+	}
+
+	if !entry.restoreIntent {
+		if err := appendJournalStep(journal, index, "restore-original", "intent"); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(entry.Target), 0o700); err != nil {
+		return err
+	}
+	if err := restoreRename(entry.Rollback, entry.Target); err != nil {
+		return fmt.Errorf("恢复原文件 %s: %w", entry.Target, err)
+	}
+	if err := restoreSyncMutationParents(restoreDir(), entry.Rollback, "data", entry.Target); err != nil {
+		return err
+	}
+	return appendJournalStep(journal, index, "restore-original", "done")
+}
+
+func rollbackRestoreJournal(journal *restoreJournal) error {
+	if journal == nil || journal.OperationID == "" {
+		return errors.New("无法回滚缺少 operationID 的恢复日志")
+	}
+	if journal.State == "committed" {
+		return errors.New("恢复事务已经提交，拒绝回滚")
+	}
+	if journal.State != "rolling_back" {
+		if err := appendJournalState(journal, "rolling_back"); err != nil {
+			return err
+		}
+	}
+	var rollbackErr error
+	for index := len(journal.Entries) - 1; index >= 0; index-- {
+		entry := &journal.Entries[index]
+		if err := ensureRestoreTargetSafe(entry.Target); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+			continue
+		}
+		if err := ensureRestorePrivatePath(filepath.Join(restoreDir(), restoreRollbackName), entry.Rollback); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+			continue
+		}
+		if entry.Staged == "" {
+			if err := rollbackRestoreOnlyJournalEntry(journal, index, entry); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+			}
+			continue
+		}
+		if entry.restoreDone {
+			entry.State = "rolled_back"
+			continue
+		}
+		if entry.restoreIntent && !entry.restoreDone {
+			rollbackExists, rollbackStatErr := pathExists(entry.Rollback)
+			targetExists, targetStatErr := pathExists(entry.Target)
+			if rollbackStatErr != nil || targetStatErr != nil {
+				rollbackErr = errors.Join(rollbackErr, rollbackStatErr, targetStatErr)
+				continue
+			}
+			if !rollbackExists && targetExists {
+				if err := restoreSyncMutationParents(restoreDir(), entry.Rollback, "data", entry.Target); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+					continue
+				}
+				if err := appendJournalStep(journal, index, "restore-original", "done"); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+				}
+				continue
+			}
+			if !rollbackExists || targetExists {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("无法判断原文件 %s 是否已恢复", entry.Target))
+				continue
+			}
+		}
+
+		installed := entry.installDone
+		if entry.Staged != "" && entry.installIntent && !entry.installDone && !entry.removeDone {
+			stagedExists, stagedErr := pathExists(entry.Staged)
+			targetExists, targetErr := pathExists(entry.Target)
+			if stagedErr != nil || targetErr != nil {
+				rollbackErr = errors.Join(rollbackErr, stagedErr, targetErr)
+				continue
+			}
+			switch {
+			case !stagedExists && targetExists:
+				if err := restoreSyncMutationParents(restoreDir(), entry.Staged, "data", entry.Target); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+					continue
+				}
+				installed = true
+			case !stagedExists && !targetExists && entry.removeIntent:
+				installed = false
+			case stagedExists && !targetExists:
+				installed = false
+			default:
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("无法判断 staged 文件 %s 是否已安装", entry.Target))
+				continue
+			}
+		}
+		if entry.removeDone {
+			if err := restoreRemove(entry.Target); err != nil && !errors.Is(err, os.ErrNotExist) {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("再次移除已恢复文件 %s: %w", entry.Target, err))
+				continue
+			}
+			if err := restoreSyncMutationParents("data", entry.Target); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+				continue
+			}
+			installed = false
+		} else if entry.removeIntent && !installed {
+			if err := restoreSyncMutationParents("data", entry.Target); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+				continue
+			}
+			if err := appendJournalStep(journal, index, "remove-installed", "done"); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+				continue
+			}
+		}
+		if installed && !entry.removeDone {
+			if !entry.removeIntent {
+				if err := appendJournalStep(journal, index, "remove-installed", "intent"); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+					continue
+				}
+			}
+			if err := restoreRemove(entry.Target); err != nil && !errors.Is(err, os.ErrNotExist) {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("移除已恢复文件 %s: %w", entry.Target, err))
+				continue
+			}
+			if err := restoreSyncMutationParents("data", entry.Target); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+				continue
+			}
+			if err := appendJournalStep(journal, index, "remove-installed", "done"); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+				continue
+			}
+		}
+
+		if !entry.HadOriginal || entry.restoreDone {
+			entry.State = "rolled_back"
+			continue
+		}
+		backedUp := entry.backupDone
+		if entry.backupIntent && !entry.backupDone {
+			rollbackExists, rollbackStatErr := pathExists(entry.Rollback)
+			targetExists, targetStatErr := pathExists(entry.Target)
+			if rollbackStatErr != nil || targetStatErr != nil {
+				rollbackErr = errors.Join(rollbackErr, rollbackStatErr, targetStatErr)
+				continue
+			}
+			switch {
+			case rollbackExists:
+				if err := restoreSyncMutationParents("data", entry.Target, restoreDir(), entry.Rollback); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+					continue
+				}
+				backedUp = true
+			case targetExists && !installed:
+				backedUp = false
+			default:
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("无法判断原文件 %s 是否已移入 rollback", entry.Target))
+				continue
+			}
+		}
+		if !backedUp {
+			entry.State = "rolled_back"
+			continue
+		}
+		if entry.restoreIntent && !entry.restoreDone {
+			rollbackExists, rollbackStatErr := pathExists(entry.Rollback)
+			targetExists, targetStatErr := pathExists(entry.Target)
+			if rollbackStatErr != nil || targetStatErr != nil {
+				rollbackErr = errors.Join(rollbackErr, rollbackStatErr, targetStatErr)
+				continue
+			}
+			if !rollbackExists && targetExists {
+				if err := restoreSyncMutationParents(restoreDir(), entry.Rollback, "data", entry.Target); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+					continue
+				}
+				if err := appendJournalStep(journal, index, "restore-original", "done"); err != nil {
+					rollbackErr = errors.Join(rollbackErr, err)
+				}
+				continue
+			}
+			if !rollbackExists || targetExists {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("无法判断原文件 %s 是否已恢复", entry.Target))
+				continue
+			}
+		}
+		if !entry.restoreIntent {
+			if err := appendJournalStep(journal, index, "restore-original", "intent"); err != nil {
+				rollbackErr = errors.Join(rollbackErr, err)
+				continue
+			}
+		}
+		if err := os.MkdirAll(filepath.Dir(entry.Target), 0o700); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+			continue
+		}
+		if err := restoreRename(entry.Rollback, entry.Target); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("恢复原文件 %s: %w", entry.Target, err))
+			continue
+		}
+		if err := restoreSyncMutationParents(restoreDir(), entry.Rollback, "data", entry.Target); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+			continue
+		}
+		if err := appendJournalStep(journal, index, "restore-original", "done"); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+		}
+	}
+	if rollbackErr != nil {
+		stateErr := appendJournalState(journal, "rollback_failed")
+		return errors.Join(rollbackErr, stateErr)
+	}
+	return appendJournalState(journal, "rolled_back")
+}
+
+func resetRolledBackPending() error {
+	pending, err := readPendingRestore()
+	if errors.Is(err, os.ErrNotExist) {
+		return errors.New("恢复已回滚，但 pending 缺失，无法确认 operationID")
+	}
+	if err != nil {
+		return fmt.Errorf("读取已回滚恢复任务: %w", err)
+	}
+	if pending.OperationID == "" {
+		return errors.New("已回滚恢复任务缺少 operationID")
+	}
+	if pending.SafetyBackupName == "" {
+		pending.Phase = "scheduled"
+	} else {
+		pending.Phase = "prepared"
+	}
+	if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return fmt.Errorf("重置已回滚恢复任务: %w", err)
+	}
+	return setRestoreStatus(RestoreStatus{
+		State:            "rolled_back",
+		OperationID:      pending.OperationID,
+		SourceName:       pending.SourceName,
+		SafetyBackupName: pending.SafetyBackupName,
+		Message:          "检测到未提交恢复，原数据已回滚；可使用同一 requestId 重试",
+	})
+}
+
+func cleanupCommittedArtifacts(removeMetadata bool) error {
+	var cleanupErr error
+	for _, directory := range []string{restoreRollbackName, restoreStagingName} {
+		if err := restoreRemoveAll(filepath.Join(restoreDir(), directory)); err != nil {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("清理 %s: %w", directory, err))
+		}
+	}
+	if err := restoreRemove(filepath.Join(restoreDir(), restoreSourceName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("清理恢复源文件: %w", err))
+	}
+	if cleanupErr == nil {
+		cleanupErr = syncDirectory(restoreDir())
+	}
+	if !removeMetadata || cleanupErr != nil {
+		return cleanupErr
+	}
+	if err := restoreRemove(restorePendingPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupErr = fmt.Errorf("清理恢复任务: %w", err)
+	}
+	if cleanupErr == nil {
+		cleanupErr = syncDirectory(restoreDir())
+	}
+	if cleanupErr == nil {
+		if err := restoreRemove(restoreJournalPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErr = fmt.Errorf("清理恢复日志: %w", err)
+		}
+	}
+	if cleanupErr == nil {
+		cleanupErr = syncDirectory(restoreDir())
+	}
+	return cleanupErr
+}
+
+func recoverInterruptedRestore() error {
+	journal, journalErr := readRestoreJournal()
+	journalEmpty := errors.Is(journalErr, errEmptyRestoreJournal)
+	if errors.Is(journalErr, os.ErrNotExist) || journalEmpty {
+		pending, pendingErr := readPendingRestore()
+		if errors.Is(pendingErr, os.ErrNotExist) {
+			return nil
+		}
+		if pendingErr != nil {
+			return fmt.Errorf("读取无日志恢复任务: %w", pendingErr)
+		}
+		if pending.OperationID == "" {
+			return errors.New("无日志恢复任务缺少 operationID")
+		}
+		status := GetRestoreStatus()
+		if status.OperationID != "" && status.OperationID != pending.OperationID {
+			return errors.New("无日志恢复任务的 pending/status operationID 不一致")
+		}
+		switch pending.Phase {
+		case "scheduled", "prepared":
+			if journalEmpty {
+				return discardEmptyRestoreJournal()
+			}
+			return nil
+		case "applied", "committed":
+			if status.State != "succeeded" || status.OperationID != pending.OperationID {
+				return fmt.Errorf("无日志 %s 任务缺少同 operationID 的 succeeded 状态", pending.Phase)
+			}
+			if journalEmpty {
+				if err := discardEmptyRestoreJournal(); err != nil {
+					return err
+				}
+			}
+			if err := restoreRemove(restorePendingPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			return syncDirectory(restoreDir())
+		case "switching", "swapped":
+			legacyOldData := filepath.Join(restoreDir(), restoreLegacyOldDataName)
+			if _, oldDataErr := os.Stat(legacyOldData); oldDataErr == nil {
+				return fmt.Errorf("检测到旧版恢复遗留目录 %s，无法无歧义自动恢复", legacyOldData)
+			} else if !errors.Is(oldDataErr, os.ErrNotExist) {
+				return oldDataErr
+			}
+			pending.Phase = "scheduled"
+			if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+				return err
+			}
+			return setRestoreStatus(RestoreStatus{State: "failed", OperationID: pending.OperationID, SourceName: pending.SourceName, SafetyBackupName: pending.SafetyBackupName, Message: "旧版恢复未移动数据，任务已重置"})
+		default:
+			return fmt.Errorf("恢复任务处于 %q 但 journal.jsonl 缺失，无法无歧义恢复", pending.Phase)
+		}
+	}
+	if journalErr != nil {
+		return fmt.Errorf("读取恢复事务日志: %w", journalErr)
+	}
+	pending, pendingErr := readPendingRestore()
+	if pendingErr != nil && !errors.Is(pendingErr, os.ErrNotExist) {
+		return pendingErr
+	}
+	if pendingErr == nil && pending.OperationID != journal.OperationID {
+		return errors.New("pending 与 journal 的 operationID 不一致")
+	}
+	status := GetRestoreStatus()
+	if status.OperationID != "" && status.OperationID != journal.OperationID {
+		return errors.New("status 与 journal 的 operationID 不一致")
+	}
+	if journal.State == "committed" {
+		removeMetadata := status.State == "succeeded" && status.OperationID == journal.OperationID
+		if err := cleanupCommittedArtifacts(removeMetadata); err != nil {
+			logger.M().Warnw("[备份恢复] 已提交事务清理未完成，将在下次启动重试", "operationId", journal.OperationID, "error", err)
+		}
+		return nil
+	}
+	if pendingErr != nil {
+		rollbackErr := rollbackRestoreJournal(journal)
+		return errors.Join(errors.New("恢复日志存在但 pending 缺失，已尝试回滚，仍需进入 degraded"), rollbackErr)
+	}
+	if journal.State != "rolled_back" {
+		if err := rollbackRestoreJournal(journal); err != nil {
+			return err
+		}
+	}
+	return resetRolledBackPending()
+}
+
+// RecoverInterruptedRestore 在 Runtime 启动前回滚上次未提交的逐文件事务。
+func RecoverInterruptedRestore() error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return recoverInterruptedRestore()
+}
+
+// HasCommittedRestore 报告是否存在已越过提交点、等待 Runtime 发布成功的恢复事务。
+func HasCommittedRestore() (bool, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	journal, err := readRestoreJournal()
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if journal.State != "committed" {
+		return false, nil
+	}
+	pending, pendingErr := readPendingRestore()
+	if pendingErr == nil && pending.OperationID != journal.OperationID {
+		return false, errors.New("已提交 journal 与 pending 的 operationID 不一致")
+	}
+	if pendingErr != nil && !errors.Is(pendingErr, os.ErrNotExist) {
+		return false, pendingErr
+	}
+	return true, nil
+}
+
+// HasRunnableScheduledRestore 报告是否存在尚未改动 data、可由 Runtime 安全续跑的恢复任务。
+func runnableScheduledRestoreOperationIDLocked() (string, error) {
+	pending, err := readPendingRestore()
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if pending.OperationID == "" || (pending.Phase != "scheduled" && pending.Phase != "prepared") {
+		return "", nil
+	}
+	status := GetRestoreStatus()
+	if status.OperationID != "" && status.OperationID != pending.OperationID {
+		return "", errors.New("可续跑恢复任务的 pending/status operationID 不一致")
+	}
+	if _, _, err = inspectBackupArchive(filepath.Join(restoreDir(), restoreSourceName)); err != nil {
+		return "", fmt.Errorf("可续跑恢复任务的源文件无效: %w", err)
+	}
+	if pending.Phase == "prepared" {
+		if pending.SafetyBackupName == "" {
+			return "", errors.New("prepared 恢复任务缺少安全备份名")
+		}
+		if _, err = backupArchivePathLocked(pending.SafetyBackupName); err != nil {
+			return "", fmt.Errorf("prepared 恢复任务的安全备份无效: %w", err)
+		}
+	}
+	journal, journalErr := readRestoreJournal()
+	if errors.Is(journalErr, os.ErrNotExist) {
+		return pending.OperationID, nil
+	}
+	if errors.Is(journalErr, errEmptyRestoreJournal) {
+		if err = discardEmptyRestoreJournal(); err != nil {
+			return "", err
+		}
+		return pending.OperationID, nil
+	}
+	if journalErr != nil {
+		return "", journalErr
+	}
+	if journal.OperationID != pending.OperationID {
+		return "", errors.New("可续跑恢复任务的 pending/journal operationID 不一致")
+	}
+	if journal.State != "rolled_back" {
+		return "", nil
+	}
+	return pending.OperationID, nil
+}
+
+// RunnableScheduledRestoreOperationID 返回经完整校验、可安全续跑的恢复 operationID。
+func RunnableScheduledRestoreOperationID() (string, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	return runnableScheduledRestoreOperationIDLocked()
+}
+
+// HasRunnableScheduledRestore 报告是否存在尚未改动 data、可由 Runtime 安全续跑的恢复任务。
+func HasRunnableScheduledRestore() (bool, error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	operationID, err := runnableScheduledRestoreOperationIDLocked()
+	return operationID != "", err
+}
+
+func prepareRolledBackRetry(operationID string) error {
+	journal, err := readRestoreJournal()
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if journal.OperationID != operationID {
+		return errors.New("重试任务与旧 journal 的 operationID 不一致")
+	}
+	if journal.State != "rolled_back" {
+		return fmt.Errorf("旧 journal 状态为 %q，不能开始重试", journal.State)
+	}
+	if err = restoreRemoveAll(filepath.Join(restoreDir(), restoreRollbackName)); err != nil {
+		return err
+	}
+	if err = restoreRemoveAll(filepath.Join(restoreDir(), restoreStagingName)); err != nil {
+		return err
+	}
+	if err = restoreRemove(restoreJournalPath()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ApplyScheduledRestore 在数据库关闭后应用已准备的待恢复文件。
+func ApplyScheduledRestore() (resultErr error) {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		return err
+	}
+	if err := recoverInterruptedRestore(); err != nil {
+		return err
+	}
+	pending, err := readPendingRestore()
+	if errors.Is(err, os.ErrNotExist) {
+		return errors.New("没有待执行的恢复任务")
+	}
+	if err != nil {
+		return err
+	}
+	if pending.OperationID == "" {
+		return errors.New("恢复任务缺少 operationID")
+	}
+	if pending.Phase == "applied" {
+		journal, journalErr := readRestoreJournal()
+		if journalErr == nil && journal.OperationID == pending.OperationID && journal.State == "applied" {
+			return nil
+		}
+		return errors.New("pending 显示 applied，但 journal 无法确认同一事务")
+	}
+	if pending.Phase != "prepared" || pending.SafetyBackupName == "" {
+		return fmt.Errorf("恢复任务尚未完成安全备份，当前阶段为 %q", pending.Phase)
+	}
+	if err = prepareRolledBackRetry(pending.OperationID); err != nil {
+		return err
+	}
+	defer func() {
+		if resultErr != nil {
+			_ = setRestoreStatus(RestoreStatus{State: "rolling_back", OperationID: pending.OperationID, SourceName: pending.SourceName, SafetyBackupName: pending.SafetyBackupName, Message: "应用备份失败，等待回滚: " + resultErr.Error()})
+		}
+	}()
+	source := filepath.Join(restoreDir(), restoreSourceName)
+	info, entries, err := inspectBackupArchive(source)
+	if err != nil {
+		return err
+	}
+	if !info.Restorable {
+		return errors.New("排队备份已不再满足恢复条件")
+	}
+	if processPath := firstProcessOwnedRestorePath(entries); processPath != "" {
+		return fmt.Errorf("备份包含进程级占用文件 %s", processPath)
+	}
+	if err = validateBackupData(source); err != nil {
+		return err
+	}
+	if err = ensureDiskSpace(restoreDir(), info.UncompressedSize); err != nil {
+		return err
+	}
+	staging := filepath.Join(restoreDir(), restoreStagingName)
+	if err = restoreRemoveAll(staging); err != nil {
+		return fmt.Errorf("清理暂存目录: %w", err)
+	}
+	if err = restoreRemoveAll(filepath.Join(restoreDir(), restoreRollbackName)); err != nil {
+		return fmt.Errorf("清理回滚目录: %w", err)
+	}
+	if err = os.MkdirAll(staging, 0o700); err != nil {
+		return err
+	}
+	if err = extractBackupTo(source, staging); err != nil {
+		return err
+	}
+	journal, err := buildRestoreJournal(pending.OperationID, staging)
+	if err != nil {
+		return err
+	}
+	if err = createRestoreJournal(journal); err != nil {
+		return err
+	}
+	pending.Phase = "applying"
+	if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return err
+	}
+	_ = setRestoreStatus(RestoreStatus{State: "applying", OperationID: pending.OperationID, SourceName: pending.SourceName, SafetyBackupName: pending.SafetyBackupName})
+	if err = applyRestoreJournal(journal); err != nil {
+		if journal.State == "rolled_back" {
+			_ = resetRolledBackPending()
+		}
+		return err
+	}
+	pending.Phase = "applied"
+	if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CommitScheduledRestore 写入唯一不可逆的提交记录，不负责发布成功状态。
+func CommitScheduledRestore() error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		return err
+	}
+	pending, err := readPendingRestore()
+	if errors.Is(err, os.ErrNotExist) {
+		status := GetRestoreStatus()
+		if status.State == "succeeded" {
+			return nil
+		}
+		return errors.New("提交恢复时 pending 缺失")
+	}
+	if err != nil {
+		return err
+	}
+	journal, err := readRestoreJournal()
+	if err != nil {
+		return err
+	}
+	if pending.OperationID == "" || pending.OperationID != journal.OperationID {
+		return errors.New("提交恢复时 operationID 不一致")
+	}
+	if journal.State == "committed" {
+		return nil
+	}
+	if pending.Phase != "applied" || journal.State != "applied" {
+		return fmt.Errorf("恢复任务尚未应用完成，pending=%s journal=%s", pending.Phase, journal.State)
+	}
+	if err = appendJournalState(journal, "committed"); err != nil {
+		return fmt.Errorf("提交记录持久化结果不确定，拒绝继续发布: %w", err)
+	}
+	pending.Phase = "committed"
+	if updateErr := writeJSONAtomic(restorePendingPath(), pending); updateErr != nil {
+		logger.M().Warnw("[备份恢复] 恢复已提交，但 pending 更新失败", "operationId", pending.OperationID, "error", updateErr)
+	}
+	if cleanupErr := cleanupCommittedArtifacts(false); cleanupErr != nil {
+		logger.M().Warnw("[备份恢复] 恢复已提交，但事务清理未完成，将在下次启动重试", "operationId", pending.OperationID, "error", cleanupErr)
+	}
+	return nil
+}
+
+// MarkScheduledRestoreSucceeded 在新 Runtime 发布后写入成功状态并清理事务元数据。
+func MarkScheduledRestoreSucceeded() error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		return err
+	}
+	journal, err := readRestoreJournal()
+	if errors.Is(err, os.ErrNotExist) {
+		if GetRestoreStatus().State == "succeeded" {
+			return nil
+		}
+		return errors.New("标记恢复成功时 journal 缺失")
+	}
+	if err != nil {
+		return err
+	}
+	if journal.State != "committed" {
+		return fmt.Errorf("标记恢复成功时 journal 状态为 %q", journal.State)
+	}
+	pending, pendingErr := readPendingRestore()
+	if pendingErr != nil && !errors.Is(pendingErr, os.ErrNotExist) {
+		return pendingErr
+	}
+	status := GetRestoreStatus()
+	if pendingErr == nil {
+		if pending.OperationID != journal.OperationID {
+			return errors.New("标记恢复成功时 operationID 不一致")
+		}
+		status = RestoreStatus{
+			State:            "succeeded",
+			OperationID:      pending.OperationID,
+			SourceName:       pending.SourceName,
+			SafetyBackupName: pending.SafetyBackupName,
+		}
+	} else {
+		if status.OperationID != journal.OperationID {
+			return errors.New("pending 缺失且 status 无法确认已提交 operationID")
+		}
+		status.State = "succeeded"
+		status.Message = ""
+	}
+	if err = setRestoreStatus(status); err != nil {
+		return err
+	}
+	if cleanupErr := cleanupCommittedArtifacts(true); cleanupErr != nil {
+		logger.M().Warnw("[备份恢复] 成功状态已发布，但事务清理未完成，将在下次启动重试", "operationId", journal.OperationID, "error", cleanupErr)
+	}
+	return nil
+}
+
+func RollbackScheduledRestore(message string) error {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err := validateRestoreStorageLocked(); err != nil {
+		return err
+	}
+	pending, pendingErr := readPendingRestore()
+	journal, journalErr := readRestoreJournal()
+	if journalErr == nil {
+		if pendingErr == nil && pending.OperationID != journal.OperationID {
+			return errors.New("回滚恢复时 operationID 不一致")
+		}
+		if journal.State == "committed" {
+			return errors.New("恢复事务已经提交，拒绝回滚")
+		}
+		if journal.State != "rolled_back" {
+			if err := rollbackRestoreJournal(journal); err != nil {
+				return err
+			}
+		}
+	} else if errors.Is(journalErr, errEmptyRestoreJournal) {
+		if pendingErr != nil || (pending.Phase != "scheduled" && pending.Phase != "prepared") {
+			return errors.New("恢复日志不含完整 begin，但 pending 阶段无法确认未改动 data")
+		}
+		if err := discardEmptyRestoreJournal(); err != nil {
+			return err
+		}
+	} else if !errors.Is(journalErr, os.ErrNotExist) {
+		return journalErr
+	} else if pendingErr == nil && pending.Phase != "scheduled" && pending.Phase != "prepared" {
+		return fmt.Errorf("恢复任务处于 %q 但 journal 缺失，拒绝宣称已回滚", pending.Phase)
+	}
+	if pendingErr != nil {
+		return pendingErr
+	}
+	if pending.OperationID == "" {
+		return errors.New("回滚恢复任务缺少 operationID")
+	}
+	if pending.SafetyBackupName == "" {
+		pending.Phase = "scheduled"
+	} else {
+		pending.Phase = "prepared"
+	}
+	if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		return err
+	}
+	return setRestoreStatus(RestoreStatus{
+		State:            "rolled_back",
+		OperationID:      pending.OperationID,
+		SourceName:       pending.SourceName,
+		SafetyBackupName: pending.SafetyBackupName,
+		Message:          message,
+	})
+}

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -1200,6 +1200,8 @@ func backupInUseLocked(name string) (bool, error) {
 }
 
 func BackupInUse(name string) bool {
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
 	inUse, err := backupInUseLocked(name)
 	return err != nil || inUse
 }
@@ -1266,7 +1268,7 @@ func openBackupArchiveLocked(name string) (*os.File, os.FileInfo, error) {
 		_ = file.Close()
 		return nil, nil, err
 	}
-	if !actual.Mode().IsRegular() || !os.SameFile(expected, actual) {
+	if !actual.Mode().IsRegular() || !os.SameFile(expected, actual) || actual.Size() != expected.Size() || !actual.ModTime().Equal(expected.ModTime()) {
 		_ = file.Close()
 		return nil, nil, errors.New("打开的备份文件与已校验目标不一致")
 	}
@@ -1477,15 +1479,15 @@ func directorySize(root string) (uint64, error) {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("目录包含符号链接: %s", filename)
-		}
-		if !entry.Type().IsRegular() {
-			return nil
-		}
 		info, infoErr := entry.Info()
 		if infoErr != nil {
 			return infoErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 || isLinkedRestorePath(info) {
+			return fmt.Errorf("目录包含符号链接或重解析点: %s", filename)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
 		}
 		if info.Size() < 0 || math.MaxUint64-total < uint64(info.Size()) {
 			return errors.New("目录大小计算溢出")

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -24,6 +24,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"golang.org/x/text/encoding/charmap"
 	"gopkg.in/yaml.v3"
 
 	"sealdice-core/logger"
@@ -500,6 +501,17 @@ func managedSQLiteDatabaseFiles(dm *DiceManager, requireExisting bool) ([]manage
 	return result, nil
 }
 
+func decodeZipEntryName(name string, nonUTF8 bool) (string, error) {
+	if !nonUTF8 {
+		return name, nil
+	}
+	decoded, err := charmap.CodePage437.NewDecoder().Bytes([]byte(name))
+	if err != nil {
+		return "", fmt.Errorf("解码 CP437 压缩包路径失败: %w", err)
+	}
+	return string(decoded), nil
+}
+
 func isWindowsReservedName(segment string) bool {
 	base := strings.ToUpper(strings.TrimRight(strings.SplitN(segment, ".", 2)[0], " ."))
 	if base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" || base == "CONIN$" || base == "CONOUT$" || base == "CLOCK$" {
@@ -788,7 +800,11 @@ func inspectBackupArchiveDetailedFile(file *os.File, stat os.FileInfo, filename 
 	var uncompressed uint64
 	var compressed uint64
 	for _, item := range reader.File {
-		clean, cleanErr := normalizeBackupEntryName(item.Name, item.FileInfo().IsDir())
+		decodedName, decodeErr := decodeZipEntryName(item.Name, item.NonUTF8)
+		if decodeErr != nil {
+			return nil, nil, emptyManifest, decodeErr
+		}
+		clean, cleanErr := normalizeBackupEntryName(decodedName, item.FileInfo().IsDir())
 		if cleanErr != nil {
 			return nil, nil, emptyManifest, cleanErr
 		}
@@ -988,7 +1004,11 @@ func validateBackupDataFile(file *os.File, stat os.FileInfo, filename string) er
 		if item.FileInfo().IsDir() {
 			continue
 		}
-		clean, cleanErr := normalizeBackupEntryName(item.Name, false)
+		decodedName, decodeErr := decodeZipEntryName(item.Name, item.NonUTF8)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		clean, cleanErr := normalizeBackupEntryName(decodedName, false)
 		if cleanErr != nil {
 			return cleanErr
 		}
@@ -2088,7 +2108,11 @@ func extractBackupTo(source, destination string) error {
 	}
 	defer func() { _ = reader.Close() }()
 	for _, item := range reader.File {
-		clean, cleanErr := normalizeBackupEntryName(item.Name, item.FileInfo().IsDir())
+		decodedName, decodeErr := decodeZipEntryName(item.Name, item.NonUTF8)
+		if decodeErr != nil {
+			return decodeErr
+		}
+		clean, cleanErr := normalizeBackupEntryName(decodedName, item.FileInfo().IsDir())
 		if cleanErr != nil {
 			return cleanErr
 		}

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -661,15 +661,6 @@ func readZIPDirectoryMetadata(file *os.File, size int64) (zipDirectoryMetadata, 
 	return metadata, nil
 }
 
-func preflightZIPCentralDirectory(filename string) error {
-	file, err := os.Open(filename)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = file.Close() }()
-	return preflightZIPCentralDirectoryFile(file)
-}
-
 func preflightZIPCentralDirectoryFile(file *os.File) error {
 	info, err := file.Stat()
 	if err != nil {
@@ -1059,19 +1050,6 @@ func validateBackupDataFile(file *os.File, stat os.FileInfo, filename string) er
 		return fmt.Errorf("data/dice.yaml 包含不安全的骰子名称: %w", err)
 	}
 	return nil
-}
-
-func copyFileSynced(source, target string) error {
-	src, err := os.Open(source)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = src.Close() }()
-	info, err := src.Stat()
-	if err != nil {
-		return err
-	}
-	return copyFileSyncedFile(src, info, target)
 }
 
 func copyFileSyncedFile(src *os.File, info os.FileInfo, target string) error {
@@ -2411,8 +2389,8 @@ func readRestoreJournal() (*restoreJournal, error) {
 			}
 			journal = &restoreJournal{OperationID: record.OperationID, State: "planned", Entries: record.Entries}
 			for index := range journal.Entries {
-				if err := validateRestoreJournalEntryPaths(&journal.Entries[index]); err != nil {
-					return nil, fmt.Errorf("恢复日志第 %d 条路径校验失败: %w", lineNumber, err)
+				if validateErr := validateRestoreJournalEntryPaths(&journal.Entries[index]); validateErr != nil {
+					return nil, fmt.Errorf("恢复日志第 %d 条路径校验失败: %w", lineNumber, validateErr)
 				}
 			}
 			continue
@@ -3087,7 +3065,7 @@ func cleanupRolledBackArtifactsWithoutPending(journal *restoreJournal) error {
 	}
 	if cleanupErr == nil {
 		if err := restoreRemove(restoreJournalPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
-			cleanupErr = errors.Join(cleanupErr, err)
+			cleanupErr = err
 		}
 	}
 	if cleanupErr == nil {

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -651,6 +651,10 @@ func preflightZIPCentralDirectory(filename string) error {
 		return err
 	}
 	defer func() { _ = file.Close() }()
+	return preflightZIPCentralDirectoryFile(file)
+}
+
+func preflightZIPCentralDirectoryFile(file *os.File) error {
 	info, err := file.Stat()
 	if err != nil {
 		return err
@@ -738,22 +742,33 @@ func inspectBackupArchive(filename string) (*BackupArchiveInfo, map[string]struc
 }
 
 func inspectBackupArchiveDetailed(filename string) (*BackupArchiveInfo, map[string]struct{}, backupManifest, error) {
-	var emptyManifest backupManifest
 	stat, err := os.Lstat(filename)
 	if err != nil {
-		return nil, nil, emptyManifest, err
+		var empty backupManifest
+		return nil, nil, empty, err
 	}
 	if !stat.Mode().IsRegular() {
-		return nil, nil, emptyManifest, errors.New("备份文件不是普通文件或为符号链接")
+		var empty backupManifest
+		return nil, nil, empty, errors.New("备份文件不是普通文件或为符号链接")
 	}
-	if err = preflightZIPCentralDirectory(filename); err != nil {
+	file, err := os.Open(filename)
+	if err != nil {
+		var empty backupManifest
+		return nil, nil, empty, err
+	}
+	defer func() { _ = file.Close() }()
+	return inspectBackupArchiveDetailedFile(file, stat, filename)
+}
+
+func inspectBackupArchiveDetailedFile(file *os.File, stat os.FileInfo, filename string) (*BackupArchiveInfo, map[string]struct{}, backupManifest, error) {
+	var emptyManifest backupManifest
+	if err := preflightZIPCentralDirectoryFile(file); err != nil {
 		return nil, nil, emptyManifest, fmt.Errorf("zip 中央目录预检失败: %w", err)
 	}
-	reader, err := zip.OpenReader(filename)
+	reader, err := zip.NewReader(file, stat.Size())
 	if err != nil {
 		return nil, nil, emptyManifest, fmt.Errorf("不是有效的 ZIP 文件: %w", err)
 	}
-	defer func() { _ = reader.Close() }()
 	if len(reader.File) > maxBackupEntries {
 		return nil, nil, emptyManifest, fmt.Errorf("压缩包条目超过 %d 个", maxBackupEntries)
 	}
@@ -930,7 +945,23 @@ func InspectBackupArchive(filename string) *BackupArchiveInfo {
 }
 
 func validateBackupData(filename string) error {
-	_, _, manifest, err := inspectBackupArchiveDetailed(filename)
+	stat, err := os.Lstat(filename)
+	if err != nil {
+		return err
+	}
+	if !stat.Mode().IsRegular() {
+		return errors.New("备份文件不是普通文件或为符号链接")
+	}
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return validateBackupDataFile(file, stat, filename)
+}
+
+func validateBackupDataFile(file *os.File, stat os.FileInfo, filename string) error {
+	_, _, manifest, err := inspectBackupArchiveDetailedFile(file, stat, filename)
 	if err != nil {
 		return err
 	}
@@ -940,11 +971,10 @@ func validateBackupData(filename string) error {
 			expected[file.Path] = file
 		}
 	}
-	reader, err := zip.OpenReader(filename)
+	reader, err := zip.NewReader(file, stat.Size())
 	if err != nil {
 		return err
 	}
-	defer func() { _ = reader.Close() }()
 	seen := make(map[string]struct{}, len(expected))
 	var archivedDiceConfig []byte
 	for _, item := range reader.File {
@@ -1010,6 +1040,17 @@ func copyFileSynced(source, target string) error {
 		return err
 	}
 	defer func() { _ = src.Close() }()
+	info, err := src.Stat()
+	if err != nil {
+		return err
+	}
+	return copyFileSyncedFile(src, info, target)
+}
+
+func copyFileSyncedFile(src *os.File, info os.FileInfo, target string) error {
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
 	dst, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
@@ -1201,6 +1242,10 @@ func BackupArchivePath(name string) (string, error) {
 func OpenBackupArchive(name string) (*os.File, os.FileInfo, error) {
 	backupOperationMu.Lock()
 	defer backupOperationMu.Unlock()
+	return openBackupArchiveLocked(name)
+}
+
+func openBackupArchiveLocked(name string) (*os.File, os.FileInfo, error) {
 	target, expected, err := backupArchiveFileLocked(name)
 	if err != nil {
 		return nil, nil, err
@@ -1267,8 +1312,15 @@ func fileSHA256(filename string) ([sha256.Size]byte, error) {
 		return [sha256.Size]byte{}, err
 	}
 	defer func() { _ = file.Close() }()
+	return fileSHA256File(file)
+}
+
+func fileSHA256File(file *os.File) ([sha256.Size]byte, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return [sha256.Size]byte{}, err
+	}
 	hasher := sha256.New()
-	if _, err = io.Copy(hasher, file); err != nil {
+	if _, err := io.Copy(hasher, file); err != nil {
 		return [sha256.Size]byte{}, err
 	}
 	var digest [sha256.Size]byte
@@ -1342,8 +1394,11 @@ func ImportBackup(reader io.Reader) (*BackupArchiveInfo, error) {
 	}
 	var uploadedDigest [sha256.Size]byte
 	copy(uploadedDigest[:], hash.Sum(nil))
-	digest := hex.EncodeToString(uploadedDigest[:])[:8]
-	existing, _ := filepath.Glob(filepath.Join(BackupDir, "import_*_"+digest+".zip"))
+	digest := hex.EncodeToString(uploadedDigest[:])
+	existing, globErr := filepath.Glob(filepath.Join(BackupDir, "import_*_"+digest+".zip"))
+	if globErr != nil {
+		return nil, fmt.Errorf("查找同内容备份: %w", globErr)
+	}
 	for _, candidate := range existing {
 		candidateDigest, hashErr := fileSHA256(candidate)
 		if hashErr != nil || candidateDigest != uploadedDigest {
@@ -1627,6 +1682,9 @@ func restoreOperationFromExisting(name, requestID string) (*RestoreOperation, bo
 	if status.OperationID != requestID || status.SourceName != name {
 		return nil, false, errors.New("恢复授权存在但 pending/status 无法确认同一 requestId 和备份源")
 	}
+	if status.State != "succeeded" {
+		return nil, false, fmt.Errorf("pending 缺失且恢复状态为 %q，不能当作可复用操作", status.State)
+	}
 	auth, authErr = refreshRestoreStatusAuth(nil, auth)
 	if authErr != nil {
 		return nil, false, fmt.Errorf("刷新终态恢复授权失败: %w", authErr)
@@ -1766,11 +1824,12 @@ func (dm *DiceManager) ScheduleRestore(name, requestID string) (*RestoreOperatio
 	if err := ensureRestoreVolumesMatch(); err != nil {
 		return nil, err
 	}
-	source, err := backupArchivePathLocked(name)
+	sourceFile, sourceInfo, err := openBackupArchiveLocked(name)
 	if err != nil {
 		return nil, err
 	}
-	info, entries, err := inspectBackupArchive(source)
+	defer func() { _ = sourceFile.Close() }()
+	info, entries, _, err := inspectBackupArchiveDetailedFile(sourceFile, sourceInfo, filepath.Join(BackupDir, name))
 	if err != nil {
 		return nil, err
 	}
@@ -1786,7 +1845,7 @@ func (dm *DiceManager) ScheduleRestore(name, requestID string) (*RestoreOperatio
 	if processPath := firstProcessOwnedRestorePath(entries); processPath != "" {
 		return nil, fmt.Errorf("备份包含进程级占用文件 %s，不能安全恢复", processPath)
 	}
-	if err = validateBackupData(source); err != nil {
+	if err = validateBackupDataFile(sourceFile, sourceInfo, filepath.Join(BackupDir, name)); err != nil {
 		return nil, fmt.Errorf("备份内容校验失败: %w", err)
 	}
 	dataSize, err := directorySize("data")
@@ -1800,12 +1859,12 @@ func (dm *DiceManager) ScheduleRestore(name, requestID string) (*RestoreOperatio
 	if err = ensureDiskSpace(BackupDir, required); err != nil {
 		return nil, err
 	}
-	sourceDigest, err := fileSHA256(source)
+	sourceDigest, err := fileSHA256File(sourceFile)
 	if err != nil {
 		return nil, err
 	}
 	queuedSource := filepath.Join(restoreDir(), restoreSourceName)
-	if err = copyFileSynced(source, queuedSource); err != nil {
+	if err = copyFileSyncedFile(sourceFile, sourceInfo, queuedSource); err != nil {
 		return nil, err
 	}
 	queuedDigest, err := fileSHA256(queuedSource)
@@ -2288,6 +2347,11 @@ func readRestoreJournal() (*restoreJournal, error) {
 				return nil, errors.New("恢复日志缺少有效 begin 记录")
 			}
 			journal = &restoreJournal{OperationID: record.OperationID, State: "planned", Entries: record.Entries}
+			for index := range journal.Entries {
+				if err := validateRestoreJournalEntryPaths(&journal.Entries[index]); err != nil {
+					return nil, fmt.Errorf("恢复日志第 %d 条路径校验失败: %w", lineNumber, err)
+				}
+			}
 			continue
 		}
 		if record.OperationID != journal.OperationID {
@@ -2382,6 +2446,31 @@ func ensureRestorePrivatePath(root, target string) error {
 	return ensureNoLinkedPath(root, target, true)
 }
 
+func validateRestoreJournalEntryPaths(entry *restoreJournalEntry) error {
+	if entry == nil {
+		return errors.New("恢复日志包含空条目")
+	}
+	if err := ensureRestoreTargetSafe(entry.Target); err != nil {
+		return fmt.Errorf("恢复日志目标不安全: %w", err)
+	}
+	rollbackRoot := filepath.Join(restoreDir(), restoreRollbackName)
+	if err := ensureRestorePrivatePath(rollbackRoot, entry.Rollback); err != nil {
+		return fmt.Errorf("恢复日志回滚路径不安全: %w", err)
+	}
+	if entry.Staged != "" {
+		stagingRoot := filepath.Join(restoreDir(), restoreStagingName)
+		if err := ensureRestorePrivatePath(stagingRoot, entry.Staged); err != nil {
+			return fmt.Errorf("恢复日志暂存路径不安全: %w", err)
+		}
+		if info, statErr := os.Lstat(entry.Staged); statErr == nil && !info.Mode().IsRegular() {
+			return fmt.Errorf("恢复日志暂存路径不是普通文件: %s", entry.Staged)
+		} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return statErr
+		}
+	}
+	return nil
+}
+
 func buildRestoreJournal(operationID, staging string) (*restoreJournal, error) {
 	if operationID == "" {
 		return nil, errors.New("恢复事务缺少 operationID")
@@ -2447,6 +2536,10 @@ func buildRestoreJournal(operationID, staging string) (*restoreJournal, error) {
 			if err = ensureRestoreTargetSafe(sidecar); err != nil {
 				return nil, err
 			}
+			sidecarRollback := filepath.Join(restoreDir(), restoreRollbackName, sidecar)
+			if err = ensureRestorePrivatePath(filepath.Join(restoreDir(), restoreRollbackName), sidecarRollback); err != nil {
+				return nil, fmt.Errorf("sqlite sidecar 回滚路径不安全: %w", err)
+			}
 			hadOriginal := false
 			if info, statErr := os.Lstat(sidecar); statErr == nil {
 				if !info.Mode().IsRegular() {
@@ -2500,6 +2593,12 @@ func applyRestoreJournal(journal *restoreJournal) (resultErr error) {
 		entry := &journal.Entries[index]
 		if err := ensureRestoreTargetSafe(entry.Target); err != nil {
 			return err
+		}
+		if entry.Staged != "" {
+			stagingRoot := filepath.Join(restoreDir(), restoreStagingName)
+			if err := ensureRestorePrivatePath(stagingRoot, entry.Staged); err != nil {
+				return fmt.Errorf("恢复暂存路径不安全 %s: %w", entry.Staged, err)
+			}
 		}
 		if !entry.backupIntent {
 			if err := appendJournalStep(journal, index, "backup-original", "intent"); err != nil {
@@ -2769,13 +2868,13 @@ func rollbackRestoreJournal(journal *restoreJournal) error {
 				continue
 			}
 			switch {
-			case rollbackExists:
+			case rollbackExists && !targetExists:
 				if err := restoreSyncMutationParents("data", entry.Target, restoreDir(), entry.Rollback); err != nil {
 					rollbackErr = errors.Join(rollbackErr, err)
 					continue
 				}
 				backedUp = true
-			case targetExists && !installed:
+			case !rollbackExists && targetExists && !installed:
 				backedUp = false
 			default:
 				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("无法判断原文件 %s 是否已移入 rollback", entry.Target))
@@ -2898,6 +2997,37 @@ func cleanupCommittedArtifacts(removeMetadata bool) error {
 	return cleanupErr
 }
 
+func cleanupRolledBackArtifactsWithoutPending(journal *restoreJournal) error {
+	if err := setRestoreStatus(RestoreStatus{
+		State:       "rolled_back",
+		OperationID: journal.OperationID,
+		Message:     "检测到已回滚恢复但 pending 缺失，事务已清理",
+	}); err != nil {
+		return err
+	}
+	var cleanupErr error
+	for _, directory := range []string{restoreRollbackName, restoreStagingName} {
+		if err := restoreRemoveAll(filepath.Join(restoreDir(), directory)); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	if err := restoreRemove(filepath.Join(restoreDir(), restoreSourceName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupErr = errors.Join(cleanupErr, err)
+	}
+	if cleanupErr == nil {
+		cleanupErr = syncDirectory(restoreDir())
+	}
+	if cleanupErr == nil {
+		if err := restoreRemove(restoreJournalPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	if cleanupErr == nil {
+		cleanupErr = syncDirectory(restoreDir())
+	}
+	return cleanupErr
+}
+
 func recoverInterruptedRestore() error {
 	journal, journalErr := readRestoreJournal()
 	journalEmpty := errors.Is(journalErr, errEmptyRestoreJournal)
@@ -2973,6 +3103,12 @@ func recoverInterruptedRestore() error {
 		return nil
 	}
 	if pendingErr != nil {
+		if journal.State == "rolled_back" {
+			if err := cleanupRolledBackArtifactsWithoutPending(journal); err != nil {
+				return err
+			}
+			return nil
+		}
 		rollbackErr := rollbackRestoreJournal(journal)
 		return errors.Join(errors.New("恢复日志存在但 pending 缺失，已尝试回滚，仍需进入 degraded"), rollbackErr)
 	}
@@ -3070,7 +3206,9 @@ func runnableScheduledRestoreOperationIDLocked() (string, error) {
 	if journal.OperationID != pending.OperationID {
 		return "", errors.New("可续跑恢复任务的 pending/journal operationID 不一致")
 	}
-	if journal.State != "rolled_back" {
+	// A fully rolled back transaction must only run again after an explicit
+	// user retry; never re-enqueue it automatically at startup.
+	if journal.State == "rolled_back" {
 		return "", nil
 	}
 	return pending.OperationID, nil
@@ -3162,9 +3300,16 @@ func ApplyScheduledRestore() (resultErr error) {
 	if err = prepareRolledBackRetry(pending.OperationID); err != nil {
 		return err
 	}
+	var journal *restoreJournal
 	defer func() {
 		if resultErr != nil {
-			_ = setRestoreStatus(RestoreStatus{State: "rolling_back", OperationID: pending.OperationID, SourceName: pending.SourceName, SafetyBackupName: pending.SafetyBackupName, Message: "应用备份失败，等待回滚: " + resultErr.Error()})
+			state := "rolling_back"
+			message := "应用备份失败，等待回滚: " + resultErr.Error()
+			if journal != nil && journal.State == "rolled_back" {
+				state = "rolled_back"
+				message = "应用备份失败，已回滚: " + resultErr.Error()
+			}
+			_ = setRestoreStatus(RestoreStatus{State: state, OperationID: pending.OperationID, SourceName: pending.SourceName, SafetyBackupName: pending.SafetyBackupName, Message: message})
 		}
 	}()
 	source := filepath.Join(restoreDir(), restoreSourceName)
@@ -3197,7 +3342,7 @@ func ApplyScheduledRestore() (resultErr error) {
 	if err = extractBackupTo(source, staging); err != nil {
 		return err
 	}
-	journal, err := buildRestoreJournal(pending.OperationID, staging)
+	journal, err = buildRestoreJournal(pending.OperationID, staging)
 	if err != nil {
 		return err
 	}

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -1032,7 +1032,7 @@ func validateBackupDataFile(file *os.File, stat os.FileInfo, filename string) er
 	if err = yaml.Unmarshal(archivedDiceConfig, &config); err != nil {
 		return fmt.Errorf("解析 data/dice.yaml 失败: %w", err)
 	}
-	if err = ValidateDiceConfigNames(config.DiceConfigs); err != nil {
+	if err = ValidateDiceConfigNamesPortable(config.DiceConfigs); err != nil {
 		return fmt.Errorf("data/dice.yaml 包含不安全的骰子名称: %w", err)
 	}
 	return nil

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -1329,8 +1329,6 @@ func fileSHA256File(file *os.File) ([sha256.Size]byte, error) {
 }
 
 func ImportBackup(reader io.Reader) (*BackupArchiveInfo, error) {
-	backupOperationMu.Lock()
-	defer backupOperationMu.Unlock()
 	if err := ensureBackupDirectoryLocked(); err != nil {
 		return nil, err
 	}
@@ -1385,6 +1383,14 @@ func ImportBackup(reader io.Reader) (*BackupArchiveInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// The network upload itself must not hold the global backup lock; only
+	// validation, deduplication and the atomic publish step are serialized.
+	backupOperationMu.Lock()
+	defer backupOperationMu.Unlock()
+	if err = validateBackupDirectoryLocked(); err != nil {
+		return nil, err
+	}
 	info, _, err := inspectBackupArchive(tmpName)
 	if err != nil {
 		return nil, err
@@ -1414,6 +1420,7 @@ func ImportBackup(reader io.Reader) (*BackupArchiveInfo, error) {
 		return nil, err
 	}
 	if err = syncDirectory(BackupDir); err != nil {
+		_ = os.Remove(target)
 		return nil, err
 	}
 	info.Name = name

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -1648,6 +1648,17 @@ func releaseRetryablePendingRestore() error {
 		} else if !errors.Is(journalErr, os.ErrNotExist) {
 			return journalErr
 		}
+		if _, legacyJournalErr := os.Stat(restoreLegacyJournalPath()); legacyJournalErr == nil {
+			return errors.New("检测到旧版恢复日志 journal.json 且 pending 缺失，拒绝自动清除")
+		} else if !errors.Is(legacyJournalErr, os.ErrNotExist) {
+			return legacyJournalErr
+		}
+		legacyOldData := filepath.Join(restoreDir(), restoreLegacyOldDataName)
+		if _, oldDataErr := os.Stat(legacyOldData); oldDataErr == nil {
+			return fmt.Errorf("检测到旧版恢复遗留目录 %s 且 pending 缺失，拒绝自动清除", restoreLegacyOldDataName)
+		} else if !errors.Is(oldDataErr, os.ErrNotExist) {
+			return oldDataErr
+		}
 		return nil
 	}
 	if err != nil {

--- a/dice/dice_backup_restore.go
+++ b/dice/dice_backup_restore.go
@@ -867,14 +867,17 @@ func inspectBackupArchiveDetailedFile(file *os.File, stat os.FileInfo, filename 
 	if err = checkCompressionRatio("整个压缩包", compressed, uncompressed); err != nil {
 		return nil, nil, emptyManifest, err
 	}
-	if !manifestFound || manifest.VersionCode <= 0 {
+	if !manifestFound {
 		return nil, nil, emptyManifest, errors.New("缺少有效的 backup_info.json")
+	}
+	if manifest.FormatVersion == backupManifestFormatVersion && manifest.VersionCode <= 0 {
+		return nil, nil, emptyManifest, errors.New("v2 备份缺少有效的 versionCode")
+	}
+	if manifest.VersionCode > 0 && manifest.VersionCode > VERSION_CODE {
+		return nil, nil, emptyManifest, fmt.Errorf("备份版本 %d 高于当前程序版本 %d", manifest.VersionCode, VERSION_CODE)
 	}
 	if !dataConfigFound {
 		return nil, nil, emptyManifest, errors.New("备份缺少 data/dice.yaml")
-	}
-	if manifest.VersionCode > VERSION_CODE {
-		return nil, nil, emptyManifest, fmt.Errorf("备份版本 %d 高于当前程序版本 %d", manifest.VersionCode, VERSION_CODE)
 	}
 	restorable := true
 	if manifest.FormatVersion > backupManifestFormatVersion {

--- a/dice/dice_backup_restore_test.go
+++ b/dice/dice_backup_restore_test.go
@@ -1136,6 +1136,25 @@ func TestOpenBackupArchiveReturnsVerifiedHandle(t *testing.T) {
 	}
 }
 
+func TestReleaseRetryablePendingRefusesLegacyArtifactsWithoutPending(t *testing.T) {
+	prepareRestoreTest(t)
+	legacyOldData := filepath.Join(restoreDir(), restoreLegacyOldDataName)
+	writeTestFile(t, filepath.Join(legacyOldData, "data.db"), "keep")
+	if err := releaseRetryablePendingRestore(); err == nil {
+		t.Fatal("releaseRetryablePendingRestore accepted legacy old-data without pending")
+	}
+	assertRestoreTestFile(t, filepath.Join(legacyOldData, "data.db"), "keep")
+
+	if err := restoreRemoveAll(restoreDir()); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, restoreLegacyJournalPath(), `{"legacy":true}`)
+	if err := releaseRetryablePendingRestore(); err == nil {
+		t.Fatal("releaseRetryablePendingRestore accepted legacy journal without pending")
+	}
+	assertRestoreTestFile(t, restoreLegacyJournalPath(), `{"legacy":true}`)
+}
+
 func TestScheduleRestoreRejectsLinkedBackupRootBeforeCleanup(t *testing.T) {
 	prepareRestoreTest(t)
 	dm := newRestoreSQLiteManager(t)

--- a/dice/dice_backup_restore_test.go
+++ b/dice/dice_backup_restore_test.go
@@ -1,0 +1,1171 @@
+package dice //nolint:testpackage // Tests exercise the unexported restore transaction implementation.
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mysqlengine "sealdice-core/utils/dboperator/engine/mysql"
+	sqliteengine "sealdice-core/utils/dboperator/engine/sqlite"
+)
+
+const restoreTestDiceConfig = "diceConfigs:\n  - name: default\n"
+
+func prepareRestoreTest(t *testing.T) string {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	t.Setenv("DATADIR", filepath.Join("data", "default"))
+	if err := os.MkdirAll(filepath.Join(BackupDir, restoreDirName), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join("data", "default"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalProbe := probeRestoreDiskSpace
+	probeRestoreDiskSpace = func(string) (packageDiskSpace, error) {
+		return packageDiskSpace{Volume: "test", Available: 1 << 50, Total: 1 << 50}, nil
+	}
+	t.Cleanup(func() { probeRestoreDiskSpace = originalProbe })
+	return filepath.Join(restoreDir(), restoreSourceName)
+}
+
+func writeTestFile(t *testing.T, filename, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRestoreTestArchive(t *testing.T, filename string, files map[string]string, v2 bool) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := os.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(archive)
+	manifestFiles := make([]backupManifestFile, 0, len(files))
+	for name, content := range files {
+		file, createErr := writer.Create(name)
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		if _, createErr = file.Write([]byte(content)); createErr != nil {
+			t.Fatal(createErr)
+		}
+		digest := sha256.Sum256([]byte(content))
+		manifestFiles = append(manifestFiles, backupManifestFile{
+			Path:   filepath.ToSlash(name),
+			Size:   uint64(len(content)),
+			SHA256: hex.EncodeToString(digest[:]),
+		})
+	}
+	manifest := backupManifest{
+		Config:      mustMarshalJSON(map[string]any{"decks": true, "dices": map[string]any{"default": map[string]any{"jsScripts": true}}}),
+		Version:     mustMarshalJSON("test"),
+		VersionCode: VERSION_CODE,
+	}
+	if v2 {
+		manifest.FormatVersion = backupManifestFormatVersion
+		manifest.RestorePolicy = backupRestorePolicyOverlay
+		manifest.DatabaseType = "sqlite"
+		manifest.Files = manifestFiles
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestFile, err := writer.Create("backup_info.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = manifestFile.Write(manifestData); err != nil {
+		t.Fatal(err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newRestoreSQLiteManager(t *testing.T) *DiceManager {
+	t.Helper()
+	writeTestFile(t, "data/dice.yaml", restoreTestDiceConfig)
+	writeTestFile(t, "data/default/serve.yaml", "serve config")
+	operator := &sqliteengine.SQLiteEngine{}
+	if err := operator.Init(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(operator.Close)
+	d := &Dice{
+		BaseConfig: BaseConfig{Name: "default", DataDir: filepath.Join("data", "default")},
+		DBOperator: operator,
+		ImSession:  &IMSession{},
+	}
+	return &DiceManager{Operator: operator, Dice: []*Dice{d}}
+}
+
+func assertRestoreTestFile(t *testing.T, filename, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != want {
+		t.Fatalf("%s = %q, want %q", filename, data, want)
+	}
+}
+
+func TestInspectBackupArchiveSupportsLegacyAndV2(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		v2   bool
+	}{
+		{name: "legacy", v2: false},
+		{name: "v2", v2: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := prepareRestoreTest(t)
+			writeRestoreTestArchive(t, source, map[string]string{"data/dice.yaml": restoreTestDiceConfig}, test.v2)
+			info, _, err := inspectBackupArchive(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !info.Valid || !info.Restorable {
+				t.Fatalf("unexpected archive info: %#v", info)
+			}
+			if test.v2 && info.FormatVersion != backupManifestFormatVersion {
+				t.Fatalf("formatVersion = %d", info.FormatVersion)
+			}
+			if err = validateBackupData(source); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestValidateBackupDataRejectsV2HashMismatch(t *testing.T) {
+	source := prepareRestoreTest(t)
+	archive, err := os.Create(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(archive)
+	payload, err := writer.Create("data/dice.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = payload.Write([]byte(restoreTestDiceConfig))
+	manifest := backupManifest{
+		FormatVersion: backupManifestFormatVersion,
+		RestorePolicy: backupRestorePolicyOverlay,
+		DatabaseType:  "sqlite",
+		Files: []backupManifestFile{{
+			Path: "data/dice.yaml", Size: uint64(len(restoreTestDiceConfig)), SHA256: strings.Repeat("0", sha256.Size*2),
+		}},
+		Config: mustMarshalJSON(map[string]any{}), Version: mustMarshalJSON("test"), VersionCode: VERSION_CODE,
+	}
+	manifestData, _ := json.Marshal(manifest)
+	manifestEntry, _ := writer.Create("backup_info.json")
+	_, _ = manifestEntry.Write(manifestData)
+	if err = writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = validateBackupData(source); err == nil {
+		t.Fatal("validateBackupData accepted corrupt v2 payload")
+	}
+}
+
+func TestInspectBackupArchiveRejectsUnsafePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "traversal", path: "../outside.txt"},
+		{name: "windows traversal", path: `data\..\outside.txt`},
+		{name: "UNC", path: `\\server\share\file.txt`},
+		{name: "drive", path: `C:\data\file.txt`},
+		{name: "ADS", path: "data/file.txt:stream"},
+		{name: "reserved", path: "data/CON.txt"},
+		{name: "reserved superscript COM", path: "data/COM¹.txt"},
+		{name: "reserved superscript LPT", path: "data/LPT².log"},
+		{name: "reserved console input", path: "data/CONIN$"},
+		{name: "reserved console output", path: "data/CONOUT$.txt"},
+		{name: "reserved before extension", path: "data/CON .txt"},
+		{name: "trailing dot", path: "data/name."},
+		{name: "trailing space", path: "data/name "},
+		{name: "WAL", path: "data/default/data.db-wal"},
+		{name: "SHM", path: "data/default/data.db-shm"},
+		{name: "journal", path: "data/default/data.db-journal"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := prepareRestoreTest(t)
+			writeRestoreTestArchive(t, source, map[string]string{
+				"data/dice.yaml": restoreTestDiceConfig,
+				test.path:        "unsafe",
+			}, false)
+			if _, _, err := inspectBackupArchive(source); err == nil {
+				t.Fatalf("accepted unsafe path %q", test.path)
+			}
+		})
+	}
+}
+
+func TestInspectBackupArchiveRejectsCaseAndFileDirectoryAliases(t *testing.T) {
+	for _, files := range []map[string]string{
+		{"data/dice.yaml": restoreTestDiceConfig, "data/Foo.txt": "a", "data/foo.txt": "b"},
+		{"data/dice.yaml": restoreTestDiceConfig, "data/file": "a", "data/file/child": "b"},
+	} {
+		source := prepareRestoreTest(t)
+		writeRestoreTestArchive(t, source, files, false)
+		if _, _, err := inspectBackupArchive(source); err == nil {
+			t.Fatal("accepted aliased ZIP paths")
+		}
+	}
+}
+
+func TestInspectBackupArchiveRejectsSymlinkAndSpecialFile(t *testing.T) {
+	for _, mode := range []os.FileMode{os.ModeSymlink | 0o777, os.ModeNamedPipe | 0o600} {
+		source := prepareRestoreTest(t)
+		archive, err := os.Create(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writer := zip.NewWriter(archive)
+		config, _ := writer.Create("data/dice.yaml")
+		_, _ = config.Write([]byte(restoreTestDiceConfig))
+		header := &zip.FileHeader{Name: "data/unsafe"}
+		header.SetMode(mode)
+		unsafe, createErr := writer.CreateHeader(header)
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		_, _ = unsafe.Write([]byte("target"))
+		manifest, _ := writer.Create("backup_info.json")
+		_, _ = manifest.Write([]byte(`{"config":{},"version":"test","versionCode":1}`))
+		_ = writer.Close()
+		_ = archive.Close()
+		if _, _, err = inspectBackupArchive(source); err == nil {
+			t.Fatalf("accepted special mode %v", mode)
+		}
+	}
+}
+
+func TestInspectBackupArchiveRejectsZipBombHeader(t *testing.T) {
+	source := prepareRestoreTest(t)
+	archive, err := os.Create(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(archive)
+	config, _ := writer.Create("data/dice.yaml")
+	_, _ = config.Write([]byte(restoreTestDiceConfig))
+	bombHeader := &zip.FileHeader{
+		Name:               "data/bomb.bin",
+		Method:             zip.Store,
+		CRC32:              crc32.ChecksumIEEE([]byte{'x'}),
+		CompressedSize64:   1,
+		UncompressedSize64: compressionRatioMinimumSize + 1,
+	}
+	bomb, err := writer.CreateRaw(bombHeader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = bomb.Write([]byte{'x'})
+	manifest, _ := writer.Create("backup_info.json")
+	_, _ = manifest.Write([]byte(`{"config":{},"version":"test","versionCode":1}`))
+	_ = writer.Close()
+	_ = archive.Close()
+	if _, _, err = inspectBackupArchive(source); err == nil {
+		t.Fatal("accepted suspicious compression ratio")
+	}
+}
+
+func TestInspectBackupArchivePreflightsCentralDirectoryEntryCount(t *testing.T) {
+	source := prepareRestoreTest(t)
+	var header [46]byte
+	binary.LittleEndian.PutUint32(header[:4], 0x02014b50)
+	entryCount := maxBackupEntries + 1
+	central := bytes.Repeat(header[:], entryCount)
+	eocd := make([]byte, 22)
+	binary.LittleEndian.PutUint32(eocd[:4], 0x06054b50)
+	binary.LittleEndian.PutUint16(eocd[8:10], uint16(entryCount))  //nolint:gosec // ZIP32 stores the count modulo 65536.
+	binary.LittleEndian.PutUint16(eocd[10:12], uint16(entryCount)) //nolint:gosec // Deliberately truncated malicious count.
+	binary.LittleEndian.PutUint32(eocd[12:16], uint32(len(central)))
+	if err := os.WriteFile(source, append(central, eocd...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := inspectBackupArchive(source); err == nil || !strings.Contains(err.Error(), "条目超过") {
+		t.Fatalf("central directory count preflight did not reject archive: %v", err)
+	}
+}
+
+func TestValidateBackupDataRejectsUnsafeDiceConfigNames(t *testing.T) {
+	configs := []string{
+		"diceConfigs:\n  - name: ../../outside\n",
+		"diceConfigs:\n  - name: ''\n",
+		"diceConfigs:\n  - name: default\n  - name: DEFAULT\n",
+	}
+	for _, v2 := range []bool{false, true} {
+		for index, config := range configs {
+			t.Run(fmt.Sprintf("v2-%t-%d", v2, index), func(t *testing.T) {
+				source := prepareRestoreTest(t)
+				writeRestoreTestArchive(t, source, map[string]string{"data/dice.yaml": config}, v2)
+				if err := validateBackupData(source); err == nil {
+					t.Fatal("validateBackupData accepted unsafe dice config name")
+				}
+			})
+		}
+	}
+}
+
+func TestInspectBackupArchiveMarksProcessOwnedFilesNonRestorable(t *testing.T) {
+	for _, filename := range []string{"data/main.log", "data/panic.log", "data/runtime.lock"} {
+		source := prepareRestoreTest(t)
+		writeRestoreTestArchive(t, source, map[string]string{"data/dice.yaml": restoreTestDiceConfig, filename: "busy"}, false)
+		info, _, err := inspectBackupArchive(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Restorable || !strings.Contains(info.RestoreError, filename) {
+			t.Fatalf("process file should be non-restorable: %#v", info)
+		}
+	}
+}
+
+func TestScheduleRestoreIsIdempotentAndDoesNotCreateSafetyBackup(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	first, err := dm.ScheduleRestore("source.zip", "request-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Reused || first.SafetyBackupName != "" || first.ExpiresAt == 0 {
+		t.Fatalf("unexpected first operation: %#v", first)
+	}
+	if restoreStatusTokenValidDuration != 24*time.Hour {
+		t.Fatalf("status token validity = %v, want 24h", restoreStatusTokenValidDuration)
+	}
+	expiresIn := time.Until(time.Unix(first.ExpiresAt, 0))
+	if expiresIn < 23*time.Hour+59*time.Minute || expiresIn > restoreStatusTokenValidDuration {
+		t.Fatalf("status token expiry = %v, want approximately %v", expiresIn, restoreStatusTokenValidDuration)
+	}
+	second, err := dm.ScheduleRestore("source.zip", "request-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.Reused || second.OperationID != first.OperationID || second.StatusToken != first.StatusToken || second.ExpiresAt != first.ExpiresAt {
+		t.Fatalf("idempotent operation mismatch: first=%#v second=%#v", first, second)
+	}
+	pending, err := readPendingRestore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending.Phase != "scheduled" || pending.SafetyBackupName != "" {
+		t.Fatalf("schedule performed active-runtime backup: %#v", pending)
+	}
+	if !ValidateRestoreStatusToken(first.OperationID, first.StatusToken) {
+		t.Fatal("stored status token did not validate")
+	}
+	if len(first.StatusToken) < 43 {
+		t.Fatalf("status token is too short: %d", len(first.StatusToken))
+	}
+}
+
+func TestScheduleRestoreRefreshesExpiredTokenAndBindsAuthorizedStatus(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	first, err := dm.ScheduleRestore("source.zip", "request-refresh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := readRestoreStatusAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := readPendingRestore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth.ExpiresAt = time.Now().Add(-time.Minute).Unix()
+	pending.ExpiresAt = auth.ExpiresAt
+	if err = writeJSONAtomic(restoreStatusAuthPath(), auth); err != nil {
+		t.Fatal(err)
+	}
+	if err = writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		t.Fatal(err)
+	}
+	if err = setRestoreStatus(RestoreStatus{State: "rolled_back", OperationID: first.OperationID, SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := dm.ScheduleRestore("source.zip", first.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.Reused || second.StatusToken == first.StatusToken || second.ExpiresAt <= time.Now().Unix() {
+		t.Fatalf("expired token was not refreshed: first=%#v second=%#v", first, second)
+	}
+	if ValidateRestoreStatusToken(first.OperationID, first.StatusToken) {
+		t.Fatal("expired token still validates after refresh")
+	}
+	status, ok := GetRestoreStatusAuthorized(second.OperationID, second.StatusToken)
+	if !ok || status.OperationID != second.OperationID || status.State != "pending" {
+		t.Fatalf("authorized status = %#v, %v", status, ok)
+	}
+	if _, ok = GetRestoreStatusAuthorized("another-operation", second.StatusToken); ok {
+		t.Fatal("token authorized a different operation")
+	}
+}
+
+func TestScheduleRestoreRefreshesExpiredTerminalToken(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	first, err := dm.ScheduleRestore("source.zip", "request-terminal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth, err := readRestoreStatusAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	auth.ExpiresAt = time.Now().Add(-time.Minute).Unix()
+	if err = writeJSONAtomic(restoreStatusAuthPath(), auth); err != nil {
+		t.Fatal(err)
+	}
+	if err = os.Remove(restorePendingPath()); err != nil {
+		t.Fatal(err)
+	}
+	if err = setRestoreStatus(RestoreStatus{State: "succeeded", OperationID: first.OperationID, SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := dm.ScheduleRestore("source.zip", first.OperationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.Reused || second.StatusToken == first.StatusToken || !ValidateRestoreStatusToken(second.OperationID, second.StatusToken) {
+		t.Fatalf("terminal token was not refreshed: %#v", second)
+	}
+}
+
+func TestScheduleRestoreRepairsPendingBeforeAuthAndStatus(t *testing.T) {
+	for _, phase := range []string{"scheduled", "prepared"} {
+		t.Run(phase, func(t *testing.T) {
+			queuedSource := prepareRestoreTest(t)
+			dm := newRestoreSQLiteManager(t)
+			writeRestoreTestArchive(t, queuedSource, map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+			writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+			pending := restorePending{Phase: phase, OperationID: "request-crash", SourceName: "source.zip"}
+			if phase == "prepared" {
+				pending.SafetyBackupName = "safety.zip"
+				writeRestoreTestArchive(t, filepath.Join(BackupDir, pending.SafetyBackupName), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+			}
+			if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+				t.Fatal(err)
+			}
+			operation, err := dm.ScheduleRestore("source.zip", "request-crash")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !operation.Reused || operation.StatusToken == "" || operation.ExpiresAt == 0 {
+				t.Fatalf("operation was not repaired: %#v", operation)
+			}
+			if !ValidateRestoreStatusToken(operation.OperationID, operation.StatusToken) {
+				t.Fatal("repaired token did not validate")
+			}
+			second, err := dm.ScheduleRestore("source.zip", "request-crash")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if second.StatusToken != operation.StatusToken || second.ExpiresAt != operation.ExpiresAt {
+				t.Fatalf("repaired operation was not stable: first=%#v second=%#v", operation, second)
+			}
+			runnable, err := HasRunnableScheduledRestore()
+			if err != nil || !runnable {
+				t.Fatalf("HasRunnableScheduledRestore = %v, %v", runnable, err)
+			}
+			wantState := "pending"
+			if phase == "prepared" {
+				wantState = "quiescing"
+			}
+			if status := GetRestoreStatus(); status.State != wantState || status.OperationID != "request-crash" {
+				t.Fatalf("status = %#v", status)
+			}
+			operationID, err := RunnableScheduledRestoreOperationID()
+			if err != nil || operationID != "request-crash" {
+				t.Fatalf("RunnableScheduledRestoreOperationID = %q, %v", operationID, err)
+			}
+		})
+	}
+}
+
+func TestScheduleRestoreRejectsExternalOrEscapedSQLiteData(t *testing.T) {
+	prepareRestoreTest(t)
+	writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	dm := newRestoreSQLiteManager(t)
+	t.Setenv("DATADIR", filepath.Join(t.TempDir(), "external"))
+	if _, err := dm.ScheduleRestore("source.zip", "request-1"); err == nil {
+		t.Fatal("ScheduleRestore accepted DATADIR outside managed data")
+	}
+	dm.Operator = nil
+	if _, err := dm.ScheduleRestore("source.zip", "request-2"); err == nil {
+		t.Fatal("ScheduleRestore accepted nil database operator")
+	}
+}
+
+func TestScheduleRestoreRejectsReusedOperationAfterDatabaseTypeChanges(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	if _, err := dm.ScheduleRestore("source.zip", "request-db-change"); err != nil {
+		t.Fatal(err)
+	}
+	dm.Operator = &mysqlengine.MYSQLEngine{}
+	if _, err := dm.ScheduleRestore("source.zip", "request-db-change"); err == nil || !strings.Contains(strings.ToLower(err.Error()), "mysql") {
+		t.Fatalf("reused restore accepted external database: %v", err)
+	}
+}
+
+func TestPrepareScheduledRestoreCreatesStrictSafetyBackup(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	writeRestoreTestArchive(t, filepath.Join(BackupDir, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	operation, err := dm.ScheduleRestore("source.zip", "request-prepare")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = PrepareScheduledRestore(dm); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := readPendingRestore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending.Phase != "prepared" || pending.SafetyBackupName == "" {
+		t.Fatalf("unexpected prepared pending: %#v", pending)
+	}
+	if status := GetRestoreStatus(); status.State != "quiescing" || status.OperationID != operation.OperationID {
+		t.Fatalf("unexpected external status: %#v", status)
+	}
+	if err = validateSafetyBackup(filepath.Join(BackupDir, pending.SafetyBackupName), dm); err != nil {
+		t.Fatal(err)
+	}
+	_, _, manifest, err := inspectBackupArchiveDetailed(filepath.Join(BackupDir, pending.SafetyBackupName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range manifest.Files {
+		if strings.Contains(file.Path, "\\") {
+			t.Fatalf("v2 export path is not slash-normalized: %q", file.Path)
+		}
+	}
+	if err = PrepareScheduledRestore(dm); err != nil {
+		t.Fatalf("PrepareScheduledRestore retry failed: %v", err)
+	}
+}
+
+func TestStrictSafetyBackupUsesManagedDataDirInsteadOfDiceName(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	dm.Dice[0].BaseConfig.Name = "display-name"
+	dm.Dice[0].BaseConfig.DataDir = filepath.Join("data", "custom")
+	writeTestFile(t, "data/custom/serve.yaml", "serve config")
+	backupPath, err := dm.backupStrict(BackupSelectionAll)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = validateSafetyBackup(backupPath, dm); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGeneratedBackupSkipsProcessOwnedFiles(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	writeTestFile(t, "data/default/scripts/main.js", "// script")
+	writeTestFile(t, "data/default/scripts/runtime.lock", "locked")
+	backupPath, err := dm.Backup(BackupSelectionJS, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, entries, err := inspectBackupArchive(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Restorable {
+		t.Fatalf("generated backup is not restorable: %#v", info)
+	}
+	if _, exists := entries["data/default/scripts/runtime.lock"]; exists {
+		t.Fatal("generated backup contains process-owned lock file")
+	}
+	if _, exists := entries["data/default/scripts/main.js"]; !exists {
+		t.Fatal("generated backup omitted normal script")
+	}
+	reader, err := zip.OpenReader(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reader.Close() }()
+	for _, entry := range reader.File {
+		if entry.Name == "data/default/scripts/main.js" && entry.Mode().Perm() != 0o600 {
+			t.Fatalf("generated backup widened file mode: %v", entry.Mode().Perm())
+		}
+	}
+}
+
+func prepareApplyTest(t *testing.T, files map[string]string) {
+	t.Helper()
+	source := prepareRestoreTest(t)
+	writeRestoreTestArchive(t, source, files, true)
+	pending := restorePending{Phase: "prepared", OperationID: "op", SourceName: "source.zip", SafetyBackupName: "safety.zip"}
+	if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		t.Fatal(err)
+	}
+	if err := setRestoreStatus(RestoreStatus{State: "quiescing", OperationID: "op", SourceName: "source.zip", SafetyBackupName: "safety.zip"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestApplyRestoreUsesAppendOnlyJournalAndOverlay(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig, "data/new.txt": "added"})
+	writeTestFile(t, "data/dice.yaml", "old")
+	writeTestFile(t, "data/keep.txt", "keep")
+	if err := ApplyScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	assertRestoreTestFile(t, "data/dice.yaml", restoreTestDiceConfig)
+	assertRestoreTestFile(t, "data/new.txt", "added")
+	assertRestoreTestFile(t, "data/keep.txt", "keep")
+	if os.PathSeparator == '/' {
+		info, err := os.Stat("data/new.txt")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("restored file mode = %v, want 0600", info.Mode().Perm())
+		}
+	}
+	journalData, err := os.ReadFile(restoreJournalPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(journalData, []byte(`"phase":"intent"`)) || !bytes.Contains(journalData, []byte(`"phase":"done"`)) {
+		t.Fatalf("journal lacks intent/done records: %s", journalData)
+	}
+	journal, err := readRestoreJournal()
+	if err != nil || journal.State != "applied" {
+		t.Fatalf("journal=%#v err=%v", journal, err)
+	}
+}
+
+func TestApplyScheduledRestoreRollsBackOnRenameFailure(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig, "data/new.txt": "added"})
+	writeTestFile(t, "data/dice.yaml", "old")
+	originalRename := restoreRename
+	restoreRename = func(oldPath, newPath string) error {
+		if filepath.Base(oldPath) == "new.txt" && filepath.Clean(newPath) == filepath.Clean("data/new.txt") {
+			return errors.New("injected rename failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	t.Cleanup(func() { restoreRename = originalRename })
+	if err := ApplyScheduledRestore(); err == nil {
+		t.Fatal("ApplyScheduledRestore unexpectedly succeeded")
+	}
+	assertRestoreTestFile(t, "data/dice.yaml", "old")
+	if _, err := os.Stat("data/new.txt"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("new file remains after rollback: %v", err)
+	}
+	journal, err := readRestoreJournal()
+	if err != nil || journal.State != "rolled_back" {
+		t.Fatalf("journal=%#v err=%v", journal, err)
+	}
+	status := GetRestoreStatus()
+	if status.State != "rolling_back" || !strings.Contains(status.Message, "等待回滚") {
+		t.Fatalf("apply failure exposed a terminal status: %#v", status)
+	}
+}
+
+func TestRestoreTransactionSynthesizesSQLiteSidecars(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig, "data/default/data.db": "new-db"})
+	writeTestFile(t, "data/dice.yaml", "old")
+	writeTestFile(t, "data/default/data.db", "old-db")
+	writeTestFile(t, "data/default/data.db-wal", "old-wal")
+	writeTestFile(t, "data/default/data.db-shm", "old-shm")
+	writeTestFile(t, "data/default/data.db-journal", "old-journal")
+	if err := ApplyScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		if _, err := os.Stat("data/default/data.db" + suffix); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("sidecar remains after apply: %s", suffix)
+		}
+	}
+	if err := RecoverInterruptedRestore(); err != nil {
+		t.Fatal(err)
+	}
+	assertRestoreTestFile(t, "data/default/data.db-wal", "old-wal")
+	assertRestoreTestFile(t, "data/default/data.db-shm", "old-shm")
+	assertRestoreTestFile(t, "data/default/data.db-journal", "old-journal")
+}
+
+func TestRestoreRollbackRemovesSidecarsCreatedByNewRuntime(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig, "data/default/data.db": "new-db"})
+	writeTestFile(t, "data/dice.yaml", "old")
+	writeTestFile(t, "data/default/data.db", "old-db")
+	if err := ApplyScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		writeTestFile(t, "data/default/data.db"+suffix, "new-runtime-sidecar")
+	}
+	if err := RollbackScheduledRestore("new Runtime validation failed"); err != nil {
+		t.Fatal(err)
+	}
+	assertRestoreTestFile(t, "data/default/data.db", "old-db")
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		if _, err := os.Stat("data/default/data.db" + suffix); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("new Runtime sidecar remains after rollback: %s: %v", suffix, err)
+		}
+	}
+}
+
+func TestRecoverInterruptedRestoreAfterRestoreRenameBeforeDone(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		files      map[string]string
+		target     string
+		oldContent string
+	}{
+		{
+			name: "ordinary file",
+			files: map[string]string{
+				"data/dice.yaml": restoreTestDiceConfig,
+			},
+			target: "data/dice.yaml", oldContent: "old",
+		},
+		{
+			name: "sqlite sidecar",
+			files: map[string]string{
+				"data/dice.yaml":       restoreTestDiceConfig,
+				"data/default/data.db": "new-db",
+			},
+			target: "data/default/data.db-wal", oldContent: "old-wal",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prepareApplyTest(t, test.files)
+			writeTestFile(t, "data/dice.yaml", "old")
+			if strings.HasSuffix(test.target, "-wal") {
+				writeTestFile(t, "data/default/data.db", "old-db")
+				writeTestFile(t, test.target, test.oldContent)
+			}
+			if err := ApplyScheduledRestore(); err != nil {
+				t.Fatal(err)
+			}
+			journal, err := readRestoreJournal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err = appendJournalState(journal, "rolling_back"); err != nil {
+				t.Fatal(err)
+			}
+			entryIndex := -1
+			for index := range journal.Entries {
+				if filepath.Clean(journal.Entries[index].Target) == filepath.Clean(test.target) {
+					entryIndex = index
+					break
+				}
+			}
+			if entryIndex < 0 {
+				t.Fatalf("journal lacks target %s", test.target)
+			}
+			entry := &journal.Entries[entryIndex]
+			if err = appendJournalStep(journal, entryIndex, "remove-installed", "intent"); err != nil {
+				t.Fatal(err)
+			}
+			if err = os.Remove(entry.Target); err != nil && !errors.Is(err, os.ErrNotExist) {
+				t.Fatal(err)
+			}
+			if err = appendJournalStep(journal, entryIndex, "remove-installed", "done"); err != nil {
+				t.Fatal(err)
+			}
+			if err = appendJournalStep(journal, entryIndex, "restore-original", "intent"); err != nil {
+				t.Fatal(err)
+			}
+			if err = os.Rename(entry.Rollback, entry.Target); err != nil {
+				t.Fatal(err)
+			}
+			// Simulate a crash before restore-original done reaches the journal.
+			if err = RecoverInterruptedRestore(); err != nil {
+				t.Fatal(err)
+			}
+			assertRestoreTestFile(t, test.target, test.oldContent)
+		})
+	}
+}
+
+func TestApplyScheduledRestoreRollsBackAfterDirectorySyncFailure(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig})
+	writeTestFile(t, "data/dice.yaml", "old")
+	originalSync := restoreSyncMutationParents
+	failed := false
+	restoreSyncMutationParents = func(rootAndFiles ...string) error {
+		if err := originalSync(rootAndFiles...); err != nil {
+			return err
+		}
+		if !failed {
+			failed = true
+			return errors.New("injected directory sync failure")
+		}
+		return nil
+	}
+	t.Cleanup(func() { restoreSyncMutationParents = originalSync })
+	if err := ApplyScheduledRestore(); err == nil {
+		t.Fatal("ApplyScheduledRestore unexpectedly ignored directory sync failure")
+	}
+	assertRestoreTestFile(t, "data/dice.yaml", "old")
+}
+
+func TestRecoverInterruptedRestoreHandlesBackupIntentCrash(t *testing.T) {
+	prepareRestoreTest(t)
+	writeTestFile(t, "data/dice.yaml", "old")
+	pending := restorePending{Phase: "applying", OperationID: "op", SourceName: "source.zip", SafetyBackupName: "safety.zip"}
+	if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+		t.Fatal(err)
+	}
+	rollback := filepath.Join(restoreDir(), restoreRollbackName, "data", "dice.yaml")
+	if err := os.MkdirAll(filepath.Dir(rollback), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	journal := &restoreJournal{OperationID: "op", Entries: []restoreJournalEntry{{
+		Target: "data/dice.yaml", Rollback: rollback, HadOriginal: true,
+	}}}
+	if err := createRestoreJournal(journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := appendJournalStep(journal, 0, "backup-original", "intent"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename("data/dice.yaml", rollback); err != nil {
+		t.Fatal(err)
+	}
+	journalFile, err := os.OpenFile(restoreJournalPath(), os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = journalFile.WriteString(`{"operationId":"op"`); err != nil {
+		t.Fatal(err)
+	}
+	if err = errors.Join(journalFile.Sync(), journalFile.Close()); err != nil {
+		t.Fatal(err)
+	}
+	if err = RecoverInterruptedRestore(); err != nil {
+		t.Fatal(err)
+	}
+	assertRestoreTestFile(t, "data/dice.yaml", "old")
+	if status := GetRestoreStatus(); status.State != "rolled_back" {
+		t.Fatalf("status = %#v", status)
+	}
+	journal, err = readRestoreJournal()
+	if err != nil || journal.State != "rolled_back" {
+		t.Fatalf("journal remained corrupt after torn tail recovery: %#v, %v", journal, err)
+	}
+}
+
+func TestRecoverInterruptedRestoreKeepsSafeNoJournalPending(t *testing.T) {
+	for _, phase := range []string{"scheduled", "prepared"} {
+		t.Run(phase, func(t *testing.T) {
+			prepareRestoreTest(t)
+			pending := restorePending{Phase: phase, OperationID: "op", SourceName: "source.zip"}
+			if phase == "prepared" {
+				pending.SafetyBackupName = "safety.zip"
+			}
+			if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+				t.Fatal(err)
+			}
+			if err := setRestoreStatus(RestoreStatus{State: "pending", OperationID: "op", SourceName: "source.zip"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := RecoverInterruptedRestore(); err != nil {
+				t.Fatal(err)
+			}
+			updated, err := readPendingRestore()
+			if err != nil || updated.Phase != phase {
+				t.Fatalf("pending=%#v err=%v", updated, err)
+			}
+		})
+	}
+}
+
+func TestRecoverInterruptedRestoreDiscardsTornBeginBeforeDataChanges(t *testing.T) {
+	source := prepareRestoreTest(t)
+	writeRestoreTestArchive(t, source, map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	if err := writeJSONAtomic(restorePendingPath(), restorePending{Phase: "scheduled", OperationID: "op", SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := setRestoreStatus(RestoreStatus{State: "pending", OperationID: "op", SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(restoreJournalPath(), []byte(`{"operationId":"op","type":"begin"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecoverInterruptedRestore(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(restoreJournalPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("torn begin journal was not discarded: %v", err)
+	}
+	pending, err := readPendingRestore()
+	if err != nil || pending.Phase != "scheduled" {
+		t.Fatalf("pending changed after safe torn begin: %#v, %v", pending, err)
+	}
+	operationID, err := RunnableScheduledRestoreOperationID()
+	if err != nil || operationID != "op" {
+		t.Fatalf("runnable operation after torn begin = %q, %v", operationID, err)
+	}
+}
+
+func TestRecoverInterruptedRestoreAcceptsSucceededMetadataAfterJournalCleanup(t *testing.T) {
+	prepareRestoreTest(t)
+	if err := writeJSONAtomic(restorePendingPath(), restorePending{Phase: "applied", OperationID: "op", SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := setRestoreStatus(RestoreStatus{State: "succeeded", OperationID: "op", SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RecoverInterruptedRestore(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(restorePendingPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("succeeded pending residue was not removed: %v", err)
+	}
+}
+
+func TestRollbackScheduledRestoreRejectsUnsafePhaseWithoutJournal(t *testing.T) {
+	prepareRestoreTest(t)
+	if err := writeJSONAtomic(restorePendingPath(), restorePending{Phase: "applying", OperationID: "op", SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := RollbackScheduledRestore("must not claim rollback"); err == nil {
+		t.Fatal("RollbackScheduledRestore accepted applying pending without journal")
+	}
+}
+
+func TestBuildRestoreJournalRejectsLinkedTargetDirectory(t *testing.T) {
+	prepareRestoreTest(t)
+	external := t.TempDir()
+	if err := os.Symlink(external, filepath.Join("data", "link")); err != nil {
+		t.Skipf("current environment cannot create symlink: %v", err)
+	}
+	staged := filepath.Join(restoreDir(), restoreStagingName)
+	writeTestFile(t, filepath.Join(staged, "data", "link", "outside.txt"), "unsafe")
+	if _, err := buildRestoreJournal("op", staged); err == nil {
+		t.Fatal("buildRestoreJournal accepted linked target directory")
+	}
+	if _, err := os.Stat(filepath.Join(external, "outside.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("restore escaped through linked target: %v", err)
+	}
+}
+
+func TestRecoverInterruptedRestoreRejectsAmbiguousOrMismatchedOperation(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		pendingID  string
+		journalID  string
+		withIntent bool
+	}{
+		{name: "operation mismatch", pendingID: "pending", journalID: "journal"},
+		{name: "ambiguous move", pendingID: "op", journalID: "op", withIntent: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			prepareRestoreTest(t)
+			pending := restorePending{Phase: "applying", OperationID: test.pendingID, SafetyBackupName: "safety.zip"}
+			if err := writeJSONAtomic(restorePendingPath(), pending); err != nil {
+				t.Fatal(err)
+			}
+			journal := &restoreJournal{OperationID: test.journalID, Entries: []restoreJournalEntry{{
+				Target: "data/missing.txt", Rollback: filepath.Join(restoreDir(), restoreRollbackName, "data/missing.txt"), HadOriginal: true,
+			}}}
+			if err := createRestoreJournal(journal); err != nil {
+				t.Fatal(err)
+			}
+			if test.withIntent {
+				if err := appendJournalStep(journal, 0, "backup-original", "intent"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := RecoverInterruptedRestore(); err == nil {
+				t.Fatal("RecoverInterruptedRestore accepted ambiguous transaction")
+			}
+		})
+	}
+}
+
+func TestCommitIsOnlyIrreversiblePointAndSuccessFollowsRuntimePublish(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig})
+	writeTestFile(t, "data/dice.yaml", "old")
+	if err := ApplyScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	if err := CommitScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	journal, err := readRestoreJournal()
+	if err != nil || journal.State != "committed" {
+		t.Fatalf("journal=%#v err=%v", journal, err)
+	}
+	if status := GetRestoreStatus(); status.State == "succeeded" {
+		t.Fatal("commit published succeeded before Runtime publication")
+	}
+	committed, err := HasCommittedRestore()
+	if err != nil || !committed {
+		t.Fatalf("HasCommittedRestore = %v, %v", committed, err)
+	}
+	if err = MarkScheduledRestoreSucceeded(); err != nil {
+		t.Fatal(err)
+	}
+	if status := GetRestoreStatus(); status.State != "succeeded" {
+		t.Fatalf("status = %#v", status)
+	}
+	if _, err = os.Stat(restoreJournalPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("journal remains after success: %v", err)
+	}
+}
+
+func TestCommittedCleanupFailureDoesNotBecomeRollbackFailure(t *testing.T) {
+	prepareApplyTest(t, map[string]string{"data/dice.yaml": restoreTestDiceConfig})
+	writeTestFile(t, "data/dice.yaml", "old")
+	if err := ApplyScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	originalRemoveAll := restoreRemoveAll
+	restoreRemoveAll = func(target string) error {
+		if filepath.Base(target) == restoreRollbackName {
+			return errors.New("injected cleanup failure")
+		}
+		return os.RemoveAll(target)
+	}
+	t.Cleanup(func() { restoreRemoveAll = originalRemoveAll })
+	if err := CommitScheduledRestore(); err != nil {
+		t.Fatalf("commit should remain successful after cleanup failure: %v", err)
+	}
+	journal, err := readRestoreJournal()
+	if err != nil || journal.State != "committed" {
+		t.Fatalf("journal=%#v err=%v", journal, err)
+	}
+	if err = RollbackScheduledRestore("must not rollback"); err == nil {
+		t.Fatal("committed restore was rolled back")
+	}
+	restoreRemoveAll = originalRemoveAll
+	if err = MarkScheduledRestoreSucceeded(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeleteAndCleanBackupRespectPendingRestore(t *testing.T) {
+	prepareRestoreTest(t)
+	writeTestFile(t, filepath.Join(BackupDir, "source.zip"), "source")
+	writeTestFile(t, filepath.Join(BackupDir, "old.zip"), "old")
+	if err := writeJSONAtomic(restorePendingPath(), restorePending{OperationID: "op", Phase: "scheduled", SourceName: "source.zip"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteBackup("source.zip"); err == nil {
+		t.Fatal("DeleteBackup removed in-use source")
+	}
+	if err := DeleteBackup("SOURCE.ZIP"); err == nil || !strings.Contains(err.Error(), "使用") {
+		t.Fatalf("DeleteBackup did not recognize case-folded in-use source: %v", err)
+	}
+	dm := &DiceManager{BackupCleanStrategy: BackupCleanStrategyByCount, BackupCleanKeepCount: 0}
+	if err := dm.BackupClean(false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(BackupDir, "source.zip")); err != nil {
+		t.Fatalf("BackupClean removed in-use source: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(BackupDir, "old.zip")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("BackupClean did not remove old backup: %v", err)
+	}
+}
+
+func TestOpenBackupArchiveReturnsVerifiedHandle(t *testing.T) {
+	prepareRestoreTest(t)
+	filename := filepath.Join(BackupDir, "source.zip")
+	writeTestFile(t, filename, "archive bytes")
+	file, info, err := OpenBackupArchive("source.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(info, openedInfo) {
+		t.Fatal("returned info does not describe opened archive")
+	}
+	data, err := io.ReadAll(file)
+	if err != nil || string(data) != "archive bytes" {
+		t.Fatalf("opened archive = %q, %v", data, err)
+	}
+}
+
+func TestScheduleRestoreRejectsLinkedBackupRootBeforeCleanup(t *testing.T) {
+	prepareRestoreTest(t)
+	dm := newRestoreSQLiteManager(t)
+	external := t.TempDir()
+	writeTestFile(t, filepath.Join(external, restoreDirName, "sentinel"), "keep")
+	writeRestoreTestArchive(t, filepath.Join(external, "source.zip"), map[string]string{"data/dice.yaml": restoreTestDiceConfig}, true)
+	if err := os.RemoveAll(BackupDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, BackupDir); err != nil {
+		t.Skipf("current environment cannot create directory symlink: %v", err)
+	}
+	if _, err := dm.ScheduleRestore("source.zip", "request-linked-root"); err == nil {
+		t.Fatal("ScheduleRestore accepted linked backup root")
+	}
+	assertRestoreTestFile(t, filepath.Join(external, restoreDirName, "sentinel"), "keep")
+}
+
+func TestBackupArchivePathRejectsSymlink(t *testing.T) {
+	prepareRestoreTest(t)
+	external := filepath.Join(t.TempDir(), "external.zip")
+	writeTestFile(t, external, "external")
+	if err := os.Symlink(external, filepath.Join(BackupDir, "linked.zip")); err != nil {
+		t.Skipf("current environment cannot create symlink: %v", err)
+	}
+	if _, err := BackupArchivePath("linked.zip"); err == nil {
+		t.Fatal("BackupArchivePath accepted symlink")
+	}
+	if file, _, err := OpenBackupArchive("linked.zip"); err == nil {
+		_ = file.Close()
+		t.Fatal("OpenBackupArchive accepted symlink")
+	}
+}

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -668,7 +668,12 @@ func (d *Dice) JsInit() {
 		// `)
 		_, _ = vm.RunString(`Object.freeze(seal);Object.freeze(seal.deck);Object.freeze(seal.coc);Object.freeze(seal.ext);Object.freeze(seal.vars);`)
 	})
+	loopDone := make(chan struct{})
+	d.jsLoopMu.Lock()
+	d.jsLoopDone = loopDone
+	d.jsLoopMu.Unlock()
 	go func() {
+		defer close(loopDone)
 		defer func() {
 			if r := recover(); r != nil {
 				d.Logger.Errorf("JS核心执行异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -692,6 +697,7 @@ func (d *Dice) JsShutdown() {
 }
 
 func (d *Dice) jsClear() {
+	sealws.GlobalConnManager.CloseAll()
 	// Wrapper 架构：不再调用 ExtRemove，只清空 JsExtRegistry
 	// 注意：不标记 wrapper 为 IsDeleted，否则重载期间消息到达会导致 wrapper 被移除
 	// IsDeleted 只在 JsDelete/ExtRemove（永久删除脚本）时设置

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -697,7 +697,6 @@ func (d *Dice) JsShutdown() {
 }
 
 func (d *Dice) jsClear() {
-	sealws.GlobalConnManager.CloseAll()
 	// Wrapper 架构：不再调用 ExtRemove，只清空 JsExtRegistry
 	// 注意：不标记 wrapper 为 IsDeleted，否则重载期间消息到达会导致 wrapper 被移除
 	// IsDeleted 只在 JsDelete/ExtRemove（永久删除脚本）时设置

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -40,10 +41,25 @@ var windowsReservedDiceNames = map[string]struct{}{
 	"LPT6": {}, "LPT7": {}, "LPT8": {}, "LPT9": {},
 }
 
-// ValidateDiceConfigNames ensures every Dice name is a portable single path
-// segment before Dice.Init derives a data directory from it.
+// ValidateDiceConfigNames ensures every Dice name is a single path segment
+// before Dice.Init derives a data directory from it. Windows-specific
+// restrictions are only enforced on platforms that actually have those file
+// system rules, preserving legacy Linux/macOS installations.
 func ValidateDiceConfigNames(configs []BaseConfig) error {
+	return validateDiceConfigNames(configs, false)
+}
+
+// ValidateDiceConfigNamesPortable applies the strictest cross-platform rules
+// and is used when validating backup archives that may be restored on another
+// operating system.
+func ValidateDiceConfigNamesPortable(configs []BaseConfig) error {
+	return validateDiceConfigNames(configs, true)
+}
+
+func validateDiceConfigNames(configs []BaseConfig, portable bool) error {
 	names := make([]string, 0, len(configs))
+	enforceWindowsRules := portable || runtime.GOOS == "windows"
+	caseInsensitiveFS := portable || runtime.GOOS == "windows" || runtime.GOOS == "darwin"
 	for index, config := range configs {
 		name := config.Name
 		if name == "" || strings.TrimSpace(name) != name {
@@ -52,10 +68,13 @@ func ValidateDiceConfigNames(configs []BaseConfig) error {
 		if name == "." || name == ".." || filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
 			return fmt.Errorf("dice 名称 %q 不是安全的单一路径段", name)
 		}
-		if strings.ContainsAny(name, `/\\:<>"|?*`) {
-			return fmt.Errorf("dice 名称 %q 含路径分隔符或非法字符", name)
+		if strings.ContainsAny(name, `/\`) {
+			return fmt.Errorf("dice 名称 %q 含路径分隔符", name)
 		}
-		if strings.HasSuffix(name, ".") {
+		if enforceWindowsRules && strings.ContainsAny(name, `:<>"|?*`) {
+			return fmt.Errorf("dice 名称 %q 含 Windows 非法字符", name)
+		}
+		if enforceWindowsRules && strings.HasSuffix(name, ".") {
 			return fmt.Errorf("dice 名称 %q 不能以点结尾", name)
 		}
 		for _, current := range name {
@@ -63,16 +82,20 @@ func ValidateDiceConfigNames(configs []BaseConfig) error {
 				return fmt.Errorf("dice 名称 %q 含控制字符", name)
 			}
 		}
-		base := name
-		if dot := strings.IndexByte(base, '.'); dot >= 0 {
-			base = base[:dot]
+		if enforceWindowsRules {
+			base := name
+			if dot := strings.IndexByte(base, '.'); dot >= 0 {
+				base = base[:dot]
+			}
+			if _, reserved := windowsReservedDiceNames[strings.ToUpper(base)]; reserved {
+				return fmt.Errorf("dice 名称 %q 是 Windows 保留设备名", name)
+			}
 		}
-		if _, reserved := windowsReservedDiceNames[strings.ToUpper(base)]; reserved {
-			return fmt.Errorf("dice 名称 %q 是 Windows 保留设备名", name)
-		}
-		for _, previous := range names {
-			if strings.EqualFold(previous, name) {
-				return fmt.Errorf("dice 名称 %q 与 %q 仅大小写不同", name, previous)
+		if caseInsensitiveFS {
+			for _, previous := range names {
+				if strings.EqualFold(previous, name) {
+					return fmt.Errorf("dice 名称 %q 与 %q 仅大小写不同", name, previous)
+				}
 			}
 		}
 		names = append(names, name)

--- a/dice/dice_manager.go
+++ b/dice/dice_manager.go
@@ -1,8 +1,11 @@
 package dice
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -28,6 +31,54 @@ type VersionInfo struct {
 
 // MaxTrayTooltipPrefixLength 自定义托盘提示前缀的最大字符数。
 const MaxTrayTooltipPrefixLength = 10
+
+var windowsReservedDiceNames = map[string]struct{}{
+	"CON": {}, "PRN": {}, "AUX": {}, "NUL": {}, "CLOCK$": {},
+	"COM1": {}, "COM2": {}, "COM3": {}, "COM4": {}, "COM5": {},
+	"COM6": {}, "COM7": {}, "COM8": {}, "COM9": {},
+	"LPT1": {}, "LPT2": {}, "LPT3": {}, "LPT4": {}, "LPT5": {},
+	"LPT6": {}, "LPT7": {}, "LPT8": {}, "LPT9": {},
+}
+
+// ValidateDiceConfigNames ensures every Dice name is a portable single path
+// segment before Dice.Init derives a data directory from it.
+func ValidateDiceConfigNames(configs []BaseConfig) error {
+	names := make([]string, 0, len(configs))
+	for index, config := range configs {
+		name := config.Name
+		if name == "" || strings.TrimSpace(name) != name {
+			return fmt.Errorf("第 %d 个 Dice 名称为空或含首尾空白", index+1)
+		}
+		if name == "." || name == ".." || filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
+			return fmt.Errorf("dice 名称 %q 不是安全的单一路径段", name)
+		}
+		if strings.ContainsAny(name, `/\\:<>"|?*`) {
+			return fmt.Errorf("dice 名称 %q 含路径分隔符或非法字符", name)
+		}
+		if strings.HasSuffix(name, ".") {
+			return fmt.Errorf("dice 名称 %q 不能以点结尾", name)
+		}
+		for _, current := range name {
+			if current < 0x20 {
+				return fmt.Errorf("dice 名称 %q 含控制字符", name)
+			}
+		}
+		base := name
+		if dot := strings.IndexByte(base, '.'); dot >= 0 {
+			base = base[:dot]
+		}
+		if _, reserved := windowsReservedDiceNames[strings.ToUpper(base)]; reserved {
+			return fmt.Errorf("dice 名称 %q 是 Windows 保留设备名", name)
+		}
+		for _, previous := range names {
+			if strings.EqualFold(previous, name) {
+				return fmt.Errorf("dice 名称 %q 与 %q 仅大小写不同", name, previous)
+			}
+		}
+		names = append(names, name)
+	}
+	return nil
+}
 
 type GroupNameCacheItem struct {
 	Name string
@@ -89,8 +140,17 @@ type DiceManager struct { //nolint:revive
 	JsRegistry           *require.Registry
 	UpdateSealdiceByFile func(packName string) bool // 使用指定压缩包升级海豹，如果出错返回false，如果成功进程会自动结束
 
-	ContainerMode bool          // 容器模式：禁用内置适配器，不允许使用内置Lagrange和旧的内置Gocq
-	CleanupFlag   atomic.Uint32 // 1 为正在清理，0为普通状态
+	ContainerMode            bool          // 容器模式：禁用内置适配器，不允许使用内置Lagrange和旧的内置Gocq
+	CleanupFlag              atomic.Uint32 // 0 为运行中，1 为静默中，2 为已完成释放
+	runtimeCtx               context.Context
+	runtimeCancel            context.CancelFunc
+	runtimeMu                sync.Mutex
+	runtimeClosing           bool
+	runtimeListenAddress     string
+	runtimeConfiguredAddress string
+	runtimeWG                sync.WaitGroup
+	quiescePhase             lifecyclePhase
+	finalizePhase            lifecyclePhase
 }
 
 type Configs struct { //nolint:revive
@@ -240,9 +300,82 @@ func (dm *DiceManager) LoadDice() {
 	}
 }
 
+// SetRuntimeContext 设置当前 Runtime 的取消域，必须在 InitDice 前调用。
+func (dm *DiceManager) SetRuntimeContext(ctx context.Context, cancel context.CancelFunc) {
+	dm.runtimeMu.Lock()
+	defer dm.runtimeMu.Unlock()
+	dm.runtimeCtx = ctx
+	dm.runtimeCancel = cancel
+	dm.runtimeClosing = false
+}
+
+// SetRuntimeServeAddress separates the process listener from the address that
+// should be persisted for the next process start.
+func (dm *DiceManager) SetRuntimeServeAddress(listenAddress, configuredAddress string) {
+	dm.runtimeMu.Lock()
+	defer dm.runtimeMu.Unlock()
+	dm.runtimeListenAddress = listenAddress
+	dm.runtimeConfiguredAddress = configuredAddress
+	dm.ServeAddress = listenAddress
+}
+
+func (dm *DiceManager) context() context.Context {
+	if dm.runtimeCtx == nil {
+		return context.Background()
+	}
+	return dm.runtimeCtx
+}
+
+func (dm *DiceManager) goRuntime(fn func(context.Context)) bool {
+	dm.runtimeMu.Lock()
+	if dm.runtimeClosing {
+		dm.runtimeMu.Unlock()
+		return false
+	}
+	ctx := dm.context()
+	dm.runtimeWG.Add(1)
+	dm.runtimeMu.Unlock()
+	go func() {
+		defer dm.runtimeWG.Done()
+		fn(ctx)
+	}()
+	return true
+}
+
+// GoRuntime 注册属于当前 Runtime generation 的后台任务。
+// Runtime 进入关闭阶段后会拒绝新任务，避免 Wait 与 Add 并发。
+func (dm *DiceManager) GoRuntime(fn func(context.Context)) bool {
+	if fn == nil {
+		return false
+	}
+	return dm.goRuntime(fn)
+}
+
+func (dm *DiceManager) beginRuntimeTask() (func(), bool) {
+	dm.runtimeMu.Lock()
+	defer dm.runtimeMu.Unlock()
+	if dm.runtimeClosing {
+		return nil, false
+	}
+	dm.runtimeWG.Add(1)
+	return dm.runtimeWG.Done, true
+}
+
 func (dm *DiceManager) Save() {
 	var dc Configs
-	dc.ServeAddress = dm.ServeAddress
+	dm.runtimeMu.Lock()
+	serveAddress := dm.ServeAddress
+	if dm.runtimeListenAddress != "" {
+		if serveAddress != dm.runtimeListenAddress {
+			dm.runtimeConfiguredAddress = serveAddress
+			dm.ServeAddress = dm.runtimeListenAddress
+		}
+		if dm.runtimeConfiguredAddress != "" {
+			serveAddress = dm.runtimeConfiguredAddress
+		}
+	}
+	dm.runtimeMu.Unlock()
+	dc.ServeAddress = serveAddress
 	dc.TrayTooltip = dm.GetTrayTooltip()
 	dc.HelpDocEngineType = dm.HelpDocEngineType
 	dc.UIPasswordSalt = dm.UIPasswordSalt
@@ -330,7 +463,7 @@ func (dm *DiceManager) InitDice(writer *logger.UIWriter) {
 		i.Init(dm.Operator, writer)
 	}
 
-	go func() {
+	dm.goRuntime(func(ctx context.Context) {
 		defer func() {
 			if r := recover(); r != nil {
 				log.Warn("帮助文档加载失败。可能是由于退出程序过快，帮助文档还未加载完成所致", r)
@@ -339,9 +472,14 @@ func (dm *DiceManager) InitDice(writer *logger.UIWriter) {
 				}
 			}
 		}()
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		// 加载帮助
 		dm.InitHelp()
-	}()
+	})
 
 	dm.ResetAutoBackup()
 	dm.ResetBackupClean()

--- a/dice/execute_new_db_nocgo_test.go
+++ b/dice/execute_new_db_nocgo_test.go
@@ -12,6 +12,7 @@ package dice
 // execute_new_db_cgo_test.go.
 
 import (
+	_ "github.com/ncruces/go-sqlite3/embed"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
 

--- a/dice/im_session.go
+++ b/dice/im_session.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -884,8 +885,37 @@ func (ctx *MsgContext) fillPrivilege(msg *Message) int {
 	return ctx.PrivilegeLevel
 }
 
+func runDiceRuntimeTask(d *Dice, task func()) {
+	runDiceRuntimeTaskContext(d, func(context.Context) { task() })
+}
+
+func runDiceRuntimeTaskContext(d *Dice, task func(context.Context)) bool {
+	if d != nil && d.Parent != nil {
+		return d.Parent.GoRuntime(task)
+	}
+	go task(context.Background())
+	return true
+}
+
+func beginDiceRuntimeTask(d *Dice) (func(), bool) {
+	if d == nil || d.Parent == nil {
+		return func() {}, true
+	}
+	return d.Parent.beginRuntimeTask()
+}
+
 func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 	d := s.Parent
+	if d == nil {
+		return
+	}
+	if d.Parent != nil {
+		done, ok := d.Parent.beginRuntimeTask()
+		if !ok {
+			return
+		}
+		defer done()
+	}
 
 	mctx := &MsgContext{}
 	mctx.Dice = d
@@ -1185,7 +1215,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 			if runInSync {
 				f()
 			} else {
-				go f()
+				runDiceRuntimeTask(d, f)
 			}
 		} else {
 			if mctx.PrivilegeLevel == -30 {
@@ -1239,7 +1269,7 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 							if runInSync {
 								notCommandReceiveCall()
 							} else {
-								go notCommandReceiveCall()
+								runDiceRuntimeTask(d, notCommandReceiveCall)
 							}
 						}
 					}
@@ -1255,6 +1285,16 @@ func (s *IMSession) Execute(ep *EndPointInfo, msg *Message, runInSync bool) {
 // 这个 ExcuteNew 方法优化了对消息段的解析，其他平台应当尽快实现消息段解析并使用这个方法
 func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 	d := s.Parent
+	if d == nil {
+		return
+	}
+	if d.Parent != nil {
+		done, ok := d.Parent.beginRuntimeTask()
+		if !ok {
+			return
+		}
+		defer done()
+	}
 
 	mctx := &MsgContext{}
 	mctx.Dice = d
@@ -1476,7 +1516,7 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 	// Note(Szzrain): 赋值临时变量，不然有些地方没法用
 	SetTempVars(mctx, msg.Sender.Nickname)
 	if cmdArgs != nil {
-		go s.PreTriggerCommand(mctx, msg, cmdArgs)
+		runDiceRuntimeTask(d, func() { s.PreTriggerCommand(mctx, msg, cmdArgs) })
 	} else {
 		// if cmdArgs == nil will execute this block
 		if mctx.PrivilegeLevel == -30 {
@@ -1525,7 +1565,7 @@ func (s *IMSession) ExecuteNew(ep *EndPointInfo, msg *Message) {
 							}
 						}
 
-						go notCommandReceiveCall()
+						runDiceRuntimeTask(d, notCommandReceiveCall)
 					}
 				}
 			}
@@ -1671,7 +1711,7 @@ func (s *IMSession) OnGroupJoined(ctx *MsgContext, msg *Message) {
 	}
 	time.Sleep(2 * time.Second)
 	groupName := dm.TryGetGroupName(msg.GroupID)
-	go func() {
+	welcomeTask := func(runtimeCtx context.Context) {
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorf("入群致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -1679,16 +1719,32 @@ func (s *IMSession) OnGroupJoined(ctx *MsgContext, msg *Message) {
 		}()
 
 		// 稍作等待后发送入群致词
-		time.Sleep(2 * time.Second)
+		timer := time.NewTimer(2 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-runtimeCtx.Done():
+			return
+		case <-timer.C:
+		}
 
 		ctx.Player = &GroupPlayerInfo{}
 		log.Infof("发送入群致辞，群: <%s>(%s)", groupName, msg.GroupID)
 		text := DiceFormatTmpl(ctx, "核心:骰子进群")
 		for _, i := range ctx.SplitText(text) {
+			select {
+			case <-runtimeCtx.Done():
+				return
+			default:
+			}
 			doSleepQQ(ctx)
 			ReplyGroup(ctx, msg, strings.TrimSpace(i))
 		}
-	}()
+	}
+	if d.Parent != nil {
+		d.Parent.GoRuntime(welcomeTask)
+	} else {
+		go welcomeTask(context.Background())
+	}
 	txt := fmt.Sprintf("加入群组: <%s>(%s)", groupName, msg.GroupID)
 	log.Info(txt)
 	ctx.Notice(txt, NoticeTypeGroup)
@@ -1891,7 +1947,7 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 		noticeCtx.Notice(fmt.Sprintf("自动退群任务开始：本轮预计处理 %d 个群。", len(selectedGroupEndpoints)), NoticeTypeInactive)
 	}
 
-	go func() {
+	quitTask := func(runtimeCtx context.Context) {
 		defer func() {
 			if r := recover(); r != nil {
 				log := zap.S().Named(logger.LogKeyAdapter)
@@ -1903,6 +1959,11 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 		cancelled := 0
 		quitStarted := 0
 		for i, pair := range selectedGroupEndpoints {
+			select {
+			case <-runtimeCtx.Done():
+				return
+			default:
+			}
 			grp := pair.Group
 			ep := pair.Endpoint
 			if !isAutoQuitEndpointReady(grp, ep, "QQ", "send") {
@@ -1924,7 +1985,13 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 			msgText := DiceFormatTmpl(msgCtx, "核心:骰子自动退群告别语")
 			ep.Adapter.SendToGroup(msgCtx, grp.GroupID, msgText, "")
 			// 退群在退群消息延迟两秒后发送，确保消息发送完成
-			time.Sleep(2 * time.Second)
+			timer := time.NewTimer(2 * time.Second)
+			select {
+			case <-runtimeCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
 			if !isAutoQuitEndpointReady(grp, ep, "QQ", "quit") {
 				s.Parent.Logger.Infof("自动退群已取消: 当前账号状态发生变化，本次不再继续退群。group=%s endpoint=%s", grp.GroupID, ep.UserID)
 				cancelled++
@@ -1943,12 +2010,23 @@ func (s *IMSession) LongTimeQuitInactiveGroupReborn(threshold time.Time, groupsP
 			// 生成一个随机值（8~11秒随机）
 			randomSleep := time.Duration(rand.Intn(3000)+8000) * time.Millisecond
 			logger.M().Infof("退群等待，等待 %f 秒后继续", randomSleep.Seconds())
-			time.Sleep(randomSleep)
+			timer = time.NewTimer(randomSleep)
+			select {
+			case <-runtimeCtx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
 		}
 		if summaryMode && noticeCtx != nil {
 			noticeCtx.Notice(fmt.Sprintf("自动退群任务结束：候选 %d 个，开始处理 %d 个，已发起退群 %d 个，跳过 %d 个，取消 %d 个。", len(selectedGroupEndpoints), processed, quitStarted, skipped, cancelled), NoticeTypeInactive)
 		}
-	}()
+	}
+	if s.Parent.Parent != nil {
+		s.Parent.Parent.GoRuntime(quitTask)
+	} else {
+		go quitTask(context.Background())
+	}
 }
 
 // FormatBlacklistReasons 格式化黑名单原因文本
@@ -2652,7 +2730,7 @@ func (d *Dice) NoticeForEveryEndpoint(txt string, allowCrossPlatform bool, notic
 			}
 		}
 	}
-	go foo()
+	runDiceRuntimeTask(d, foo)
 }
 
 // NoticeCrossPlatform 优先用当前账号发送，并为其他平台寻找第一个启用账号。
@@ -2693,7 +2771,7 @@ func (ctx *MsgContext) NoticeCrossPlatform(txt string, noticeTypes ...NoticeType
 			ctx.Dice.Logger.Errorf("未能发送来自%s的通知：%s", platform, txt)
 		}
 	}
-	go foo()
+	runDiceRuntimeTask(ctx.Dice, foo)
 }
 
 // Notice 使用当前消息上下文的账号发送指定分类通知。
@@ -2740,7 +2818,7 @@ func (ctx *MsgContext) Notice(txt string, noticeTypes ...NoticeType) {
 			}
 		}
 	}
-	go foo()
+	runDiceRuntimeTask(ctx.Dice, foo)
 }
 
 var randSourceSplitKey = rand2.NewSource(uint64(time.Now().Unix()))

--- a/dice/package_disk_space_windows.go
+++ b/dice/package_disk_space_windows.go
@@ -3,6 +3,7 @@
 package dice
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -24,8 +25,22 @@ func platformPackageDiskSpace(path string) (packageDiskSpace, error) {
 	if err := windows.GetDiskFreeSpaceEx(pathPtr, &available, &total, &totalFree); err != nil {
 		return packageDiskSpace{}, err
 	}
+	volumeName := strings.ToUpper(filepath.VolumeName(absPath))
+	volume := volumeName
+	root := absPath
+	if volumeName != "" {
+		root = volumeName + `\`
+	} else if index := strings.Index(absPath, `\`); index >= 0 {
+		root = absPath[:index+1]
+	}
+	if rootPtr, rootErr := windows.UTF16PtrFromString(root); rootErr == nil {
+		var serial uint32
+		if windows.GetVolumeInformation(rootPtr, nil, 0, &serial, nil, nil, nil, 0) == nil {
+			volume = fmt.Sprintf("%s:%08X", volumeName, serial)
+		}
+	}
 	return packageDiskSpace{
-		Volume:    strings.ToUpper(filepath.VolumeName(absPath)),
+		Volume:    volume,
 		Available: available,
 		Total:     total,
 	}, nil

--- a/dice/platform_adapter_discord.go
+++ b/dice/platform_adapter_discord.go
@@ -33,7 +33,7 @@ func (pa *PlatformAdapterDiscord) GetGroupInfoAsync(groupID string) {
 	if pa.IntentSession == nil {
 		return
 	}
-	go pa.updateChannelNum()
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, pa.updateChannelNum)
 	logger := pa.EndPoint.Session.Parent.Logger
 	dm := pa.EndPoint.Session.Parent.Parent
 	channel, err := pa.IntentSession.Channel(ExtractDiscordChannelID(groupID))

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -9,6 +9,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Szzrain/dodo-open-go/client"
@@ -26,6 +28,10 @@ type PlatformAdapterDodo struct {
 	WebSocket         websocket.Client                                        `json:"-"        yaml:"-"`
 	UserPermCache     *SyncMap[string, *SyncMap[string, *GuildPermCacheItem]] `json:"-"        yaml:"-"`
 	RetryConnectTimes int                                                     `json:"-"        yaml:"-"` // 重连次数
+	runtimeMu         sync.Mutex
+	runtimeStopping   atomic.Bool
+	runtimeStop       chan struct{}
+	listenDone        chan struct{}
 }
 
 const (
@@ -58,13 +64,28 @@ func (pa *PlatformAdapterDodo) GetGroupInfoAsync(groupID string) {
 
 func (pa *PlatformAdapterDodo) Serve() int {
 	logger := pa.EndPoint.Session.Parent.Logger
+	runtimeStop := make(chan struct{})
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		return 0
+	}
+	pa.runtimeStop = runtimeStop
+	pa.listenDone = nil
+	pa.runtimeMu.Unlock()
 	clientID := pa.ClientID
 	token := pa.Token
 	instance, err := client.New(clientID, token, client.WithTimeout(time.Second*3))
-	pa.Client = instance
 	if err != nil {
 		return 1
 	}
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		return 0
+	}
+	pa.Client = instance
+	pa.runtimeMu.Unlock()
 	selfid, err := instance.GetBotInfo(context.Background())
 	if err == nil {
 		pa.EndPoint.UserID = FormatDiceIDDodo(selfid.DodoSourceId)
@@ -102,12 +123,28 @@ func (pa *PlatformAdapterDodo) Serve() int {
 	msgHandlers.PersonalMessage = personalMessageHandler
 
 	ws, _ := websocket.New(instance, websocket.WithMessageHandlers(msgHandlers))
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		if ws != nil {
+			ws.Close()
+		}
+		return 0
+	}
+	pa.WebSocket = ws
+	pa.runtimeMu.Unlock()
 	// 主动连接到 WebSocket 服务器
 	if err = ws.Connect(); err != nil {
 		logger.Errorf("Dodo连接错误:%s", err.Error())
 		for pa.RetryConnectTimes <= 5 {
 			pa.RetryConnectTimes++
-			time.Sleep(time.Second * 5)
+			timer := time.NewTimer(time.Second * 5)
+			select {
+			case <-runtimeStop:
+				timer.Stop()
+				return 0
+			case <-timer.C:
+			}
 			pa.EndPoint.Session.Parent.Logger.Infof("Dodo 尝试重连, 第 [%d/5] 次", pa.RetryConnectTimes)
 			ws.Close()
 			if err = ws.Connect(); err == nil {
@@ -119,6 +156,11 @@ func (pa *PlatformAdapterDodo) Serve() int {
 			}
 		}
 		if err != nil {
+			select {
+			case <-runtimeStop:
+				return 0
+			default:
+			}
 			logger.Errorf("Dodo 短时间内重试次数过多，先行中断")
 			pa.EndPoint.State = 3
 			d := pa.EndPoint.Session.Parent
@@ -127,7 +169,10 @@ func (pa *PlatformAdapterDodo) Serve() int {
 			return 1
 		}
 	}
-	pa.WebSocket = ws
+	if pa.runtimeStopping.Load() {
+		ws.Close()
+		return 0
+	}
 	pa.EndPoint.State = 1
 	pa.RetryConnectTimes = 0
 	pa.EndPoint.Session.Parent.Logger.Infof("Dodo 连接成功")
@@ -135,11 +180,21 @@ func (pa *PlatformAdapterDodo) Serve() int {
 	d := pa.EndPoint.Session.Parent
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
+	listenDone := make(chan struct{})
+	pa.runtimeMu.Lock()
+	pa.listenDone = listenDone
+	pa.runtimeMu.Unlock()
 	go func() {
+		defer close(listenDone)
 		err := ws.Listen()
 		if err != nil {
 			logger.Errorf("Dodo监听错误:%s", err.Error())
-			if pa.EndPoint.Enable {
+			select {
+			case <-runtimeStop:
+				return
+			default:
+			}
+			if pa.EndPoint.Enable && !pa.runtimeStopping.Load() {
 				pa.EndPoint.State = 3
 				d := pa.EndPoint.Session.Parent
 				d.LastUpdatedTime = time.Now().Unix()
@@ -287,6 +342,9 @@ func (pa *PlatformAdapterDodo) DoRelogin() bool {
 		_ = recover()
 	}()
 	logger := pa.EndPoint.Session.Parent.Logger
+	if pa.runtimeStopping.Load() {
+		return false
+	}
 	if pa.WebSocket != nil {
 		pa.WebSocket.Close()
 		pa.Client = nil
@@ -315,7 +373,9 @@ func (pa *PlatformAdapterDodo) SetEnable(enable bool) {
 		logger.Infof("正在启用Dodo……")
 		pa.Serve()
 	} else {
-		pa.WebSocket.Close()
+		if pa.WebSocket != nil {
+			pa.WebSocket.Close()
+		}
 		pa.Client = nil
 		pa.WebSocket = nil
 		pa.EndPoint.State = 0

--- a/dice/platform_adapter_dodo.go
+++ b/dice/platform_adapter_dodo.go
@@ -44,8 +44,18 @@ type GuildPermCacheItem struct {
 	time int64
 }
 
+func (pa *PlatformAdapterDodo) clientSnapshot() client.Client {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.Client
+}
+
 func (pa *PlatformAdapterDodo) GetGroupInfoAsync(groupID string) {
-	info, err := pa.Client.GetChannelInfo(context.Background(), &model.GetChannelInfoReq{
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return
+	}
+	info, err := instance.GetChannelInfo(context.Background(), &model.GetChannelInfoReq{
 		ChannelId: ExtractDodoGroupID(groupID),
 	})
 	if err != nil {
@@ -289,7 +299,11 @@ func (pa *PlatformAdapterDodo) checkGuildAdmin(guildID string, userID string) st
 
 func (pa *PlatformAdapterDodo) refreshPermCache(guildID string, userID string) (aperm int64) {
 	aperm = int64(0)
-	list, err := pa.Client.GetMemberRoleList(context.Background(), &model.GetMemberRoleListReq{
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return aperm
+	}
+	list, err := instance.GetMemberRoleList(context.Background(), &model.GetMemberRoleListReq{
 		IslandSourceId: guildID,
 		DodoSourceId:   userID,
 	})
@@ -313,7 +327,7 @@ func (pa *PlatformAdapterDodo) refreshPermCache(guildID string, userID string) (
 			time: time.Now().Unix(),
 		})
 	} else {
-		info, err := pa.Client.GetIslandInfo(context.Background(), &model.GetIslandInfoReq{
+		info, err := instance.GetIslandInfo(context.Background(), &model.GetIslandInfoReq{
 			IslandSourceId: guildID,
 		})
 		if err != nil {
@@ -345,6 +359,7 @@ func (pa *PlatformAdapterDodo) DoRelogin() bool {
 	if pa.runtimeStopping.Load() {
 		return false
 	}
+	pa.runtimeMu.Lock()
 	if pa.WebSocket != nil {
 		pa.WebSocket.Close()
 		pa.Client = nil
@@ -352,6 +367,7 @@ func (pa *PlatformAdapterDodo) DoRelogin() bool {
 		pa.EndPoint.State = 0
 		pa.EndPoint.Enable = false
 	}
+	pa.runtimeMu.Unlock()
 	logger.Infof("正在启用Dodo……")
 	pa.Serve()
 	return false
@@ -363,6 +379,7 @@ func (pa *PlatformAdapterDodo) SetEnable(enable bool) {
 	}()
 	logger := pa.EndPoint.Session.Parent.Logger
 	if enable {
+		pa.runtimeMu.Lock()
 		if pa.Client != nil && pa.WebSocket != nil {
 			pa.WebSocket.Close()
 			pa.Client = nil
@@ -370,14 +387,17 @@ func (pa *PlatformAdapterDodo) SetEnable(enable bool) {
 			pa.EndPoint.State = 0
 			pa.EndPoint.Enable = false
 		}
+		pa.runtimeMu.Unlock()
 		logger.Infof("正在启用Dodo……")
 		pa.Serve()
 	} else {
+		pa.runtimeMu.Lock()
 		if pa.WebSocket != nil {
 			pa.WebSocket.Close()
 		}
 		pa.Client = nil
 		pa.WebSocket = nil
+		pa.runtimeMu.Unlock()
 		pa.EndPoint.State = 0
 		pa.EndPoint.Enable = false
 	}
@@ -485,7 +505,10 @@ func convertLinksToMarkdown(text string) string {
 }
 
 func (pa *PlatformAdapterDodo) SendToPersonRaw(ctx *MsgContext, uid string, text string, isPrivate bool) error {
-	instance := pa.Client
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return nil
+	}
 	elem := message.ConvertStringMessage(text)
 	streamToByte := func(stream io.Reader) []byte {
 		buf := new(bytes.Buffer)
@@ -527,7 +550,10 @@ func (pa *PlatformAdapterDodo) SendToPersonRaw(ctx *MsgContext, uid string, text
 
 func (pa *PlatformAdapterDodo) SendToChatRaw(ctx *MsgContext, uid string, text string, isPrivate bool) error {
 	referenceMessageId := ""
-	instance := pa.Client
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return nil
+	}
 	elem := message.ConvertStringMessage(text)
 	streamToByte := func(stream io.Reader) []byte {
 		buf := new(bytes.Buffer)
@@ -616,9 +642,13 @@ func (pa *PlatformAdapterDodo) SendToChatRaw(ctx *MsgContext, uid string, text s
 }
 
 func (pa *PlatformAdapterDodo) SendMessageRaw(ctx *MsgContext, msgBody model.IMessageBody, uid string, isPrivate bool, referenceMessageId string) error {
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return nil
+	}
 	if isPrivate {
 		rawID := ExtractDodoUserID(uid)
-		_, err := pa.Client.SendDirectMessage(context.Background(), &model.SendDirectMessageReq{
+		_, err := instance.SendDirectMessage(context.Background(), &model.SendDirectMessageReq{
 			IslandSourceId: ctx.Group.GuildID,
 			DodoSourceId:   rawID,
 			MessageBody:    msgBody,
@@ -626,7 +656,7 @@ func (pa *PlatformAdapterDodo) SendMessageRaw(ctx *MsgContext, msgBody model.IMe
 		return err
 	}
 	rawID := ExtractDodoGroupID(uid)
-	_, err := pa.Client.SendChannelMessage(context.Background(), &model.SendChannelMessageReq{
+	_, err := instance.SendChannelMessage(context.Background(), &model.SendChannelMessageReq{
 		ChannelId:           rawID,
 		MessageBody:         msgBody,
 		ReferencedMessageId: referenceMessageId,
@@ -660,7 +690,11 @@ func ExtractDodoGroupID(id string) string {
 	return id
 }
 func (pa *PlatformAdapterDodo) QuitGroup(ctx *MsgContext, groupId string) {
-	_, err := pa.Client.SetBotIslandLeave(context.Background(), &model.SetBotLeaveIslandReq{
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return
+	}
+	_, err := instance.SetBotIslandLeave(context.Background(), &model.SetBotLeaveIslandReq{
 		IslandSourceId: ctx.Group.GuildID,
 	})
 	if err != nil {
@@ -669,7 +703,11 @@ func (pa *PlatformAdapterDodo) QuitGroup(ctx *MsgContext, groupId string) {
 }
 
 func (pa *PlatformAdapterDodo) SetGroupCardName(ctx *MsgContext, name string) {
-	_, err := pa.Client.SetMemberNick(context.Background(), &model.SetMemberNickReq{
+	instance := pa.clientSnapshot()
+	if instance == nil {
+		return
+	}
+	_, err := instance.SetMemberNick(context.Background(), &model.SetMemberNickReq{
 		IslandSourceId: ctx.Group.GuildID,
 		DodoSourceId:   ExtractDodoUserID(ctx.Player.UserID),
 		NickName:       name,

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -418,6 +418,23 @@ func OneBot11CqMessageToArrayMessage(longText string) []interface{} {
 	return lo.Reverse(arr) //nolint:staticcheck // old code
 }
 
+func (pa *PlatformAdapterGocq) bumpLoginIndexLocked() int {
+	pa.CurLoginIndex++
+	return pa.CurLoginIndex
+}
+
+func (pa *PlatformAdapterGocq) bumpLoginIndex() int {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.bumpLoginIndexLocked()
+}
+
+func (pa *PlatformAdapterGocq) currentLoginIndex() int {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.CurLoginIndex
+}
+
 func (pa *PlatformAdapterGocq) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {
 }
 
@@ -1204,7 +1221,9 @@ func (pa *PlatformAdapterGocq) Serve() int {
 			pa.runtimeMu.Unlock()
 			if err != nil {
 				log.Error("Onebot v11 反向WS服务关闭: ", err)
+				pa.runtimeMu.Lock()
 				pa.diceServing = false
+				pa.runtimeMu.Unlock()
 			}
 		})
 	} else {
@@ -1239,20 +1258,28 @@ func (pa *PlatformAdapterGocq) Serve() int {
 func (pa *PlatformAdapterGocq) DoRelogin() bool {
 	myDice := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
-	if pa.Socket != nil {
+	pa.runtimeMu.Lock()
+	socket := pa.Socket
+	pa.runtimeMu.Unlock()
+	if socket != nil {
 		runDiceRuntimeTask(myDice, func() {
 			defer func() {
 				_ = recover()
 			}()
-			pa.Socket.Close()
+			socket.Close()
+			pa.runtimeMu.Lock()
 			pa.diceServing = false
+			pa.runtimeMu.Unlock()
 		})
 	}
 
 	if pa.IsReverse {
-		if pa.reverseApp != nil {
-			_ = pa.reverseApp.Close()
-			pa.reverseApp = nil
+		pa.runtimeMu.Lock()
+		reverseApp := pa.reverseApp
+		pa.reverseApp = nil
+		pa.runtimeMu.Unlock()
+		if reverseApp != nil {
+			_ = reverseApp.Close()
 		}
 
 		runDiceRuntimeTaskWithContext(myDice, func(ctx context.Context) {
@@ -1264,12 +1291,15 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 	}
 
 	if pa.UseInPackClient {
-		if pa.InPackGoCqhttpDisconnectedCH != nil {
-			signalAdapterStop(pa.InPackGoCqhttpDisconnectedCH, -1)
+		pa.runtimeMu.Lock()
+		disconnected := pa.InPackGoCqhttpDisconnectedCH
+		pa.runtimeMu.Unlock()
+		if disconnected != nil {
+			signalAdapterStop(disconnected, -1)
 		}
 		if pa.BuiltinMode == "lagrange" {
 			myDice.Logger.Infof("重新启动 lagrange 进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
-			pa.CurLoginIndex++
+			pa.bumpLoginIndex()
 			pa.GoCqhttpState = StateCodeInit
 			BuiltinQQServeProcessKill(myDice, ep)
 			if !waitRuntimeDelay(diceRuntimeContext(myDice), 10*time.Second) {
@@ -1285,7 +1315,7 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 			return true
 		} else {
 			myDice.Logger.Infof("重新启动go-cqhttp进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
-			pa.CurLoginIndex++
+			pa.bumpLoginIndex()
 			pa.GoCqhttpState = StateCodeInit
 			BuiltinQQServeProcessKill(myDice, ep)
 			if !waitRuntimeDelay(diceRuntimeContext(myDice), 10*time.Second) {
@@ -1353,17 +1383,20 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 		}
 	} else {
 		c.Enable = false
+		pa.runtimeMu.Lock()
 		if pa.Socket != nil {
 			pa.Socket.Close()
 			pa.Socket = nil
 		}
 		pa.diceServing = false
+		reverseApp := pa.reverseApp
+		pa.reverseApp = nil
+		pa.runtimeMu.Unlock()
 		if pa.UseInPackClient {
 			BuiltinQQServeProcessKill(d, c)
 		}
-		if pa.IsReverse && pa.reverseApp != nil {
-			_ = pa.reverseApp.Close()
-			pa.reverseApp = nil
+		if pa.IsReverse && reverseApp != nil {
+			_ = reverseApp.Close()
 		}
 	}
 

--- a/dice/platform_adapter_gocq.go
+++ b/dice/platform_adapter_gocq.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,8 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -68,6 +71,11 @@ type PlatformAdapterGocq struct {
 	CurLoginIndex   int    `json:"curLoginIndex"     yaml:"-"`                 // 当前登录序号，如果正在进行的登录不是该Index，证明过时
 
 	GoCqhttpProcess           *procs.Process `json:"-"                    yaml:"-"`
+	processMu                 sync.Mutex     `json:"-"                    yaml:"-"`
+	processStarted            bool           `json:"-"                    yaml:"-"`
+	processDone               chan struct{}  `json:"-"                    yaml:"-"`
+	runtimeMu                 sync.Mutex     `json:"-"                    yaml:"-"`
+	runtimeStopping           atomic.Bool    `json:"-"                    yaml:"-"`
 	GocqhttpLoginFailedReason string         `json:"curLoginFailedReason" yaml:"-"` // 当前登录失败原因
 
 	GoCqhttpLoginCaptcha       string `json:"goCqHttpLoginCaptcha"       yaml:"-"`
@@ -417,6 +425,9 @@ func (pa *PlatformAdapterGocq) SendSegmentToPerson(ctx *MsgContext, userID strin
 }
 
 func (pa *PlatformAdapterGocq) Serve() int {
+	if pa.runtimeStopping.Load() {
+		return 0
+	}
 	if pa.BuiltinMode == "lagrange" {
 		pa.Implementation = "lagrange"
 	} else {
@@ -428,15 +439,37 @@ func (pa *PlatformAdapterGocq) Serve() int {
 	dm := s.Parent.Parent
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
 
-	pa.InPackGoCqhttpDisconnectedCH = make(chan int, 1)
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		return 0
+	}
+	disconnected := make(chan int, 1)
+	pa.InPackGoCqhttpDisconnectedCH = disconnected
+	pa.runtimeMu.Unlock()
+	defer func() {
+		pa.runtimeMu.Lock()
+		if pa.InPackGoCqhttpDisconnectedCH == disconnected {
+			pa.InPackGoCqhttpDisconnectedCH = nil
+		}
+		pa.runtimeMu.Unlock()
+	}()
 	session := s
 
 	socket := gowebsocket.New(pa.ConnectURL)
 	if pa.AccessToken != "" {
 		socket.RequestHeader.Add("Authorization", "Bearer "+pa.AccessToken)
 	}
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		socket.Close()
+		return 0
+	}
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
 
 	ep.State = 2
 	socket.OnConnected = func(socket gowebsocket.Socket) {
@@ -460,7 +493,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		log.Error("onebot v11 connection error: ", err)
 		log.Info("onebot wss connection addr: ", socket.Url)
 		// }
-		pa.InPackGoCqhttpDisconnectedCH <- 2
+		signalAdapterStop(disconnected, 2)
 	}
 
 	// {"channel_id":"3574366","guild_id":"51541481646552899","message":"说句话试试","message_id":"BAC3HLRYvXdDAAAAAAA2il4AAAAAAAAABA==","message_type":"guild","post_type":"mes
@@ -513,7 +546,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		}
 
 		if !ep.Enable {
-			pa.InPackGoCqhttpDisconnectedCH <- 3
+			signalAdapterStop(disconnected, 3)
 		}
 
 		msg := msgQQ.toStdMessage()
@@ -807,7 +840,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				welcome := DiceFormatTmpl(ctx, "核心:骰子成为好友")
 				log.Infof("与 %s 成为好友，发送好友致辞: %s", uid, welcome)
 
-				go func() {
+				runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 					defer func() {
 						if r := recover(); r != nil {
 							log.Errorf("好友致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -831,7 +864,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 							return func() { ext.OnBecomeFriend(ctx, msg) }
 						})
 					}
-				}()
+				})
 			}()
 			return
 		}
@@ -872,7 +905,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 			time.Sleep(2 * time.Second)
 			groupName := dm.TryGetGroupName(msg.GroupID)
-			go func() {
+			runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 				defer func() {
 					if r := recover(); r != nil {
 						log.Errorf("入群致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -889,7 +922,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 					doSleepQQ(ctx)
 					pa.SendToGroup(ctx, msg.GroupID, strings.TrimSpace(i), "")
 				}
-			}()
+			})
 			txt := fmt.Sprintf("加入QQ群组: <%s>(%s)", groupName, msgQQ.GroupID)
 			log.Info(txt)
 			ctx.Notice(txt, NoticeTypeGroup)
@@ -1046,7 +1079,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 		// 戳一戳
 		if msgQQ.PostType == "notice" && msgQQ.SubType == "poke" {
 			// {"post_type":"notice","notice_type":"notify","time":1672489767,"self_id":2589922907,"sub_type":"poke","group_id":131687852,"user_id":303451945,"sender_id":303451945,"target_id":2589922907}
-			go func() {
+			runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 				defer ErrorLogAndContinue(pa.EndPoint.Session.Parent)
 				isPrivate := msg.MessageType == "private"
 				pa.EndPoint.Session.OnPoke(pa.packTempCtx(msgQQ, msg), &events.PokeEvent{
@@ -1055,7 +1088,7 @@ func (pa *PlatformAdapterGocq) Serve() int {
 					TargetID:  FormatDiceIDQQ(string(msgQQ.TargetID)),
 					IsPrivate: isPrivate,
 				})
-			}()
+			})
 			return
 		}
 
@@ -1105,14 +1138,20 @@ func (pa *PlatformAdapterGocq) Serve() int {
 
 		log.Info("onebot 服务的连接被对方关闭")
 		_ = pa.EndPoint.Session.Parent.SendMail("", MailTypeConnectClose, NoticeTypeSystem)
-		pa.InPackGoCqhttpDisconnectedCH <- 1
+		signalAdapterStop(disconnected, 1)
 	}
 
 	if pa.IsReverse {
-		go func() {
-			if pa.IsReverse && pa.reverseApp != nil {
-				_ = pa.reverseApp.Close()
-				pa.reverseApp = nil
+		runDiceRuntimeTaskWithContext(s.Parent, func(ctx context.Context) {
+			if ctx.Err() != nil || pa.runtimeStopping.Load() {
+				return
+			}
+			pa.runtimeMu.Lock()
+			previousReverseApp := pa.reverseApp
+			pa.reverseApp = nil
+			pa.runtimeMu.Unlock()
+			if pa.IsReverse && previousReverseApp != nil {
+				_ = previousReverseApp.Close()
 			}
 
 			e := echo.New()
@@ -1134,49 +1173,64 @@ func (pa *PlatformAdapterGocq) Serve() int {
 				socketClone.OnConnected = socket.OnConnected
 				socketClone.OnConnectError = socket.OnConnectError
 				// 注: 只能管一个socket，不过不管了
+				pa.runtimeMu.Lock()
+				if pa.runtimeStopping.Load() {
+					pa.runtimeMu.Unlock()
+					return nil
+				}
 				pa.Socket = &socketClone
+				pa.runtimeMu.Unlock()
 
 				pa.EndPoint.State = 1
 				socketClone.NewClient(ws)
 				return nil
 			})
 
+			pa.runtimeMu.Lock()
+			if pa.runtimeStopping.Load() {
+				pa.runtimeMu.Unlock()
+				_ = e.Close()
+				return
+			}
 			pa.reverseApp = e
+			pa.runtimeMu.Unlock()
 			log.Info("Onebot v11 反向WS服务启动，地址: ", pa.ReverseAddr)
 			e.HideBanner = true
 			err := e.Start(pa.ReverseAddr)
+			pa.runtimeMu.Lock()
+			if pa.reverseApp == e {
+				pa.reverseApp = nil
+			}
+			pa.runtimeMu.Unlock()
 			if err != nil {
 				log.Error("Onebot v11 反向WS服务关闭: ", err)
 				pa.diceServing = false
 			}
-		}()
+		})
 	} else {
 		socket.Connect()
 	}
 
 	defer func() {
 		// fmt.Println("socket close")
-		go func() {
-			defer func() {
-				if r := recover(); r != nil { //nolint
-					// 太频繁了 不输出了
-					// fmt.Println("关闭连接时遭遇异常")
-					// core.GetLogger().Error(r)
-				}
-			}()
-
-			// 可能耗时好久
-			socket.Close()
+		defer func() {
+			_ = recover()
 		}()
+		socket.Close()
+		pa.runtimeMu.Lock()
+		if pa.Socket == &socket {
+			pa.Socket = nil
+		}
+		pa.runtimeMu.Unlock()
 	}()
 
 	for {
 		select {
 		case <-interrupt:
 			log.Info("interrupt")
-			pa.InPackGoCqhttpDisconnectedCH <- 0
+			signalAdapterStop(disconnected, 0)
 			return 0
-		case val := <-pa.InPackGoCqhttpDisconnectedCH:
+		case val := <-disconnected:
 			return val
 		}
 	}
@@ -1186,13 +1240,13 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 	myDice := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
 	if pa.Socket != nil {
-		go func() {
+		runDiceRuntimeTask(myDice, func() {
 			defer func() {
 				_ = recover()
 			}()
 			pa.Socket.Close()
 			pa.diceServing = false
-		}()
+		})
 	}
 
 	if pa.IsReverse {
@@ -1201,24 +1255,28 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 			pa.reverseApp = nil
 		}
 
-		go pa.Serve()
+		runDiceRuntimeTaskWithContext(myDice, func(ctx context.Context) {
+			if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+				pa.Serve()
+			}
+		})
 		return true
 	}
 
 	if pa.UseInPackClient {
 		if pa.InPackGoCqhttpDisconnectedCH != nil {
-			pa.InPackGoCqhttpDisconnectedCH <- -1
+			signalAdapterStop(pa.InPackGoCqhttpDisconnectedCH, -1)
 		}
 		if pa.BuiltinMode == "lagrange" {
 			myDice.Logger.Infof("重新启动 lagrange 进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
 			pa.CurLoginIndex++
 			pa.GoCqhttpState = StateCodeInit
-			ep.Enable = false // 拉格朗进程杀死前应先禁用账号，否则拉格朗会自动重启（该行为在LagrangeServe中）
-			go BuiltinQQServeProcessKill(myDice, ep)
-			time.Sleep(10 * time.Second)           // 上面那个清理有概率卡住，具体不懂，改成等5s -> 10s 超过一次重试间隔
+			BuiltinQQServeProcessKill(myDice, ep)
+			if !waitRuntimeDelay(diceRuntimeContext(myDice), 10*time.Second) {
+				return false
+			}
 			LagrangeServeRemoveSession(myDice, ep) // 删除 keystore
 			pa.GoCqhttpLastRestrictedTime = 0      // 重置风控时间
-			ep.Enable = true
 			myDice.LastUpdatedTime = time.Now().Unix()
 			myDice.Save(false)
 			LagrangeServe(myDice, ep, LagrangeLoginInfo{
@@ -1229,8 +1287,10 @@ func (pa *PlatformAdapterGocq) DoRelogin() bool {
 			myDice.Logger.Infof("重新启动go-cqhttp进程，对应账号: <%s>(%s)", ep.Nickname, ep.UserID)
 			pa.CurLoginIndex++
 			pa.GoCqhttpState = StateCodeInit
-			go BuiltinQQServeProcessKill(myDice, ep)
-			time.Sleep(10 * time.Second)                // 上面那个清理有概率卡住，具体不懂，改成等5s -> 10s 超过一次重试间隔
+			BuiltinQQServeProcessKill(myDice, ep)
+			if !waitRuntimeDelay(diceRuntimeContext(myDice), 10*time.Second) {
+				return false
+			}
 			GoCqhttpServeRemoveSessionToken(myDice, ep) // 删除session.token
 			pa.GoCqhttpLastRestrictedTime = 0           // 重置风控时间
 			myDice.LastUpdatedTime = time.Now().Unix()
@@ -1258,13 +1318,17 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 		if pa.UseInPackClient {
 			if pa.BuiltinMode == "lagrange" {
 				BuiltinQQServeProcessKill(d, c)
-				time.Sleep(1 * time.Second)
+				if !waitRuntimeDelay(diceRuntimeContext(d), time.Second) {
+					return
+				}
 				LagrangeServe(d, c, LagrangeLoginInfo{
 					IsAsyncRun: true,
 				})
 			} else {
 				BuiltinQQServeProcessKill(d, c)
-				time.Sleep(1 * time.Second)
+				if !waitRuntimeDelay(diceRuntimeContext(d), time.Second) {
+					return
+				}
 				GoCqhttpServe(d, c, GoCqhttpLoginInfo{
 					Password:         pa.InPackGoCqhttpPassword,
 					Protocol:         pa.InPackGoCqhttpProtocol,
@@ -1273,14 +1337,27 @@ func (pa *PlatformAdapterGocq) SetEnable(enable bool) {
 					UseSignServer:    pa.UseSignServer,
 					SignServerConfig: pa.SignServerConfig,
 				})
-				go ServeQQ(d, c)
+				runDiceRuntimeTaskWithContext(d, func(ctx context.Context) {
+					if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+						ServeQQ(d, c)
+					}
+				})
 			}
 		} else {
 			pa.GoCqhttpState = StateCodeLoginSuccessed
-			go ServeQQ(d, c)
+			runDiceRuntimeTaskWithContext(d, func(ctx context.Context) {
+				if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+					ServeQQ(d, c)
+				}
+			})
 		}
 	} else {
 		c.Enable = false
+		if pa.Socket != nil {
+			pa.Socket.Close()
+			pa.Socket = nil
+		}
+		pa.diceServing = false
 		if pa.UseInPackClient {
 			BuiltinQQServeProcessKill(d, c)
 		}

--- a/dice/platform_adapter_gocq_helper.go
+++ b/dice/platform_adapter_gocq_helper.go
@@ -631,7 +631,7 @@ func NewGoCqhttpConnectInfoItem(account string) *EndPointInfo {
 	return conn
 }
 
-func BuiltinQQServeProcessKillBase(dice *Dice, conn *EndPointInfo, isSync bool) {
+func BuiltinQQServeProcessKillBase(dice *Dice, conn *EndPointInfo) {
 	f := func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -681,12 +681,11 @@ func BuiltinQQServeProcessKillBase(dice *Dice, conn *EndPointInfo, isSync bool) 
 			}
 		}
 	}
-	_ = isSync
 	f()
 }
 
 func BuiltinQQServeProcessKill(dice *Dice, conn *EndPointInfo) {
-	BuiltinQQServeProcessKillBase(dice, conn, false)
+	BuiltinQQServeProcessKillBase(dice, conn)
 }
 
 func gocqGetWorkDir(dice *Dice, conn *EndPointInfo) string {

--- a/dice/platform_adapter_gocq_helper.go
+++ b/dice/platform_adapter_gocq_helper.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	crand "crypto/rand"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ShiraazMoollatjie/goluhn"
@@ -25,6 +27,138 @@ import (
 	"sealdice-core/utils"
 	"sealdice-core/utils/procs"
 )
+
+func runDiceRuntimeTaskWithContext(d *Dice, task func(context.Context)) bool {
+	if d != nil && d.Parent != nil {
+		return d.Parent.GoRuntime(task)
+	}
+	go task(context.Background())
+	return true
+}
+
+func diceRuntimeContext(d *Dice) context.Context {
+	if d != nil && d.Parent != nil {
+		return d.Parent.context()
+	}
+	return context.Background()
+}
+
+func waitRuntimeDelay(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func startManagedProcess(
+	ctx context.Context,
+	mu *sync.Mutex,
+	current **procs.Process,
+	started *bool,
+	done *chan struct{},
+	process *procs.Process,
+) error {
+	for {
+		mu.Lock()
+		if err := ctx.Err(); err != nil {
+			mu.Unlock()
+			return err
+		}
+		if *current == nil {
+			break
+		}
+		previousDone := *done
+		mu.Unlock()
+		if previousDone == nil {
+			return errors.New("内置客户端进程状态不完整")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-previousDone:
+		}
+	}
+	*current = process
+	*done = make(chan struct{})
+	if err := process.Start(); err != nil {
+		*current = nil
+		close(*done)
+		*done = nil
+		mu.Unlock()
+		return err
+	}
+	*started = true
+	mu.Unlock()
+	return nil
+}
+
+func waitManagedProcess(
+	mu *sync.Mutex,
+	current **procs.Process,
+	started *bool,
+	done *chan struct{},
+	process *procs.Process,
+) error {
+	err := process.Wait()
+	mu.Lock()
+	if *current == process {
+		*current = nil
+		*started = false
+		if *done != nil {
+			close(*done)
+			*done = nil
+		}
+	}
+	mu.Unlock()
+	return err
+}
+
+func stopManagedProcess(
+	mu *sync.Mutex,
+	current **procs.Process,
+	started *bool,
+	expected *procs.Process,
+) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if *current == nil || !*started || (expected != nil && *current != expected) {
+		return nil
+	}
+	if err := (*current).KillProcess(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}
+
+func (pa *PlatformAdapterGocq) startGoCqhttpProcess(ctx context.Context, process *procs.Process) error {
+	if pa.runtimeStopping.Load() {
+		return context.Canceled
+	}
+	return startManagedProcess(ctx, &pa.processMu, &pa.GoCqhttpProcess, &pa.processStarted, &pa.processDone, process)
+}
+
+func (pa *PlatformAdapterGocq) waitGoCqhttpProcess(process *procs.Process) error {
+	return waitManagedProcess(&pa.processMu, &pa.GoCqhttpProcess, &pa.processStarted, &pa.processDone, process)
+}
+
+func (pa *PlatformAdapterGocq) stopGoCqhttpProcess() error {
+	return stopManagedProcess(&pa.processMu, &pa.GoCqhttpProcess, &pa.processStarted, nil)
+}
+
+func (pa *PlatformAdapterGocq) stopGoCqhttpRuntime() error {
+	pa.runtimeMu.Lock()
+	pa.runtimeStopping.Store(true)
+	pa.runtimeMu.Unlock()
+	return pa.stopGoCqhttpProcess()
+}
+
+func (pa *PlatformAdapterGocq) stopGoCqhttpProcessInstance(process *procs.Process) error {
+	return stopManagedProcess(&pa.processMu, &pa.GoCqhttpProcess, &pa.processStarted, process)
+}
 
 type deviceFile struct {
 	Display      string         `json:"display"`
@@ -528,13 +662,8 @@ func BuiltinQQServeProcessKillBase(dice *Dice, conn *EndPointInfo, isSync bool) 
 				dice.Logger.Info("onebot: 删除已存在的二维码文件")
 			}
 
-			// 注意这个会panic，因此recover捕获了
-			if pa.GoCqhttpProcess != nil {
-				p := pa.GoCqhttpProcess
-				pa.GoCqhttpProcess = nil
-				// sigintwindows.SendCtrlBreak(p.Cmds[0].Process.Pid)
-				_ = p.Stop()
-				_ = p.Wait() // 等待进程退出，因为Stop内部是Kill，这是不等待的
+			if err := pa.stopGoCqhttpProcess(); err != nil {
+				dice.Logger.Error("停止内置 QQ 客户端失败: ", err)
 			}
 		} else {
 			pa.GoCqhttpLoginDeviceLockURL = ""
@@ -547,21 +676,13 @@ func BuiltinQQServeProcessKillBase(dice *Dice, conn *EndPointInfo, isSync bool) 
 				dice.Logger.Info("onebot: 删除已存在的二维码文件")
 			}
 
-			// 注意这个会panic，因此recover捕获了
-			if pa.GoCqhttpProcess != nil {
-				p := pa.GoCqhttpProcess
-				pa.GoCqhttpProcess = nil
-				// sigintwindows.SendCtrlBreak(p.Cmds[0].Process.Pid)
-				_ = p.Stop()
-				_ = p.Wait() // 等待进程退出，因为Stop内部是Kill，这是不等待的
+			if err := pa.stopGoCqhttpProcess(); err != nil {
+				dice.Logger.Error("停止内置 QQ 客户端失败: ", err)
 			}
 		}
 	}
-	if isSync {
-		f()
-	} else {
-		go f()
-	}
+	_ = isSync
+	f()
 }
 
 func BuiltinQQServeProcessKill(dice *Dice, conn *EndPointInfo) {
@@ -632,7 +753,11 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		pa.GoCqhttpState = StateCodeLoginSuccessed
 		pa.GoCqhttpLoginSucceeded = true
 		dice.Save(false)
-		go ServeQQ(dice, conn)
+		runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+			if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+				ServeQQ(dice, conn)
+			}
+		})
 	}
 }
 
@@ -720,13 +845,16 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 		chCaptcha := make(chan string, 1)
 
 		p.OutputHandler = func(line string, _type string) string {
+			if pa.runtimeStopping.Load() {
+				return ""
+			}
 			if loginIndex != pa.CurLoginIndex {
 				// 当前连接已经无用，进程自杀
 				if !isSelfKilling {
 					dice.Logger.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.CurLoginIndex, loginIndex)
 					// 注: 这里不要调用kill
 					isSelfKilling = true
-					_ = p.Stop()
+					_ = pa.stopGoCqhttpProcessInstance(p)
 				}
 				return ""
 			}
@@ -735,7 +863,10 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 			if pa.IsInLogin() {
 				// 请使用手机QQ扫描二维码 (qrcode.png) :
 				if strings.Contains(line, "qrcode.png") {
-					chQrCode <- 1
+					select {
+					case chQrCode <- 1:
+					default:
+					}
 				}
 
 				// 获取二维码失败，登录失败
@@ -821,20 +952,33 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 
 							dice.Logger.Info("进入滑条验证码流程，等待输入")
 							pa.GoCqhttpLoginCaptcha = ""
-							go func() {
+							started := runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+								code := ""
 								// 检查是否有短信验证码
 								for range 100 {
 									if pa.GoCqhttpState != GoCqhttpStateCodeInLoginBar {
 										break
 									}
-									time.Sleep(6 * time.Second)
+									if !waitRuntimeDelay(ctx, 6*time.Second) {
+										break
+									}
 									if pa.GoCqhttpLoginCaptcha != "" {
-										chCaptcha <- pa.GoCqhttpLoginCaptcha
+										code = pa.GoCqhttpLoginCaptcha
 										break
 									}
 								}
-							}()
+								select {
+								case chCaptcha <- code:
+								default:
+								}
+							})
+							if !started {
+								return ""
+							}
 							code := <-chCaptcha
+							if code == "" {
+								return ""
+							}
 							dice.Logger.Infof("即将输入token: %v", code)
 							return code + "\n"
 						}
@@ -845,20 +989,33 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 					dice.Logger.Info("进入短信验证码流程，等待输入")
 					pa.GoCqhttpState = GoCqhttpStateCodeInLoginVerifyCode
 					pa.GoCqhttpLoginVerifyCode = ""
-					go func() {
+					started := runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+						code := ""
 						// 检查是否有短信验证码
 						for range 100 {
 							if pa.GoCqhttpState != GoCqhttpStateCodeInLoginVerifyCode {
 								break
 							}
-							time.Sleep(6 * time.Second)
+							if !waitRuntimeDelay(ctx, 6*time.Second) {
+								break
+							}
 							if pa.GoCqhttpLoginVerifyCode != "" {
-								chSMS <- pa.GoCqhttpLoginVerifyCode
+								code = pa.GoCqhttpLoginVerifyCode
 								break
 							}
 						}
-					}()
+						select {
+						case chSMS <- code:
+						default:
+						}
+					})
+					if !started {
+						return ""
+					}
 					code := <-chSMS
+					if code == "" {
+						return ""
+					}
 					dice.Logger.Infof("即将输入短信验证码: %v", code)
 					return code + "\n"
 				}
@@ -878,7 +1035,11 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 					dice.LastUpdatedTime = time.Now().Unix()
 					dice.Save(false)
 
-					go ServeQQ(dice, conn)
+					runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+						if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+							ServeQQ(dice, conn)
+						}
+					})
 				}
 			}
 
@@ -962,8 +1123,15 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 			return ""
 		}
 
-		go func() {
-			<-chQrCode
+		runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-chQrCode:
+			}
+			if ctx.Err() != nil || pa.runtimeStopping.Load() {
+				return
+			}
 			if _, err := os.Stat(qrcodeFile); err == nil {
 				dice.Logger.Info("onebot: 二维码已经就绪")
 				fmt.Fprintln(os.Stdout, "如控制台二维码不好扫描，可以手动打开 ./data/default/extra/go-cqhttp-qqXXXXX 目录下qrcode.png")
@@ -984,9 +1152,9 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 					dice.Logger.Info("获取二维码失败，错误为: ", err.Error())
 				}
 			}
-		}()
+		})
 
-		run := func() {
+		run := func(ctx context.Context) {
 			defer func() {
 				if r := recover(); r != nil {
 					dice.Logger.Errorf("onebot: 异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -994,8 +1162,7 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 			}()
 
 			// 启动gocqhttp，开始登录
-			pa.GoCqhttpProcess = p
-			err := p.Start()
+			err := pa.startGoCqhttpProcess(ctx, p)
 
 			if err == nil {
 				if dice.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
@@ -1004,15 +1171,19 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 						dice.Logger.Warn("添加到进程组失败，若主进程崩溃，gocqhttp进程可能需要手动结束")
 					}
 				}
-				_ = p.Wait()
+				err = pa.waitGoCqhttpProcess(p)
+			}
+			if ctx.Err() != nil || pa.runtimeStopping.Load() {
+				return
+			}
+			if loginIndex != pa.CurLoginIndex {
+				return
 			}
 
 			isInLogin := pa.IsInLogin()
 			isDeviceLockLogin := pa.GoCqhttpState == StateCodeInLoginDeviceLock
 			if !isDeviceLockLogin {
-				// 如果在设备锁流程中，不清空数据
-				BuiltinQQServeProcessKill(dice, conn)
-
+				// Wait 已清理进程槽；此处只更新旧登录尝试的状态，不能再按当前槽停止进程。
 				if isInLogin {
 					conn.State = 3
 					pa.GoCqhttpState = StateCodeLoginFailed
@@ -1030,9 +1201,9 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 		}
 
 		if loginInfo.IsAsyncRun {
-			go run()
+			runDiceRuntimeTaskWithContext(dice, run)
 		} else {
-			run()
+			run(diceRuntimeContext(dice))
 		}
 	}
 }

--- a/dice/platform_adapter_gocq_helper.go
+++ b/dice/platform_adapter_gocq_helper.go
@@ -745,7 +745,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 		}
 
 		if pa.BuiltinMode == "gocq" || pa.BuiltinMode == "" {
-			pa.CurLoginIndex++
+			pa.bumpLoginIndex()
 			pa.GoCqhttpState = StateCodeInLogin
 			builtinGoCqhttpServe(dice, conn, loginInfo)
 		}
@@ -764,7 +764,7 @@ func GoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) 
 func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLoginInfo) {
 	log := zap.S().Named(logger.LogKeyAdapter)
 	pa := conn.Adapter.(*PlatformAdapterGocq)
-	loginIndex := pa.CurLoginIndex
+	loginIndex := pa.currentLoginIndex()
 
 	// 保留此if语句块，使历史可追溯，后续commit可移除if
 	if pa.UseInPackClient { //nolint:nestif
@@ -848,10 +848,10 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 			if pa.runtimeStopping.Load() {
 				return ""
 			}
-			if loginIndex != pa.CurLoginIndex {
+			if loginIndex != pa.currentLoginIndex() {
 				// 当前连接已经无用，进程自杀
 				if !isSelfKilling {
-					dice.Logger.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.CurLoginIndex, loginIndex)
+					dice.Logger.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.currentLoginIndex(), loginIndex)
 					// 注: 这里不要调用kill
 					isSelfKilling = true
 					_ = pa.stopGoCqhttpProcessInstance(p)
@@ -1176,7 +1176,7 @@ func builtinGoCqhttpServe(dice *Dice, conn *EndPointInfo, loginInfo GoCqhttpLogi
 			if ctx.Err() != nil || pa.runtimeStopping.Load() {
 				return
 			}
-			if loginIndex != pa.CurLoginIndex {
+			if loginIndex != pa.currentLoginIndex() {
 				return
 			}
 

--- a/dice/platform_adapter_kook.go
+++ b/dice/platform_adapter_kook.go
@@ -140,7 +140,7 @@ func (pa *PlatformAdapterKook) GetGroupInfoAsync(groupID string) {
 	}
 	logger := pa.EndPoint.Session.Parent.Logger
 	dm := pa.EndPoint.Session.Parent.Parent
-	go pa.updateChannelNum()
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, pa.updateChannelNum)
 	channel, err := pa.IntentSession.ChannelView(ExtractKookChannelID(groupID))
 	if err != nil {
 		logger.Errorf("获取Kook频道信息#%s时出错:%s", groupID, err.Error())
@@ -278,7 +278,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 
 		mctx := &MsgContext{Session: pa.EndPoint.Session, EndPoint: pa.EndPoint, Dice: pa.EndPoint.Session.Parent, MessageType: msg.MessageType}
 		pa.GetGroupInfoAsync(msg.GroupID)
-		go func() {
+		runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 			defer func() {
 				if r := recover(); r != nil {
 					log.Errorf("入群致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -294,7 +294,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 			for _, i := range mctx.SplitText(text) {
 				pa.SendToGroup(mctx, msg.GroupID, strings.TrimSpace(i), "")
 			}
-		}()
+		})
 
 		// 此时 ServiceAtNew 中这个频道一般为空，照 im_session.go 中的方法处理
 		// Pinenutn: 不清楚此处的逻辑，修改为Exists检查
@@ -350,7 +350,7 @@ func (pa *PlatformAdapterKook) Serve() int {
 		return 1
 	}
 	pa.IntentSession = s
-	go pa.updateGameStatus()
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, pa.updateGameStatus)
 	pa.EndPoint.State = 1
 	pa.EndPoint.Enable = true
 	self, _ := s.UserMe()

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -56,8 +56,7 @@ func NewLagrangeConnectInfoItem(account string) *EndPointInfo {
 func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) {
 	pa := conn.Adapter.(*PlatformAdapterGocq)
 
-	pa.CurLoginIndex++
-	loginIndex := pa.CurLoginIndex
+	loginIndex := pa.bumpLoginIndex()
 	pa.GoCqhttpState = StateCodeInLogin
 	helper := zap.S().Named(logger.LogKeyAdapter)
 	if pa.UseInPackClient && (pa.BuiltinMode == "lagrange") { //nolint:nestif
@@ -169,10 +168,10 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 			if pa.runtimeStopping.Load() {
 				return ""
 			}
-			if loginIndex != pa.CurLoginIndex {
+			if loginIndex != pa.currentLoginIndex() {
 				// 当前连接已经无用，进程自杀
 				if !isSelfKilling {
-					helper.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.CurLoginIndex, loginIndex)
+					helper.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.currentLoginIndex(), loginIndex)
 					// 注: 这里不要调用kill
 					isSelfKilling = true
 					_ = pa.stopGoCqhttpProcessInstance(p)
@@ -284,7 +283,7 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 			if ctx.Err() != nil || pa.runtimeStopping.Load() {
 				return
 			}
-			if loginIndex != pa.CurLoginIndex {
+			if loginIndex != pa.currentLoginIndex() {
 				return
 			}
 

--- a/dice/platform_adapter_lagrange_helper.go
+++ b/dice/platform_adapter_lagrange_helper.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -129,9 +130,9 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 			_ = os.WriteFile(configFilePath, c, 0o644)
 		}
 
-		if pa.GoCqhttpProcess != nil {
-			// 如果有正在运行的lagrange，先将其杀掉
-			BuiltinQQServeProcessKill(dice, conn)
+		// 如果有正在运行的 Lagrange，先请求其退出；Wait 由原运行任务负责。
+		if err := pa.stopGoCqhttpProcess(); err != nil {
+			helper.Errorf("停止旧 Lagrange 进程失败: %v", err)
 		}
 
 		// 启动客户端
@@ -165,13 +166,16 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 		regFatal := regexp.MustCompile(`\s*\[\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\]\s+\[[^]]+\]\s+\[(FATAL)\]:`)
 
 		p.OutputHandler = func(line string, _type string) string {
+			if pa.runtimeStopping.Load() {
+				return ""
+			}
 			if loginIndex != pa.CurLoginIndex {
 				// 当前连接已经无用，进程自杀
 				if !isSelfKilling {
 					helper.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.CurLoginIndex, loginIndex)
 					// 注: 这里不要调用kill
 					isSelfKilling = true
-					_ = p.Stop()
+					_ = pa.stopGoCqhttpProcessInstance(p)
 				}
 				return ""
 			}
@@ -183,7 +187,10 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 				qrcodeExpiredSignal := "QrCode Expired, Please Fetch QrCode Again"
 				// 读取二维码
 				if strings.Contains(line, qrcodeSignal) {
-					chQrCode <- 1
+					select {
+					case chQrCode <- 1:
+					default:
+					}
 				}
 
 				// 登录成功
@@ -196,8 +203,11 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 					isPrintLog = false
 
 					// 经测试，若不延时，登录成功的同一时刻进行ws正向连接有几率导致第一次连接失败
-					time.Sleep(1 * time.Second)
-					go ServeQQ(dice, conn)
+					runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+						if waitRuntimeDelay(ctx, time.Second) && !pa.runtimeStopping.Load() {
+							ServeQQ(dice, conn)
+						}
+					})
 				}
 
 				if strings.Contains(line, qrcodeExpiredSignal) {
@@ -223,9 +233,15 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 			return ""
 		}
 
-		go func() {
-			<-chQrCode
-			time.Sleep(3 * time.Second)
+		runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-chQrCode:
+			}
+			if !waitRuntimeDelay(ctx, 3*time.Second) || pa.runtimeStopping.Load() {
+				return
+			}
 			if _, err := os.Stat(qrcodeFilePath); err == nil {
 				helper.Info("onebot: 二维码已就绪")
 				qrdata, err := os.ReadFile(qrcodeFilePath)
@@ -244,18 +260,17 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 					helper.Infof("onebot: 读取二维码失败：%s", err)
 				}
 			}
-		}()
+		})
 
-		run := func() {
+		run := func(ctx context.Context) {
 			defer func() {
 				if r := recover(); r != nil {
 					helper.Errorf("onebot: 异常: %v 堆栈: %v", r, string(debug.Stack()))
 				}
 			}()
 
-			pa.GoCqhttpProcess = p
 			processStartTime := time.Now().Unix()
-			err := p.Start()
+			err := pa.startGoCqhttpProcess(ctx, p)
 
 			if err == nil {
 				if dice.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
@@ -264,7 +279,13 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 						dice.Logger.Warn("添加到进程组失败，若主进程崩溃，lagrange 进程可能需要手动结束")
 					}
 				}
-				err = p.Wait()
+				err = pa.waitGoCqhttpProcess(p)
+			}
+			if ctx.Err() != nil || pa.runtimeStopping.Load() {
+				return
+			}
+			if loginIndex != pa.CurLoginIndex {
+				return
 			}
 
 			isInLogin := pa.IsInLogin()
@@ -300,11 +321,13 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 								helper.Info("自动重启次数达到上限，放弃")
 							} else {
 								pa.lagrangeRebootTimes++
-								if conn.Enable {
+								if conn.Enable && ctx.Err() == nil {
 									helper.Info("5秒后，尝试对其进行重启")
-									time.Sleep(5 * time.Second)
+									if !waitRuntimeDelay(ctx, 5*time.Second) {
+										return
+									}
 								}
-								if conn.Enable {
+								if conn.Enable && ctx.Err() == nil {
 									LagrangeServe(dice, conn, loginInfo)
 								}
 							}
@@ -317,15 +340,19 @@ func LagrangeServe(dice *Dice, conn *EndPointInfo, loginInfo LagrangeLoginInfo) 
 		}
 
 		if loginInfo.IsAsyncRun {
-			go run()
+			runDiceRuntimeTaskWithContext(dice, run)
 		} else {
-			run()
+			run(diceRuntimeContext(dice))
 		}
 	} else if !pa.UseInPackClient {
 		pa.GoCqhttpState = StateCodeLoginSuccessed
 		pa.GoCqhttpLoginSucceeded = true
 		dice.Save(false)
-		go ServeQQ(dice, conn)
+		runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+			if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+				ServeQQ(dice, conn)
+			}
+		})
 	}
 }
 

--- a/dice/platform_adapter_milky.go
+++ b/dice/platform_adapter_milky.go
@@ -9,6 +9,8 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	milky "github.com/Szzrain/Milky-go-sdk"
@@ -31,6 +33,11 @@ type PlatformAdapterMilky struct {
 	// BuiltInMode 留空则视为分离，目前支持的字段为 lagrangeV2
 	BuiltInMode       string          `json:"built_in_mode" yaml:"built_in_mode"`
 	MilkyProcess      *procs.Process  `json:"-" yaml:"-"`
+	processMu         sync.Mutex      `json:"-" yaml:"-"`
+	processStarted    bool            `json:"-" yaml:"-"`
+	processDone       chan struct{}   `json:"-" yaml:"-"`
+	runtimeMu         sync.Mutex      `json:"-" yaml:"-"`
+	runtimeStopping   atomic.Bool     `json:"-" yaml:"-"`
 	BuiltInLoginState MilkyLoginState `json:"loginState" yaml:"-"`
 	QrCodeData        []byte          `json:"-"                          yaml:"-"`
 }
@@ -138,6 +145,9 @@ func (pa *PlatformAdapterMilky) GetGroupInfoAsync(groupID string) {
 }
 
 func (pa *PlatformAdapterMilky) Serve() int {
+	if pa.runtimeStopping.Load() {
+		return 0
+	}
 	log := zap.S().Named(logger.LogKeyAdapter)
 	pa.EndPoint.State = 2 // 设置状态为连接中
 
@@ -152,7 +162,13 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		log.Errorf("Milky SDK initialization failed: %v", err)
 		return 1
 	}
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		return 0
+	}
 	pa.IntentSession = session
+	pa.runtimeMu.Unlock()
 	session.AddHandler(func(session2 *milky.Session, m *milky.ReceiveMessage) {
 		if m == nil {
 			return
@@ -422,7 +438,25 @@ func (pa *PlatformAdapterMilky) Serve() int {
 		pa.EndPoint.Session.OnMessageDeleted(mctx, msg)
 	})
 	d := pa.EndPoint.Session.Parent
-	err = pa.IntentSession.Open()
+	if pa.runtimeStopping.Load() {
+		_ = session.Close()
+		pa.runtimeMu.Lock()
+		if pa.IntentSession == session {
+			pa.IntentSession = nil
+		}
+		pa.runtimeMu.Unlock()
+		return 0
+	}
+	err = session.Open()
+	if pa.runtimeStopping.Load() {
+		_ = session.Close()
+		pa.runtimeMu.Lock()
+		if pa.IntentSession == session {
+			pa.IntentSession = nil
+		}
+		pa.runtimeMu.Unlock()
+		return 0
+	}
 	if err != nil {
 		log.Errorf("Failed to open Milky session: %v", err)
 		pa.EndPoint.State = 3 // 设置状态为连接失败
@@ -433,14 +467,26 @@ func (pa *PlatformAdapterMilky) Serve() int {
 	}
 	info, err := session.GetLoginInfo()
 	if err != nil {
+		if pa.runtimeStopping.Load() {
+			return 0
+		}
 		// 获取登录信息失败，视为连接失败
 		log.Errorf("Failed to get login info: %v", err)
-		_ = pa.IntentSession.Close()
+		_ = session.Close()
 		pa.EndPoint.State = 3
 		pa.EndPoint.Enable = false
 		d.LastUpdatedTime = time.Now().Unix()
 		d.Save(false)
 		return 1
+	}
+	if pa.runtimeStopping.Load() {
+		_ = session.Close()
+		pa.runtimeMu.Lock()
+		if pa.IntentSession == session {
+			pa.IntentSession = nil
+		}
+		pa.runtimeMu.Unlock()
+		return 0
 	}
 
 	log.Infof("Milky 服务连接成功，账号<%s>(%d)", info.Nickname, info.UIN)
@@ -556,7 +602,7 @@ func (pa *PlatformAdapterMilky) handelFriendRequest(ctx *MsgContext, event *milk
 		welcome := DiceFormatTmpl(ctx, "核心:骰子成为好友")
 		log.Infof("与 %s 成为好友，发送好友致辞: %s", uid, welcome)
 
-		go func() {
+		runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 			defer func() {
 				if r := recover(); r != nil {
 					log.Errorf("好友致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -575,7 +621,7 @@ func (pa *PlatformAdapterMilky) handelFriendRequest(ctx *MsgContext, event *milk
 					return func() { ext.OnBecomeFriend(ctx, msg) }
 				})
 			}
-		}()
+		})
 	}
 	if willAccept {
 		sendSpeech()
@@ -680,7 +726,9 @@ func (pa *PlatformAdapterMilky) DoRelogin() bool {
 	// kill
 	BuiltinMilkyClientKill(pa.EndPoint.Session.Parent, pa.EndPoint)
 	MilkyRemoveSession(pa.EndPoint.Session.Parent, pa.EndPoint)
-	go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
+		ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
+	})
 	return true
 }
 
@@ -721,7 +769,9 @@ func (pa *PlatformAdapterMilky) SetEnable(enable bool) {
 		return
 	}
 	if enable {
-		go ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
+		runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
+			ServeMilkyBuiltIn(pa.EndPoint.Session.Parent, pa.EndPoint)
+		})
 	} else {
 		if pa.IntentSession != nil {
 			_ = pa.IntentSession.Close()
@@ -946,13 +996,13 @@ func (pa *PlatformAdapterMilky) SendToGroup(ctx *MsgContext, groupID string, tex
 		log.Errorf("Failed to send group message to %s: %v", groupID, err)
 		return
 	}
-	go func(targets []int64) {
-		for _, userID := range targets {
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
+		for _, userID := range nudgeTargets {
 			log.Debugf("Sending group Nudge: %d", userID)
 			_ = pa.IntentSession.SendGroupNudge(id, userID)
 			doSleepQQ(ctx)
 		}
-	}(nudgeTargets)
+	})
 	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "QQ",
 		MessageType: "group",

--- a/dice/platform_adapter_milky_helper.go
+++ b/dice/platform_adapter_milky_helper.go
@@ -2,7 +2,6 @@ package dice
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -21,6 +20,28 @@ import (
 	"sealdice-core/logger"
 	"sealdice-core/utils/procs"
 )
+
+func (pa *PlatformAdapterMilky) startMilkyProcess(ctx context.Context, process *procs.Process) error {
+	if pa.runtimeStopping.Load() {
+		return context.Canceled
+	}
+	return startManagedProcess(ctx, &pa.processMu, &pa.MilkyProcess, &pa.processStarted, &pa.processDone, process)
+}
+
+func (pa *PlatformAdapterMilky) waitMilkyProcess(process *procs.Process) error {
+	return waitManagedProcess(&pa.processMu, &pa.MilkyProcess, &pa.processStarted, &pa.processDone, process)
+}
+
+func (pa *PlatformAdapterMilky) stopMilkyProcess() error {
+	return stopManagedProcess(&pa.processMu, &pa.MilkyProcess, &pa.processStarted, nil)
+}
+
+func (pa *PlatformAdapterMilky) stopMilkyRuntime() error {
+	pa.runtimeMu.Lock()
+	pa.runtimeStopping.Store(true)
+	pa.runtimeMu.Unlock()
+	return pa.stopMilkyProcess()
+}
 
 var defaultLagrangeV2Config = `{
     "$schema": "https://raw.githubusercontent.com/LagrangeDev/LagrangeV2/refs/heads/main/Lagrange.Milky/Resources/appsettings_schema.json",
@@ -205,28 +226,17 @@ func BuiltinMilkyClientKill(dice *Dice, conn *EndPointInfo) {
 	if pa.BuiltInMode == "" {
 		return
 	}
-	defer func() {
-		pa.MilkyProcess = nil
-	}()
-	if pa.MilkyProcess != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		go func() {
-			<-ctx.Done()
-			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				dice.Logger.Error("Milky 进程未能在 5 秒内退出，可能需要手动结束")
-			}
-		}()
-		err := pa.MilkyProcess.Stop()
-		if err != nil {
-			dice.Logger.Error("停止 Milky 进程失败: ", err)
-		}
-		_ = pa.MilkyProcess.Wait()
+	if err := pa.stopMilkyProcess(); err != nil {
+		dice.Logger.Error("停止 Milky 进程失败: ", err)
 	}
 }
 
 func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 	defer CrashLog()
+	conn := ep.Adapter.(*PlatformAdapterMilky)
+	if conn.runtimeStopping.Load() {
+		return
+	}
 	if d.ContainerMode {
 		d.Logger.Warnf("当前处于容器模式，Milky 内置版本不可用")
 		ep.State = 3
@@ -242,9 +252,8 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		d.Save(false)
 		return
 	}
-	conn := ep.Adapter.(*PlatformAdapterMilky)
 	doServe := func() {
-		if ep.Platform == "QQ" {
+		if ep.Platform == "QQ" && !conn.runtimeStopping.Load() {
 			d.Logger.Infof("Milky 尝试连接")
 			if conn.Serve() != 0 {
 				d.Logger.Errorf("连接Milky失败")
@@ -327,6 +336,9 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 	qrSignalCalled.Store(false)
 	pa.BuiltInLoginState = MilkyLoginStateInit
 	p.OutputHandler = func(line string, _type string) string {
+		if pa.runtimeStopping.Load() {
+			return ""
+		}
 		// 登录中
 		if pa.BuiltInLoginState < MilkyLoginStateConnecting {
 			var qrcodeSignal string
@@ -346,7 +358,10 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 			// 读取二维码
 			if strings.Contains(line, qrcodeSignal) && !qrSignalCalled.Load() {
 				qrSignalCalled.Store(true)
-				chQrCode <- 1
+				select {
+				case chQrCode <- 1:
+				default:
+				}
 			}
 
 			// 登录成功
@@ -357,8 +372,11 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 				d.Save(false)
 
 				// 经测试，若不延时，登录成功的同一时刻进行ws正向连接有几率导致第一次连接失败
-				time.Sleep(1 * time.Second)
-				go doServe()
+				runDiceRuntimeTaskWithContext(d, func(ctx context.Context) {
+					if waitRuntimeDelay(ctx, time.Second) {
+						doServe()
+					}
+				})
 			}
 
 			if strings.Contains(line, qrcodeExpiredSignal) {
@@ -383,9 +401,15 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		return ""
 	}
 
-	go func() {
-		<-chQrCode
-		time.Sleep(3 * time.Second)
+	runDiceRuntimeTaskWithContext(d, func(ctx context.Context) {
+		select {
+		case <-ctx.Done():
+			return
+		case <-chQrCode:
+		}
+		if !waitRuntimeDelay(ctx, 3*time.Second) || pa.runtimeStopping.Load() {
+			return
+		}
 		if _, err := os.Stat(qrcodeFilePath); err == nil {
 			log.Info("Milky 二维码已就绪")
 			qrdata, err := os.ReadFile(qrcodeFilePath)
@@ -403,35 +427,30 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 				log.Infof("Milky 读取二维码失败：%s", err)
 			}
 		}
-	}()
+	})
 
-	run := func() {
+	run := func(ctx context.Context) {
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorf("MilkyInternal 异常: %v 堆栈: %v", r, string(debug.Stack()))
 			}
 		}()
 
-		errRun := p.Start()
-		if errRun != nil {
-			log.Info("Milky 进程启动失败: ", errRun)
-			ep.State = 3
-			d.LastUpdatedTime = time.Now().Unix()
-			d.Save(false)
+		// processStartTime := time.Now().Unix()
+		errRun := pa.startMilkyProcess(ctx, p)
+
+		if errRun == nil {
+			if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
+				errAdd := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process)
+				if errAdd != nil {
+					log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
+				}
+			}
+			errRun = pa.waitMilkyProcess(p)
+		}
+		if ctx.Err() != nil || pa.runtimeStopping.Load() {
 			return
 		}
-
-		conn.MilkyProcess = p
-		close(processRegistered)
-		// processStartTime := time.Now().Unix()
-
-		if d.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
-			errAdd := d.Parent.progressExitGroupWin.AddProcess(p.Cmd.Process)
-			if errAdd != nil {
-				log.Warn("添加到进程组失败，若主进程崩溃，Milky 进程可能需要手动结束")
-			}
-		}
-		errRun = p.Wait() //nolint:ineffassign
 
 		if errRun != nil {
 			log.Info("Milky 进程异常退出: ", errRun)
@@ -440,7 +459,7 @@ func ServeMilkyBuiltIn(d *Dice, ep *EndPointInfo) {
 		}
 	}
 
-	go run()
+	runDiceRuntimeTaskWithContext(d, run)
 }
 
 // GenerateMilkyConfig 似乎暂时不需要 APPInfo, 如果以后需要了再改成双返回值

--- a/dice/platform_adapter_minecraft.go
+++ b/dice/platform_adapter_minecraft.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -16,8 +17,9 @@ type PlatformAdapterMinecraft struct {
 	EndPoint        *EndPointInfo       `json:"-"          yaml:"-"`
 	Socket          *gowebsocket.Socket `json:"-"          yaml:"-"`
 	RetryTimes      int                 `json:"-"          yaml:"-"`
-	Reconnecting    bool                `json:"-"          yaml:"-"`
+	Reconnecting    atomic.Bool         `json:"-"          yaml:"-"`
 	ConnectURL      string              `json:"connectUrl" yaml:"connectUrl"` // 连接地址
+	runtimeMu       sync.Mutex
 	runtimeStopping atomic.Bool
 }
 
@@ -43,13 +45,26 @@ type SendMessageMinecraft struct {
 
 func (pa *PlatformAdapterMinecraft) GetGroupInfoAsync(_ string) {}
 
+func (pa *PlatformAdapterMinecraft) socketSnapshot() *gowebsocket.Socket {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.Socket
+}
+
 func (pa *PlatformAdapterMinecraft) Serve() int {
 	pa.runtimeStopping.Store(false)
 	if !strings.HasPrefix(pa.ConnectURL, "ws://") {
 		pa.ConnectURL = "ws://" + pa.ConnectURL
 	}
 	socket := gowebsocket.New(pa.ConnectURL)
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		socket.Close()
+		return 0
+	}
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
 	pa.EndPoint.Nickname = "A Minecraft Server"
 	pa.EndPoint.UserID = "WebSocket"
 	d := pa.EndPoint.Session.Parent
@@ -65,15 +80,22 @@ func (pa *PlatformAdapterMinecraft) tryReconnect(socket gowebsocket.Socket) bool
 	if pa.runtimeStopping.Load() {
 		return false
 	}
-	if pa.Reconnecting {
+	if pa.Reconnecting.Load() {
 		return false
 	}
-	pa.Reconnecting = true
+	pa.Reconnecting.Store(true)
 	if pa.RetryTimes <= 5 && !socket.IsConnected {
 		pa.RetryTimes++
 		log.Infof("MC server 尝试重新连接中[%d/5]", pa.RetryTimes)
 		socket = gowebsocket.New(pa.ConnectURL)
+		pa.runtimeMu.Lock()
+		if pa.runtimeStopping.Load() {
+			pa.runtimeMu.Unlock()
+			socket.Close()
+			return false
+		}
 		pa.Socket = &socket
+		pa.runtimeMu.Unlock()
 		pa.socketSetup()
 		socket.Connect()
 	}
@@ -83,7 +105,7 @@ func (pa *PlatformAdapterMinecraft) tryReconnect(socket gowebsocket.Socket) bool
 func (pa *PlatformAdapterMinecraft) socketSetup() {
 	ep := pa.EndPoint
 	log := ep.Session.Parent.Logger
-	socket := pa.Socket
+	socket := pa.socketSnapshot()
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
 		if !ok {
@@ -95,7 +117,7 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 			socket.Close()
 			return
 		}
-		pa.Reconnecting = true
+		pa.Reconnecting.Store(true)
 		ep.State = 1
 		ep.Enable = true
 		pa.RetryTimes = 0
@@ -106,7 +128,7 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 
 		log.Info("Minecraft 连接成功")
 		time.Sleep(time.Duration(5) * time.Second)
-		pa.Reconnecting = false
+		pa.Reconnecting.Store(false)
 	}
 	socket.OnTextMessage = func(message string, socket gowebsocket.Socket) {
 		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
@@ -132,7 +154,7 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		}
 		if !socket.IsConnected {
 			// socket.Close()
-			if !pa.tryReconnect(*pa.Socket) {
+			if !pa.tryReconnect(socket) {
 				log.Errorf("短时间内连接失败次数过多，不再进行重连")
 				ep.State = 3
 				ep.Enable = false
@@ -150,13 +172,15 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 			return
 		}
 		time.Sleep(time.Duration(2) * time.Second)
-		if !pa.tryReconnect(*pa.Socket) {
+		if !pa.tryReconnect(socket) {
 			log.Errorf("短时间内连接失败次数过多，不再进行重连")
 			ep.State = 3
 			ep.Enable = false
 		}
 	}
+	pa.runtimeMu.Lock()
 	pa.Socket = socket
+	pa.runtimeMu.Unlock()
 }
 
 func (pa *PlatformAdapterMinecraft) toStdMessage(msgMC *MessageMinecraft) *Message {
@@ -191,14 +215,18 @@ func ExtractMCUserID(id string) string {
 
 func (pa *PlatformAdapterMinecraft) DoRelogin() bool {
 	log := pa.EndPoint.Session.Parent.Logger
-	pa.Reconnecting = true
-	pa.Socket.Close()
+	pa.Reconnecting.Store(true)
+	pa.runtimeMu.Lock()
+	if pa.Socket != nil {
+		pa.Socket.Close()
+	}
 	socket := gowebsocket.New(pa.ConnectURL)
-	log.Infof("MC server 重新连接")
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
+	log.Infof("MC server 重新连接")
 	pa.socketSetup()
 	socket.Connect()
-	pa.Reconnecting = false
+	pa.Reconnecting.Store(false)
 	return true
 }
 
@@ -206,28 +234,33 @@ func (pa *PlatformAdapterMinecraft) SetEnable(enable bool) {
 	log := pa.EndPoint.Session.Parent.Logger
 	if enable {
 		log.Infof("MC server 连接中")
+		pa.runtimeMu.Lock()
 		if pa.Socket != nil && pa.Socket.IsConnected {
-			pa.Reconnecting = true
+			pa.Reconnecting.Store(true)
 			pa.Socket.Close()
 			socket := gowebsocket.New(pa.ConnectURL)
 			pa.Socket = &socket
+			pa.runtimeMu.Unlock()
 			pa.socketSetup()
 			socket.Connect()
-			pa.Reconnecting = false
+			pa.Reconnecting.Store(false)
 		} else {
-			pa.Reconnecting = true
+			pa.Reconnecting.Store(true)
 			socket := gowebsocket.New(pa.ConnectURL)
 			pa.Socket = &socket
+			pa.runtimeMu.Unlock()
 			pa.socketSetup()
 			socket.Connect()
-			pa.Reconnecting = false
+			pa.Reconnecting.Store(false)
 		}
 	} else {
-		pa.Reconnecting = true
+		pa.Reconnecting.Store(true)
+		pa.runtimeMu.Lock()
 		if pa.Socket != nil {
 			pa.Socket.Close()
 		}
-		pa.Reconnecting = false
+		pa.runtimeMu.Unlock()
+		pa.Reconnecting.Store(false)
 	}
 }
 
@@ -244,7 +277,9 @@ func (pa *PlatformAdapterMinecraft) SendToPerson(ctx *MsgContext, uid string, te
 	msg.Content = text
 	msg.MessageType = "private"
 	parse, _ := json.Marshal(msg)
-	pa.Socket.SendText(string(parse))
+	if socket := pa.socketSnapshot(); socket != nil {
+		socket.SendText(string(parse))
+	}
 	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "MC",
 		MessageType: "private",
@@ -261,7 +296,9 @@ func (pa *PlatformAdapterMinecraft) SendToGroup(ctx *MsgContext, uid string, tex
 	msg.Content = text
 	msg.MessageType = "group"
 	parse, _ := json.Marshal(msg)
-	pa.Socket.SendText(string(parse))
+	if socket := pa.socketSnapshot(); socket != nil {
+		socket.SendText(string(parse))
+	}
 	pa.EndPoint.Session.OnMessageSend(ctx, &Message{
 		Platform:    "MC",
 		MessageType: "group",

--- a/dice/platform_adapter_minecraft.go
+++ b/dice/platform_adapter_minecraft.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/sacOO7/gowebsocket"
@@ -12,11 +13,12 @@ import (
 )
 
 type PlatformAdapterMinecraft struct {
-	EndPoint     *EndPointInfo       `json:"-"          yaml:"-"`
-	Socket       *gowebsocket.Socket `json:"-"          yaml:"-"`
-	RetryTimes   int                 `json:"-"          yaml:"-"`
-	Reconnecting bool                `json:"-"          yaml:"-"`
-	ConnectURL   string              `json:"connectUrl" yaml:"connectUrl"` // 连接地址
+	EndPoint        *EndPointInfo       `json:"-"          yaml:"-"`
+	Socket          *gowebsocket.Socket `json:"-"          yaml:"-"`
+	RetryTimes      int                 `json:"-"          yaml:"-"`
+	Reconnecting    bool                `json:"-"          yaml:"-"`
+	ConnectURL      string              `json:"connectUrl" yaml:"connectUrl"` // 连接地址
+	runtimeStopping atomic.Bool
 }
 
 type MessageMinecraft struct {
@@ -42,6 +44,7 @@ type SendMessageMinecraft struct {
 func (pa *PlatformAdapterMinecraft) GetGroupInfoAsync(_ string) {}
 
 func (pa *PlatformAdapterMinecraft) Serve() int {
+	pa.runtimeStopping.Store(false)
 	if !strings.HasPrefix(pa.ConnectURL, "ws://") {
 		pa.ConnectURL = "ws://" + pa.ConnectURL
 	}
@@ -59,6 +62,9 @@ func (pa *PlatformAdapterMinecraft) Serve() int {
 
 func (pa *PlatformAdapterMinecraft) tryReconnect(socket gowebsocket.Socket) bool {
 	log := pa.EndPoint.Session.Parent.Logger
+	if pa.runtimeStopping.Load() {
+		return false
+	}
 	if pa.Reconnecting {
 		return false
 	}
@@ -79,6 +85,16 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 	log := ep.Session.Parent.Logger
 	socket := pa.Socket
 	socket.OnConnected = func(socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			socket.Close()
+			return
+		}
+		defer done()
+		if pa.runtimeStopping.Load() {
+			socket.Close()
+			return
+		}
 		pa.Reconnecting = true
 		ep.State = 1
 		ep.Enable = true
@@ -93,6 +109,11 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		pa.Reconnecting = false
 	}
 	socket.OnTextMessage = func(message string, socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			return
+		}
+		defer done()
 		msgMC := new(MessageMinecraft)
 		err := json.Unmarshal([]byte(message), msgMC)
 		if err == nil {
@@ -100,7 +121,15 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		}
 	}
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			return
+		}
+		defer done()
 		log.Errorf("MC websocket出现错误: %s", err)
+		if pa.runtimeStopping.Load() {
+			return
+		}
 		if !socket.IsConnected {
 			// socket.Close()
 			if !pa.tryReconnect(*pa.Socket) {
@@ -111,7 +140,15 @@ func (pa *PlatformAdapterMinecraft) socketSetup() {
 		}
 	}
 	socket.OnDisconnected = func(err error, socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			return
+		}
+		defer done()
 		log.Errorf("与MC服务器断开连接")
+		if pa.runtimeStopping.Load() {
+			return
+		}
 		time.Sleep(time.Duration(2) * time.Second)
 		if !pa.tryReconnect(*pa.Socket) {
 			log.Errorf("短时间内连接失败次数过多，不再进行重连")
@@ -187,7 +224,7 @@ func (pa *PlatformAdapterMinecraft) SetEnable(enable bool) {
 		}
 	} else {
 		pa.Reconnecting = true
-		if pa.Socket != nil && pa.Socket.IsConnected {
+		if pa.Socket != nil {
 			pa.Socket.Close()
 		}
 		pa.Reconnecting = false

--- a/dice/platform_adapter_official_qq.go
+++ b/dice/platform_adapter_official_qq.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -104,7 +105,12 @@ type PlatformAdapterOfficialQQ struct {
 	botID          string               `json:"-" yaml:"-"`
 
 	// Webhook服务
-	webhookServer *http.Server `json:"-" yaml:"-"`
+	webhookServer   *http.Server `json:"-" yaml:"-"`
+	runtimeMu       sync.Mutex
+	sessionDone     chan struct{}
+	webhookDone     chan struct{}
+	qrDone          chan struct{}
+	runtimeStopping atomic.Bool
 
 	paginationCache map[string]*PaginationItem `json:"-" yaml:"-"`
 	paginationMu    sync.Mutex                 `json:"-" yaml:"-"`
@@ -378,6 +384,7 @@ func (pa *PlatformAdapterOfficialQQ) failConnect() int {
 }
 
 func (pa *PlatformAdapterOfficialQQ) Serve() int {
+	pa.runtimeStopping.Store(false)
 	ep := pa.EndPoint
 	log := pa.EndPoint.Session.Parent.Logger
 
@@ -407,6 +414,9 @@ func (pa *PlatformAdapterOfficialQQ) Serve() int {
 // connect 建立正式连接。probe 非空时复用探测结果，避免重复拉取机器人信息。
 // 调用方需确保 AppID/AppSecret 已就绪。
 func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult) int {
+	if pa.runtimeStopping.Load() {
+		return 1
+	}
 	ep := pa.EndPoint
 	log := ep.Session.Parent.Logger
 	d := ep.Session.Parent
@@ -488,16 +498,22 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 			ReadHeaderTimeout: 3 * time.Second,
 		}
 
-		go func() {
+		webhookDone := make(chan struct{})
+		pa.runtimeMu.Lock()
+		pa.webhookDone = webhookDone
+		server := pa.webhookServer
+		pa.runtimeMu.Unlock()
+		runDiceRuntimeTask(ep.Session.Parent, func() {
+			defer close(webhookDone)
 			log.Infof("official qq webhook: 监听地址 %s%s", addr, pa.WebhookPath)
-			if err := pa.webhookServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				log.Error("official qq webhook服务器启动失败: ", err)
 				if pa.Ctx == ctx {
 					ep.State = 3
 					ep.Enable = false
 				}
 			}
-		}()
+		})
 
 		ep.State = 1
 		ep.Enable = true
@@ -543,14 +559,20 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 		intent |= dto.IntentGroupMembers
 	}
 
+	sessionManager := pa.SessionManager
+	sessionDone := make(chan struct{})
+	pa.runtimeMu.Lock()
+	pa.sessionDone = sessionDone
+	pa.runtimeMu.Unlock()
 	go func() {
+		defer close(sessionDone)
 		currentCtx := ctx
 		defer func() {
 			isCurrent := pa.Ctx == currentCtx
 			// 防止崩掉进程
 			if r := recover(); r != nil {
 				log.Error("official qq 启动失败: ", r)
-				if isCurrent {
+				if isCurrent && !pa.runtimeStopping.Load() {
 					ep.State = 3
 					ep.Enable = false
 				}
@@ -561,9 +583,9 @@ func (pa *PlatformAdapterOfficialQQ) connect(probe *OfficialQQAccountProbeResult
 				pa.SessionManager = nil
 			}
 		}()
-		if startErr := pa.SessionManager.Start(currentCtx, ws, pa.tokenSource, &intent); startErr != nil {
+		if startErr := sessionManager.Start(currentCtx, ws, pa.tokenSource, &intent); startErr != nil {
 			log.Error("official qq session manager 启动失败: ", startErr)
-			if pa.Ctx == currentCtx {
+			if pa.Ctx == currentCtx && !pa.runtimeStopping.Load() {
 				ep.State = 3
 				ep.Enable = false
 			}
@@ -1036,14 +1058,14 @@ func (pa *PlatformAdapterOfficialQQ) GroupMemberAddReceive(event *dto.WSPayload,
 		log.Infof("official qq: 机器人加入群 %s", groupID)
 
 		// 发送入群致辞
-		go func() {
+		runDiceRuntimeTask(s.Parent, func() {
 			time.Sleep(2 * time.Second)
 			ctx.Player = &GroupPlayerInfo{}
 			text := DiceFormatTmpl(ctx, "核心:骰子进群")
 			for _, i := range ctx.SplitText(text) {
 				pa.SendToGroup(ctx, groupID, strings.TrimSpace(i), "")
 			}
-		}()
+		})
 	} else {
 		// 普通成员进群
 		ctx := &MsgContext{EndPoint: pa.EndPoint, Session: s, Dice: s.Parent}
@@ -1162,8 +1184,14 @@ func (pa *PlatformAdapterOfficialQQ) C2CFriendReceive(event *dto.WSPayload, data
 		welcomeStr := DiceFormatTmpl(ctx, "核心:骰子成为好友")
 		log.Infof("official qq: 与%s 成为好友，发送好友致辞 %s", userID, welcomeStr)
 
-		go func() {
-			time.Sleep(2 * time.Second)
+		runDiceRuntimeTaskContext(s.Parent, func(runtimeCtx context.Context) {
+			timer := time.NewTimer(2 * time.Second)
+			defer timer.Stop()
+			select {
+			case <-runtimeCtx.Done():
+				return
+			case <-timer.C:
+			}
 			for _, i := range ctx.SplitText(welcomeStr) {
 				pa.SendToPerson(ctx, userID, strings.TrimSpace(i), "")
 			}
@@ -1175,7 +1203,7 @@ func (pa *PlatformAdapterOfficialQQ) C2CFriendReceive(event *dto.WSPayload, data
 					return func() { ext.OnBecomeFriend(ctx, msg) }
 				})
 			}
-		}()
+		})
 	case dto.EventC2CFriendDel:
 		userID := formatDiceIDOfficialQQUserOpenID(pa.UIN, data.OpenID)
 		log.Infof("official qq: 与 %s 解除好友关系", userID)
@@ -2351,7 +2379,7 @@ func (pa *PlatformAdapterOfficialQQ) handleWebhookCallback(w http.ResponseWriter
 	}
 
 	// 异步处理事件
-	go func() {
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 		defer func() {
 			if rec := recover(); rec != nil {
 				log.Errorf("official qq webhook: 处理事件异常: %v", rec)
@@ -2360,7 +2388,7 @@ func (pa *PlatformAdapterOfficialQQ) handleWebhookCallback(w http.ResponseWriter
 		if err := event.ParseAndHandle(&payload); err != nil {
 			log.Errorf("official qq webhook: 事件处理失败: %v", err)
 		}
-	}()
+	})
 }
 
 // verifyWebhookSignature 验证Webhook签名
@@ -2796,7 +2824,12 @@ func (pa *PlatformAdapterOfficialQQ) serveQrLogin(source string) {
 	pa.qrMu.Unlock()
 	log.Info("official qq 扫码二维码已就绪")
 
+	qrDone := make(chan struct{})
+	pa.runtimeMu.Lock()
+	pa.qrDone = qrDone
+	pa.runtimeMu.Unlock()
 	go func() {
+		defer close(qrDone)
 		ticker := time.NewTicker(2 * time.Second)
 		defer ticker.Stop()
 
@@ -2824,6 +2857,10 @@ func (pa *PlatformAdapterOfficialQQ) serveQrLogin(source string) {
 
 			switch result.Status {
 			case qqBotBindStatusComplete:
+				if pa.runtimeStopping.Load() {
+					curSession.mu.Unlock()
+					return
+				}
 				pa.AppID = strings.TrimSpace(result.BotAppID)
 				curSession.mu.Unlock()
 				if pa.AppID == "" {

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	socketio "github.com/PaienNate/pineutil/evsocket/v2"
@@ -55,10 +56,11 @@ type PlatformAdapterOnebot struct {
 	friendRequestDedupeMu    sync.Mutex
 	friendRequestDedupTTL    time.Duration
 
-	retryAttempts  uint         // 当前重试次数
-	isRetrying     bool         // 是否正在重试
-	retryMutex     sync.RWMutex // 重试状态锁
-	isShuttingDown bool         // 是否正在主动关闭连接
+	retryAttempts   uint         // 当前重试次数
+	isRetrying      bool         // 是否正在重试
+	retryMutex      sync.RWMutex // 重试状态锁
+	isShuttingDown  bool         // 是否正在主动关闭连接
+	runtimeStopping atomic.Bool  // 当前 Runtime generation 正在关闭
 
 	// 连接建立互斥锁，确保同时只有一个连接建立过程
 	connectionMutex sync.Mutex
@@ -73,6 +75,9 @@ type PlatformAdapterOnebot struct {
 }
 
 func (p *PlatformAdapterOnebot) Serve() int {
+	if p.runtimeStopping.Load() {
+		return 0
+	}
 	p.ensureFSM()
 	p.desiredEnabled = true
 	_ = p.sm.Event(context.Background(), "enable")
@@ -87,6 +92,9 @@ func (p *PlatformAdapterOnebot) DoRelogin() bool {
 
 // SetEnable 启用或禁用适配器
 func (p *PlatformAdapterOnebot) SetEnable(enable bool) {
+	if enable && p.runtimeStopping.Load() {
+		return
+	}
 	p.ensureFSM()
 	if enable {
 		p.logger.Info("正在启用 OneBot 适配器...")
@@ -639,6 +647,9 @@ func (p *PlatformAdapterOnebot) initializeCommonResources() {
 
 // setupClientConnection 设置客户端连接
 func (p *PlatformAdapterOnebot) setupClientConnection() error {
+	if p.runtimeStopping.Load() || p.websocketManager == nil {
+		return errors.New("runtime is closing")
+	}
 	options := socketio.ClientOptions{
 		RequestHeader: http.Header{},
 	}
@@ -658,7 +669,7 @@ func (p *PlatformAdapterOnebot) setupClientConnection() error {
 			var closeErr *websocket.CloseError
 			if errors.As(err, &closeErr) && closeErr.Code == 1002 {
 				p.logger.Info("连接正常关闭 (WebSocket 1002)")
-			} else if p.isShuttingDown {
+			} else if p.isShuttingDown || p.runtimeStopping.Load() {
 				p.logger.Infof("适配器关闭中，连接断开: %v", err)
 			} else {
 				p.logger.Errorf("连接异常断开: %v", err)
@@ -700,7 +711,7 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 	retryFn := p.loginInitRetry
 	if retryFn == nil {
 		retryFn = func() {
-			if !p.desiredEnabled || p.sendEmitter == nil || p.ctx == nil {
+			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() || p.sendEmitter == nil || p.ctx == nil {
 				return
 			}
 			sleepFn := p.loginInitRetrySleep
@@ -708,7 +719,7 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 				sleepFn = time.Sleep
 			}
 			sleepFn(3 * time.Second)
-			if !p.desiredEnabled || p.sendEmitter == nil || p.ctx == nil {
+			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() || p.sendEmitter == nil || p.ctx == nil {
 				return
 			}
 			info, err := p.sendEmitter.GetLoginInfo(p.ctx)
@@ -723,11 +734,14 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 			_ = p.sm.Event(context.Background(), "connect_ok")
 		}
 	}
-	go retryFn()
+	runDiceRuntimeTask(p.EndPoint.Session.Parent, retryFn)
 }
 
 // setupServerConnection 设置服务器连接
 func (p *PlatformAdapterOnebot) setupServerConnection() error {
+	if p.runtimeStopping.Load() || p.websocketManager == nil {
+		return errors.New("runtime is closing")
+	}
 	p.echoServer = echo.New()
 	p.echoServer.HideBanner = true
 	p.echoServer.Use(middleware.Recover())
@@ -824,6 +838,9 @@ func (p *PlatformAdapterOnebot) startConnection() error {
 	if p.logger == nil {
 		p.logger = zap.S().Named(logger.LogKeyAdapter)
 	}
+	if p.runtimeStopping.Load() {
+		return errors.New("runtime is closing")
+	}
 
 	// 检查是否已经在连接中
 	if p.isConnecting {
@@ -841,13 +858,17 @@ func (p *PlatformAdapterOnebot) startConnection() error {
 
 	// 确保公共资源已初始化（包括上下文创建）
 	p.initializeCommonResources()
+	if p.runtimeStopping.Load() {
+		p.cleanupResources()
+		return errors.New("runtime is closing")
+	}
 
 	switch p.Mode {
 	case "client":
 		return p.setupClientConnection()
 	case "server":
 		// 服务器模式在 goroutine 中启动，避免阻塞
-		go func() {
+		runDiceRuntimeTask(p.EndPoint.Session.Parent, func() {
 			defer func() {
 				if r := recover(); r != nil {
 					p.logger.Errorf("服务器异常崩溃: %v", r)
@@ -861,7 +882,7 @@ func (p *PlatformAdapterOnebot) startConnection() error {
 				}
 				_ = p.sm.Event(context.Background(), "connect_fail")
 			}
-		}()
+		})
 		return nil
 	default:
 		return fmt.Errorf("未知的连接模式: %s", p.Mode)
@@ -871,7 +892,7 @@ func (p *PlatformAdapterOnebot) startConnection() error {
 // retryConnect 重试连接方法
 func (p *PlatformAdapterOnebot) retryConnect() {
 	// 检查适配器是否已被禁用
-	if !p.desiredEnabled {
+	if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() {
 		p.logger.Info("适配器已被禁用，取消重连")
 		return
 	}
@@ -893,11 +914,15 @@ func (p *PlatformAdapterOnebot) retryConnect() {
 
 	const maxRetries = 5
 	const baseDelay = 2 * time.Second
+	retryCtx := p.ctx
+	if retryCtx == nil {
+		retryCtx = context.Background()
+	}
 
 	err := retry.Do(
 		func() error {
 			// 在每次重试前再次检查适配器是否已被禁用
-			if !p.desiredEnabled {
+			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() {
 				return errors.New("适配器已被禁用，停止重连")
 			}
 
@@ -918,11 +943,12 @@ func (p *PlatformAdapterOnebot) retryConnect() {
 			return p.startConnection()
 		},
 		retry.Attempts(maxRetries),
+		retry.Context(retryCtx),
 		retry.Delay(baseDelay),
 		retry.DelayType(retry.BackOffDelay),
 		retry.OnRetry(func(n uint, err error) {
 			// 在重试前再次检查适配器是否已被禁用
-			if !p.desiredEnabled {
+			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() {
 				p.logger.Info("适配器已被禁用，停止重试")
 				return
 			}
@@ -1002,14 +1028,16 @@ func (p *PlatformAdapterOnebot) cbEnterFailed(_ context.Context, _ *loopfsm.Even
 	// 连接失败不等于用户禁用；保持 Enable 不变，避免持久化成“禁用”导致重启后不再自动连接。
 	p.EndPoint.Enable = p.desiredEnabled
 	p.updateAndSave()
-	if p.desiredEnabled {
-		go p.retryConnect()
+	if p.desiredEnabled && !p.isShuttingDown && !p.runtimeStopping.Load() {
+		runDiceRuntimeTask(p.EndPoint.Session.Parent, p.retryConnect)
 	}
 }
 
 func (p *PlatformAdapterOnebot) cbEnterDisconnected(_ context.Context, _ *loopfsm.Event) {
 	p.EndPoint.State = StateDisconnected
-	p.EndPoint.Enable = false
+	if !p.isShuttingDown && !p.runtimeStopping.Load() {
+		p.EndPoint.Enable = false
+	}
 	p.updateAndSave()
 }
 

--- a/dice/platform_adapter_onebot.go
+++ b/dice/platform_adapter_onebot.go
@@ -48,7 +48,8 @@ type PlatformAdapterOnebot struct {
 	once        sync.Once
 
 	// 执行用池
-	antPool *ants.Pool
+	antPool   *ants.Pool
+	antPoolMu sync.Mutex
 	// 群缓存
 	groupCache *otter.Cache[string, *GroupCache] // 群ID和群信息的缓存
 	// 好友申请去重缓存
@@ -59,7 +60,7 @@ type PlatformAdapterOnebot struct {
 	retryAttempts   uint         // 当前重试次数
 	isRetrying      bool         // 是否正在重试
 	retryMutex      sync.RWMutex // 重试状态锁
-	isShuttingDown  bool         // 是否正在主动关闭连接
+	isShuttingDown  atomic.Bool  // 是否正在主动关闭连接
 	runtimeStopping atomic.Bool  // 当前 Runtime generation 正在关闭
 
 	// 连接建立互斥锁，确保同时只有一个连接建立过程
@@ -442,8 +443,37 @@ func (p *PlatformAdapterOnebot) SendFileToGroup(ctx *MsgContext, groupID string,
 	p.SendSegmentToGroup(ctx, groupID, msg, flag)
 }
 
+func (p *PlatformAdapterOnebot) ensureAntPool() {
+	p.antPoolMu.Lock()
+	defer p.antPoolMu.Unlock()
+	if p.antPool == nil {
+		p.antPool, _ = ants.NewPool(500, ants.WithPanicHandler(func(re any) {
+			p.logger.Errorf("执行发送数据任务异常 %v", re)
+		}))
+	}
+}
+
+func (p *PlatformAdapterOnebot) submitAntPoolTask(task func()) error {
+	p.antPoolMu.Lock()
+	pool := p.antPool
+	p.antPoolMu.Unlock()
+	if pool == nil {
+		return errors.New("ant pool is not initialized")
+	}
+	return pool.Submit(task)
+}
+
+func (p *PlatformAdapterOnebot) releaseAntPool() {
+	p.antPoolMu.Lock()
+	defer p.antPoolMu.Unlock()
+	if p.antPool != nil {
+		p.antPool.Release()
+		p.antPool = nil
+	}
+}
+
 func (p *PlatformAdapterOnebot) GetGroupInfoAsync(groupID string) {
-	_ = p.antPool.Submit(func() {
+	_ = p.submitAntPoolTask(func() {
 		p.GetGroupInfoSync(groupID)
 	})
 }
@@ -623,11 +653,7 @@ func (p *PlatformAdapterOnebot) initializeCommonResources() {
 	p.ctx, p.cancel = context.WithCancel(context.Background())
 
 	// 条件性初始化antPool
-	if p.antPool == nil {
-		p.antPool, _ = ants.NewPool(500, ants.WithPanicHandler(func(re any) {
-			p.logger.Errorf("执行发送数据任务异常 %v", re)
-		}))
-	}
+	p.ensureAntPool()
 
 	// 条件性初始化groupCache
 	if p.groupCache == nil {
@@ -669,7 +695,7 @@ func (p *PlatformAdapterOnebot) setupClientConnection() error {
 			var closeErr *websocket.CloseError
 			if errors.As(err, &closeErr) && closeErr.Code == 1002 {
 				p.logger.Info("连接正常关闭 (WebSocket 1002)")
-			} else if p.isShuttingDown || p.runtimeStopping.Load() {
+			} else if p.isShuttingDown.Load() || p.runtimeStopping.Load() {
 				p.logger.Infof("适配器关闭中，连接断开: %v", err)
 			} else {
 				p.logger.Errorf("连接异常断开: %v", err)
@@ -711,7 +737,7 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 	retryFn := p.loginInitRetry
 	if retryFn == nil {
 		retryFn = func() {
-			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() || p.sendEmitter == nil || p.ctx == nil {
+			if !p.desiredEnabled || p.isShuttingDown.Load() || p.runtimeStopping.Load() || p.sendEmitter == nil || p.ctx == nil {
 				return
 			}
 			sleepFn := p.loginInitRetrySleep
@@ -719,7 +745,7 @@ func (p *PlatformAdapterOnebot) scheduleLoginInfoRetry() {
 				sleepFn = time.Sleep
 			}
 			sleepFn(3 * time.Second)
-			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() || p.sendEmitter == nil || p.ctx == nil {
+			if !p.desiredEnabled || p.isShuttingDown.Load() || p.runtimeStopping.Load() || p.sendEmitter == nil || p.ctx == nil {
 				return
 			}
 			info, err := p.sendEmitter.GetLoginInfo(p.ctx)
@@ -753,7 +779,7 @@ func (p *PlatformAdapterOnebot) setupServerConnection() error {
 // cleanupResources 清理资源
 func (p *PlatformAdapterOnebot) cleanupResources() {
 	// 设置主动关闭标志
-	p.isShuttingDown = true
+	p.isShuttingDown.Store(true)
 
 	// 1. 首先关闭服务器，停止接收新的请求（避免在清理过程中崩溃）
 	if p.isServer() && p.echoServer != nil {
@@ -781,10 +807,7 @@ func (p *PlatformAdapterOnebot) cleanupResources() {
 	}
 
 	// 4. 关闭资源池
-	if p.antPool != nil {
-		p.antPool.Release()
-		p.antPool = nil
-	}
+	p.releaseAntPool()
 
 	if p.friendRequestDedupeCache != nil {
 		p.friendRequestDedupeCache.Close()
@@ -798,7 +821,7 @@ func (p *PlatformAdapterOnebot) cleanupResources() {
 	p.connectionMutex.Unlock()
 
 	// 6. 重置主动关闭标志
-	p.isShuttingDown = false
+	p.isShuttingDown.Store(false)
 }
 
 func (p *PlatformAdapterOnebot) ensureFriendRequestDedupeCache() (*otter.Cache[string, struct{}], error) {
@@ -892,7 +915,7 @@ func (p *PlatformAdapterOnebot) startConnection() error {
 // retryConnect 重试连接方法
 func (p *PlatformAdapterOnebot) retryConnect() {
 	// 检查适配器是否已被禁用
-	if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() {
+	if !p.desiredEnabled || p.isShuttingDown.Load() || p.runtimeStopping.Load() {
 		p.logger.Info("适配器已被禁用，取消重连")
 		return
 	}
@@ -922,7 +945,7 @@ func (p *PlatformAdapterOnebot) retryConnect() {
 	err := retry.Do(
 		func() error {
 			// 在每次重试前再次检查适配器是否已被禁用
-			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() {
+			if !p.desiredEnabled || p.isShuttingDown.Load() || p.runtimeStopping.Load() {
 				return errors.New("适配器已被禁用，停止重连")
 			}
 
@@ -948,7 +971,7 @@ func (p *PlatformAdapterOnebot) retryConnect() {
 		retry.DelayType(retry.BackOffDelay),
 		retry.OnRetry(func(n uint, err error) {
 			// 在重试前再次检查适配器是否已被禁用
-			if !p.desiredEnabled || p.isShuttingDown || p.runtimeStopping.Load() {
+			if !p.desiredEnabled || p.isShuttingDown.Load() || p.runtimeStopping.Load() {
 				p.logger.Info("适配器已被禁用，停止重试")
 				return
 			}
@@ -1028,14 +1051,14 @@ func (p *PlatformAdapterOnebot) cbEnterFailed(_ context.Context, _ *loopfsm.Even
 	// 连接失败不等于用户禁用；保持 Enable 不变，避免持久化成“禁用”导致重启后不再自动连接。
 	p.EndPoint.Enable = p.desiredEnabled
 	p.updateAndSave()
-	if p.desiredEnabled && !p.isShuttingDown && !p.runtimeStopping.Load() {
+	if p.desiredEnabled && !p.isShuttingDown.Load() && !p.runtimeStopping.Load() {
 		runDiceRuntimeTask(p.EndPoint.Session.Parent, p.retryConnect)
 	}
 }
 
 func (p *PlatformAdapterOnebot) cbEnterDisconnected(_ context.Context, _ *loopfsm.Event) {
 	p.EndPoint.State = StateDisconnected
-	if !p.isShuttingDown && !p.runtimeStopping.Load() {
+	if !p.isShuttingDown.Load() && !p.runtimeStopping.Load() {
 		p.EndPoint.Enable = false
 	}
 	p.updateAndSave()

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -175,7 +175,7 @@ func (p *PlatformAdapterOnebot) handleGroupDecreaseAction(req gjson.Result, _ *e
 }
 
 func (p *PlatformAdapterOnebot) handleGroupPokeAction(req gjson.Result, _ *evsocket.EventPayload) error {
-	go func() {
+	runDiceRuntimeTask(p.EndPoint.Session.Parent, func() {
 		session := p.EndPoint.Session
 		defer ErrorLogAndContinue(session.Parent)
 		msgContext := p.makeCtx(req)
@@ -190,7 +190,7 @@ func (p *PlatformAdapterOnebot) handleGroupPokeAction(req gjson.Result, _ *evsoc
 			TargetID:  FormatDiceIDQQ(req.Get("target_id").String()),
 			IsPrivate: isPrivate,
 		})
-	}()
+	})
 	return nil
 }
 
@@ -566,10 +566,34 @@ func checkBlackList(id string, checkType string, inviterID string, ctx *MsgConte
 }
 
 func (p *PlatformAdapterOnebot) submitAsync(task func()) error {
-	if p != nil && p.antPool != nil {
-		return p.antPool.Submit(task)
+	var currentDice *Dice
+	if p != nil && p.EndPoint != nil && p.EndPoint.Session != nil {
+		currentDice = p.EndPoint.Session.Parent
 	}
-	return ants.Submit(task)
+	done, accepted := beginDiceRuntimeTask(currentDice)
+	if !accepted {
+		return errors.New("runtime is closing")
+	}
+	if p == nil || p.runtimeStopping.Load() {
+		done()
+		return errors.New("runtime is closing")
+	}
+	wrapped := func() {
+		defer done()
+		task()
+	}
+	if p.antPool != nil {
+		if err := p.antPool.Submit(wrapped); err != nil {
+			done()
+			return err
+		}
+		return nil
+	}
+	if err := ants.Submit(wrapped); err != nil {
+		done()
+		return err
+	}
+	return nil
 }
 
 func (p *PlatformAdapterOnebot) onOnebotMetaDataEvent(ep *evsocket.EventPayload) {

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -582,11 +582,7 @@ func (p *PlatformAdapterOnebot) submitAsync(task func()) error {
 		defer done()
 		task()
 	}
-	if p.antPool != nil {
-		if err := p.antPool.Submit(wrapped); err != nil {
-			done()
-			return err
-		}
+	if err := p.submitAntPoolTask(wrapped); err == nil {
 		return nil
 	}
 	if err := ants.Submit(wrapped); err != nil {

--- a/dice/platform_adapter_qq_helper.go
+++ b/dice/platform_adapter_qq_helper.go
@@ -35,17 +35,22 @@ func ServeQQ(d *Dice, ep *EndPointInfo) {
 }
 
 func serverGocq(d *Dice, ep *EndPointInfo, conn *PlatformAdapterGocq) {
-	if conn.diceServing {
+	conn.runtimeMu.Lock()
+	if conn.runtimeStopping.Load() || conn.diceServing {
+		conn.runtimeMu.Unlock()
 		return
 	}
 	conn.diceServing = true
-
 	ep.Enable = true
 	ep.State = 2 // 连接中
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
+	conn.runtimeMu.Unlock()
 
 	checkQuit := func() bool {
+		if conn.runtimeStopping.Load() {
+			return true
+		}
 		if conn.GoCqhttpState == StateCodeInLoginDeviceLock {
 			d.Logger.Infof("检测到设备锁流程，暂时不再连接")
 			ep.State = 0
@@ -53,7 +58,10 @@ func serverGocq(d *Dice, ep *EndPointInfo, conn *PlatformAdapterGocq) {
 			d.Save(false)
 			return true
 		}
-		if !conn.diceServing {
+		conn.runtimeMu.Lock()
+		serving := conn.diceServing
+		conn.runtimeMu.Unlock()
+		if !serving {
 			// 退出连接
 			d.Logger.Infof("检测到连接关闭，不再进行此onebot服务的重连: <%s>(%s)", ep.Nickname, ep.UserID)
 			return true
@@ -84,7 +92,9 @@ func serverGocq(d *Dice, ep *EndPointInfo, conn *PlatformAdapterGocq) {
 		}
 
 		if conn.GoCqhttpState == StateCodeInLogin || conn.GoCqhttpState == StateCodeInLoginQrCode {
-			time.Sleep(15 * time.Second)
+			if !waitRuntimeDelay(diceRuntimeContext(d), 15*time.Second) {
+				break
+			}
 			continue
 		}
 
@@ -96,14 +106,20 @@ func serverGocq(d *Dice, ep *EndPointInfo, conn *PlatformAdapterGocq) {
 			break
 		}
 
-		time.Sleep(15 * time.Second)
+		if !waitRuntimeDelay(diceRuntimeContext(d), 15*time.Second) {
+			break
+		}
 	}
 
+	conn.runtimeMu.Lock()
 	conn.diceServing = false
+	conn.runtimeMu.Unlock()
 }
 
 func serverWalleQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterWalleQ) {
-	if conn.DiceServing {
+	conn.runtimeMu.Lock()
+	if conn.runtimeStopping.Load() || conn.DiceServing {
+		conn.runtimeMu.Unlock()
 		return
 	}
 	conn.DiceServing = true
@@ -111,8 +127,12 @@ func serverWalleQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterWalleQ) {
 	ep.State = 2 // 连接中
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
+	conn.runtimeMu.Unlock()
 
 	checkQuit := func() bool {
+		if conn.runtimeStopping.Load() {
+			return true
+		}
 		if conn.WalleQState == StateCodeInLoginDeviceLock {
 			d.Logger.Infof("检测到设备锁流程，暂时不再连接")
 			ep.State = 0
@@ -120,7 +140,10 @@ func serverWalleQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterWalleQ) {
 			d.Save(false)
 			return true
 		} // 暂时去掉设备锁检查
-		if !conn.DiceServing {
+		conn.runtimeMu.Lock()
+		serving := conn.DiceServing
+		conn.runtimeMu.Unlock()
+		if !serving {
 			// 退出连接
 			d.Logger.Infof("检测到连接关闭，不再进行此onebot服务的重连: <%s>(%s)", ep.Nickname, ep.UserID)
 			return true
@@ -145,27 +168,36 @@ func serverWalleQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterWalleQ) {
 		waitTimes++
 		if waitTimes > 5 {
 			d.Logger.Infof("onebot 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
+			conn.runtimeMu.Lock()
 			conn.DiceServing = false
+			conn.runtimeMu.Unlock()
 			break
 		}
 
-		time.Sleep(15 * time.Second)
+		if !waitRuntimeDelay(diceRuntimeContext(d), 15*time.Second) {
+			break
+		}
 	}
+	conn.runtimeMu.Lock()
+	conn.DiceServing = false
+	conn.runtimeMu.Unlock()
 }
 
 func serverRed(d *Dice, ep *EndPointInfo, conn *PlatformAdapterRed) {
-	if conn.DiceServing {
+	conn.runtimeMu.Lock()
+	if conn.runtimeStopping.Load() || conn.DiceServing {
+		conn.runtimeMu.Unlock()
 		return
 	}
 	conn.DiceServing = true
-
 	ep.Enable = true
 	ep.State = 2 // 连接中
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
+	conn.runtimeMu.Unlock()
 	waitTimes := 0
 
-	for {
+	for !conn.runtimeStopping.Load() {
 		// 骰子开始连接
 		d.Logger.Infof("开始连接 red 服务，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
 		ret := ep.Adapter.Serve()
@@ -173,19 +205,29 @@ func serverRed(d *Dice, ep *EndPointInfo, conn *PlatformAdapterRed) {
 		if ret == 0 {
 			break
 		}
+		if conn.runtimeStopping.Load() {
+			break
+		}
 
 		waitTimes += 1
 		if waitTimes > 5 {
 			d.Logger.Infof("red 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			conn.DiceServing = false
 			break
 		}
 
-		time.Sleep(15 * time.Second)
+		if !waitRuntimeDelay(diceRuntimeContext(d), 15*time.Second) {
+			break
+		}
 	}
+	conn.runtimeMu.Lock()
+	conn.DiceServing = false
+	conn.runtimeMu.Unlock()
 }
 
 func serverSatori(d *Dice, ep *EndPointInfo, conn *PlatformAdapterSatori) {
+	if diceRuntimeContext(d).Err() != nil {
+		return
+	}
 	if conn.DiceServing {
 		return
 	}
@@ -197,7 +239,7 @@ func serverSatori(d *Dice, ep *EndPointInfo, conn *PlatformAdapterSatori) {
 	d.Save(false)
 	waitTimes := 0
 
-	for ep.State == 2 {
+	for ep.State == 2 && diceRuntimeContext(d).Err() == nil {
 		// 骰子开始连接
 		d.Logger.Infof("开始连接 satori 服务，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
 		ret := ep.Adapter.Serve()
@@ -213,16 +255,22 @@ func serverSatori(d *Dice, ep *EndPointInfo, conn *PlatformAdapterSatori) {
 			break
 		}
 
-		time.Sleep(15 * time.Second)
+		if !waitRuntimeDelay(diceRuntimeContext(d), 15*time.Second) {
+			break
+		}
 	}
+	conn.DiceServing = false
 }
 
 func serverOfficialQQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterOfficialQQ) {
+	conn.runtimeMu.Lock()
 	// Ctx 非空表示会话已经建立或正在运行，不能重复启动并覆盖端点状态。
-	if conn.Ctx != nil {
+	if conn.runtimeStopping.Load() || conn.Ctx != nil {
+		conn.runtimeMu.Unlock()
 		return
 	}
 	if conn.DiceServing {
+		conn.runtimeMu.Unlock()
 		return
 	}
 	conn.DiceServing = true
@@ -231,9 +279,10 @@ func serverOfficialQQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterOfficialQQ
 	ep.State = 2 // 连接中
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
+	conn.runtimeMu.Unlock()
 	waitTimes := 0
 
-	for {
+	for !conn.runtimeStopping.Load() {
 		// 骰子开始连接
 		d.Logger.Infof("开始连接 official qq，帐号 <%s>(%s)，重试计数[%d/%d]", ep.Nickname, ep.UserID, waitTimes, 5)
 		ret := ep.Adapter.Serve()
@@ -241,14 +290,21 @@ func serverOfficialQQ(d *Dice, ep *EndPointInfo, conn *PlatformAdapterOfficialQQ
 		if ret == 0 {
 			break
 		}
+		if conn.runtimeStopping.Load() {
+			break
+		}
 
 		waitTimes += 1
 		if waitTimes > 5 {
 			d.Logger.Infof("official qq 连接重试次数过多，先行中断: <%s>(%s)", ep.Nickname, ep.UserID)
-			conn.DiceServing = false
 			break
 		}
 
-		time.Sleep(15 * time.Second)
+		if !waitRuntimeDelay(diceRuntimeContext(d), 15*time.Second) {
+			break
+		}
 	}
+	conn.runtimeMu.Lock()
+	conn.DiceServing = false
+	conn.runtimeMu.Unlock()
 }

--- a/dice/platform_adapter_red.go
+++ b/dice/platform_adapter_red.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"sealdice-core/message"
@@ -37,9 +38,11 @@ type PlatformAdapterRed struct {
 	wsUrl   *url.URL
 	httpUrl *url.URL
 
-	conn      *websocket.Conn
-	muxSend   sync.Mutex
-	memberMap *SyncMap[string, *SyncMap[string, *GroupMember]]
+	conn            *websocket.Conn
+	muxSend         sync.Mutex
+	runtimeMu       sync.Mutex
+	runtimeStopping atomic.Bool
+	memberMap       *SyncMap[string, *SyncMap[string, *GroupMember]]
 }
 
 type RedPack[T any] struct {
@@ -349,6 +352,12 @@ type GroupMember struct {
 }
 
 func (pa *PlatformAdapterRed) Serve() int {
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		return 0
+	}
+	pa.runtimeMu.Unlock()
 	ep := pa.EndPoint
 	s := pa.EndPoint.Session
 	log := s.Parent.Logger
@@ -356,6 +365,7 @@ func (pa *PlatformAdapterRed) Serve() int {
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
+	defer signal.Stop(interrupt)
 
 	wsUrl := url.URL{
 		Scheme: "ws",
@@ -374,10 +384,22 @@ func (pa *PlatformAdapterRed) Serve() int {
 		return 1
 	}
 	defer resp.Body.Close()
-	defer func(conn *websocket.Conn) {
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
 		_ = conn.Close()
-	}(conn)
+		return 0
+	}
 	pa.conn = conn
+	pa.runtimeMu.Unlock()
+	defer func() {
+		_ = conn.Close()
+		pa.runtimeMu.Lock()
+		if pa.conn == conn {
+			pa.conn = nil
+		}
+		pa.runtimeMu.Unlock()
+	}()
 	pa.EndPoint.State = 2
 
 	// 鉴权
@@ -431,7 +453,7 @@ func (pa *PlatformAdapterRed) Serve() int {
 			})
 		}
 	}
-	go refreshFriends()
+	runDiceRuntimeTask(d, refreshFriends)
 	// 获得群列表
 	pa.GetGroupInfoAsync("")
 
@@ -465,31 +487,30 @@ func (pa *PlatformAdapterRed) Serve() int {
 			case websocket.BinaryMessage:
 			case websocket.CloseMessage:
 				log.Debug("server close")
-				pa.conn = nil
-				done <- struct{}{}
+				return
 			case websocket.PingMessage:
 			case websocket.PongMessage:
 			}
 		}
 	}()
 
-	for {
+	select {
+	case <-done:
+		return 0
+	case <-interrupt:
+		log.Debug("red interrupt")
+		pa.runtimeMu.Lock()
+		currentConn := pa.conn
+		pa.runtimeMu.Unlock()
+		if currentConn != nil {
+			_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			_ = currentConn.Close()
+		}
 		select {
 		case <-done:
-		case <-interrupt:
-			log.Debug("red interrupt")
-
-			if pa.conn != nil {
-				_ = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-				_ = pa.conn.Close()
-				pa.conn = nil
-			}
-
-			select {
-			case <-done:
-			case <-time.After(time.Second):
-			}
+		case <-time.After(time.Second):
 		}
+		return 0
 	}
 }
 
@@ -512,7 +533,7 @@ func (pa *PlatformAdapterRed) SetEnable(enable bool) {
 		pa.DiceServing = false
 
 		if pa.conn == nil {
-			go ServeQQ(d, e)
+			runDiceRuntimeTask(d, func() { ServeQQ(d, e) })
 		}
 	} else {
 		e.State = 0
@@ -726,7 +747,8 @@ func (pa *PlatformAdapterRed) GetGroupInfoAsync(_ string) {
 				}
 
 				// 触发群成员更新
-				go refreshMembers(group)
+				currentGroup := group
+				runDiceRuntimeTask(session.Parent, func() { refreshMembers(currentGroup) })
 
 				groupRecord := groupInfo
 				if groupRecord != nil {
@@ -746,7 +768,7 @@ func (pa *PlatformAdapterRed) GetGroupInfoAsync(_ string) {
 			}
 		}
 	}
-	go refresh()
+	runDiceRuntimeTask(session.Parent, refresh)
 }
 
 type BotInfo struct {

--- a/dice/platform_adapter_red.go
+++ b/dice/platform_adapter_red.go
@@ -518,10 +518,12 @@ func (pa *PlatformAdapterRed) DoRelogin() bool {
 	pa.EndPoint.Session.Parent.Logger.Infof("正在启用 red 连接……")
 	pa.EndPoint.State = 0
 	pa.EndPoint.Enable = false
+	pa.runtimeMu.Lock()
 	if pa.conn != nil {
 		_ = pa.conn.Close()
 	}
 	pa.conn = nil
+	pa.runtimeMu.Unlock()
 	return pa.Serve() == 0
 }
 
@@ -530,18 +532,23 @@ func (pa *PlatformAdapterRed) SetEnable(enable bool) {
 	e := pa.EndPoint
 	if enable {
 		e.Enable = true
+		pa.runtimeMu.Lock()
 		pa.DiceServing = false
+		hasConn := pa.conn != nil
+		pa.runtimeMu.Unlock()
 
-		if pa.conn == nil {
+		if !hasConn {
 			runDiceRuntimeTask(d, func() { ServeQQ(d, e) })
 		}
 	} else {
 		e.State = 0
 		e.Enable = false
+		pa.runtimeMu.Lock()
 		if pa.conn != nil {
 			_ = pa.conn.Close()
 			pa.conn = nil
 		}
+		pa.runtimeMu.Unlock()
 	}
 	d.LastUpdatedTime = time.Now().Unix()
 	d.Save(false)
@@ -635,9 +642,11 @@ func (pa *PlatformAdapterRed) SendToGroup(ctx *MsgContext, groupId string, text 
 func (pa *PlatformAdapterRed) sendRow(redMsg *RedMessageSend) {
 	pa.muxSend.Lock()
 	defer pa.muxSend.Unlock()
-	if pa.conn != nil {
+	pa.runtimeMu.Lock()
+	conn := pa.conn
+	pa.runtimeMu.Unlock()
+	if conn != nil {
 		log := pa.EndPoint.Session.Parent.Logger
-		conn := pa.conn
 
 		param := &RedPack[RedMessageSend]{
 			Type:    "message::send",

--- a/dice/platform_adapter_satori.go
+++ b/dice/platform_adapter_satori.go
@@ -135,7 +135,7 @@ func (pa *PlatformAdapterSatori) Serve() int {
 	d.Save(false)
 	log.Infof("satori 连接成功，账号<%s>(%s)", pa.EndPoint.Nickname, pa.EndPoint.UserID)
 
-	go func() {
+	runDiceRuntimeTask(d, func() {
 		for {
 			select {
 			case <-pa.Ctx.Done():
@@ -180,12 +180,12 @@ func (pa *PlatformAdapterSatori) Serve() int {
 				}
 			}
 		}
-	}()
+	})
 
 	// 更新好友列表
-	go pa.refreshFriends()
+	runDiceRuntimeTask(d, pa.refreshFriends)
 	// 更新群列表
-	go pa.refreshGroups()
+	runDiceRuntimeTask(d, pa.refreshGroups)
 
 	ticker := time.NewTicker(10 * time.Second)
 	for {
@@ -319,7 +319,7 @@ func (pa *PlatformAdapterSatori) refreshGroups() {
 			}
 
 			// 触发群成员更新
-			go pa.refreshMembers(group)
+			runDiceRuntimeTask(d, func() { pa.refreshMembers(group) })
 		}
 		if next == "" {
 			break
@@ -407,7 +407,7 @@ func (pa *PlatformAdapterSatori) SetEnable(enable bool) {
 		e.Enable = true
 		pa.DiceServing = false
 		if pa.conn == nil {
-			go ServeQQ(d, e)
+			runDiceRuntimeTask(d, func() { ServeQQ(d, e) })
 		}
 	} else {
 		e.State = 0
@@ -531,7 +531,7 @@ func (pa *PlatformAdapterSatori) GetGroupInfoAsync(groupID string) {
 		return
 	}
 
-	go pa.refreshGroups()
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, pa.refreshGroups)
 }
 
 func (pa *PlatformAdapterSatori) EditMessage(ctx *MsgContext, msgID, message string) {

--- a/dice/platform_adapter_sealchat.go
+++ b/dice/platform_adapter_sealchat.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -8,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -36,13 +38,16 @@ type PlatformAdapterSealChat struct {
 
 	// 心跳相关
 	heartbeatStop chan struct{}
+	heartbeatMu   sync.Mutex
 	lastPong      int64
 
 	// 角色卡写入速率限制器 (60次/分钟)
 	characterSetLimiter *rate.Limiter
+	runtimeStopping     atomic.Bool
 }
 
 func (pa *PlatformAdapterSealChat) Serve() int {
+	pa.runtimeStopping.Store(false)
 	if !strings.HasPrefix(pa.ConnectURL, "ws://") && !strings.HasPrefix(pa.ConnectURL, "wss://") {
 		pa.ConnectURL = "ws://" + pa.ConnectURL
 	}
@@ -76,6 +81,16 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 	log := pa.EndPoint.Session.Parent.Logger
 	socket := pa.Socket
 	socket.OnConnected = func(socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			socket.Close()
+			return
+		}
+		defer done()
+		if pa.runtimeStopping.Load() {
+			socket.Close()
+			return
+		}
 		ep.State = 2
 		ep.Enable = true
 
@@ -94,6 +109,11 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 		pa.Reconnecting = false
 	}
 	socket.OnTextMessage = func(message string, socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			return
+		}
+		defer done()
 		gatewayMsg := satori.GatewayPayloadStructure2{}
 		err := json.Unmarshal([]byte(message), &gatewayMsg)
 		if len(message) == 0 {
@@ -130,11 +150,17 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 						pa.RetryTimesLimit = 15
 					}
 
-					go func() {
+					runDiceRuntimeTaskContext(ep.Session.Parent, func(ctx context.Context) {
 						// 等一会再发，因为好像有的模块会在这个事件之后注册指令
-						time.Sleep(time.Duration(5) * time.Second)
-						pa.registerCommands()
-					}()
+						timer := time.NewTimer(5 * time.Second)
+						defer timer.Stop()
+						select {
+						case <-ctx.Done():
+							return
+						case <-timer.C:
+							pa.registerCommands()
+						}
+					})
 				}
 				// 启动心跳
 				pa.startHeartbeat()
@@ -177,8 +203,16 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 		}
 	}
 	socket.OnConnectError = func(err error, socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			return
+		}
+		defer done()
 		log.Errorf("SealChat websocket出现错误: %s", err)
 		pa.stopHeartbeat()
+		if pa.runtimeStopping.Load() {
+			return
+		}
 		if !socket.IsConnected {
 			pa.Reconnecting = false
 			time.Sleep(time.Duration(10) * time.Second)
@@ -189,6 +223,14 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 		}
 	}
 	socket.OnDisconnected = func(err error, socket gowebsocket.Socket) {
+		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
+		if !ok {
+			return
+		}
+		defer done()
+		if pa.runtimeStopping.Load() {
+			return
+		}
 		log.Info("与SealChat服务器断开连接，尝试进行重连")
 		pa.stopHeartbeat()
 		time.Sleep(time.Duration(2) * time.Second)
@@ -202,6 +244,9 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 
 func (pa *PlatformAdapterSealChat) tryReconnect(socket gowebsocket.Socket) bool {
 	log := pa.EndPoint.Session.Parent.Logger
+	if pa.runtimeStopping.Load() {
+		return false
+	}
 	if socket.IsConnected {
 		return true
 	}
@@ -233,16 +278,24 @@ func (pa *PlatformAdapterSealChat) tryReconnect(socket gowebsocket.Socket) bool 
 // startHeartbeat 启动心跳协程
 func (pa *PlatformAdapterSealChat) startHeartbeat() {
 	pa.stopHeartbeat()
-	pa.heartbeatStop = make(chan struct{})
+	stop := make(chan struct{})
+	pa.heartbeatMu.Lock()
+	pa.heartbeatStop = stop
+	pa.heartbeatMu.Unlock()
 	atomic.StoreInt64(&pa.lastPong, time.Now().Unix())
 	log := pa.EndPoint.Session.Parent.Logger
 
-	go func() {
+	runDiceRuntimeTaskContext(pa.EndPoint.Session.Parent, func(ctx context.Context) {
 		ticker := time.NewTicker(15 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case <-ticker.C:
+				if pa.runtimeStopping.Load() {
+					return
+				}
 				if pa.Socket == nil || !pa.Socket.IsConnected {
 					return
 				}
@@ -258,23 +311,21 @@ func (pa *PlatformAdapterSealChat) startHeartbeat() {
 					pa.Socket.Close()
 					return
 				}
-			case <-pa.heartbeatStop:
+			case <-stop:
 				return
 			}
 		}
-	}()
+	})
 }
 
 // stopHeartbeat 停止心跳协程
 func (pa *PlatformAdapterSealChat) stopHeartbeat() {
-	if pa.heartbeatStop != nil {
-		select {
-		case <-pa.heartbeatStop:
-			// 已关闭
-		default:
-			close(pa.heartbeatStop)
-		}
-		pa.heartbeatStop = nil
+	pa.heartbeatMu.Lock()
+	stop := pa.heartbeatStop
+	pa.heartbeatStop = nil
+	pa.heartbeatMu.Unlock()
+	if stop != nil {
+		close(stop)
 	}
 }
 
@@ -504,7 +555,7 @@ func (pa *PlatformAdapterSealChat) SetEnable(enable bool) {
 	} else {
 		pa.EndPoint.Enable = false
 		pa.Reconnecting = true
-		if pa.Socket != nil && pa.Socket.IsConnected {
+		if pa.Socket != nil {
 			pa.Socket.Close()
 		}
 		pa.Reconnecting = false

--- a/dice/platform_adapter_sealchat.go
+++ b/dice/platform_adapter_sealchat.go
@@ -32,18 +32,25 @@ type PlatformAdapterSealChat struct {
 	UserID     string                    `json:"-"          yaml:"-"`
 	assetCache SyncMap[string, struct{}] `json:"-"          yaml:"-"`
 
-	Reconnecting    bool `json:"-" yaml:"-"`
-	RetryTimes      int  `json:"-" yaml:"-"`
-	RetryTimesLimit int  `json:"-" yaml:"-"`
+	Reconnecting    atomic.Bool `json:"-" yaml:"-"`
+	RetryTimes      int         `json:"-" yaml:"-"`
+	RetryTimesLimit int         `json:"-" yaml:"-"`
 
 	// 心跳相关
 	heartbeatStop chan struct{}
 	heartbeatMu   sync.Mutex
 	lastPong      int64
+	runtimeMu     sync.Mutex
 
 	// 角色卡写入速率限制器 (60次/分钟)
 	characterSetLimiter *rate.Limiter
 	runtimeStopping     atomic.Bool
+}
+
+func (pa *PlatformAdapterSealChat) socketSnapshot() *gowebsocket.Socket {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.Socket
 }
 
 func (pa *PlatformAdapterSealChat) Serve() int {
@@ -52,7 +59,14 @@ func (pa *PlatformAdapterSealChat) Serve() int {
 		pa.ConnectURL = "ws://" + pa.ConnectURL
 	}
 	socket := gowebsocket.New(pa.ConnectURL)
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		socket.Close()
+		return 0
+	}
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
 	pa.EndPoint.Nickname = "SealChat Bot"
 	pa.EndPoint.UserID = "SEALCHAT:BOT"
 	pa.RetryTimesLimit = 15
@@ -79,7 +93,7 @@ func (pa *PlatformAdapterSealChat) _sendJSON(socket *gowebsocket.Socket, data an
 func (pa *PlatformAdapterSealChat) socketSetup() {
 	ep := pa.EndPoint
 	log := pa.EndPoint.Session.Parent.Logger
-	socket := pa.Socket
+	socket := pa.socketSnapshot()
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
 		if !ok {
@@ -106,7 +120,7 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 		})
 
 		log.Info("SealChat 建立连接，正在发送身份验证信息")
-		pa.Reconnecting = false
+		pa.Reconnecting.Store(false)
 	}
 	socket.OnTextMessage = func(message string, socket gowebsocket.Socket) {
 		done, ok := beginDiceRuntimeTask(ep.Session.Parent)
@@ -214,9 +228,9 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 			return
 		}
 		if !socket.IsConnected {
-			pa.Reconnecting = false
+			pa.Reconnecting.Store(false)
 			time.Sleep(time.Duration(10) * time.Second)
-			if !pa.tryReconnect(*pa.Socket) {
+			if !pa.tryReconnect(socket) {
 				log.Errorf("短时间内连接失败次数过多，不再进行重连")
 				ep.State = 3
 			}
@@ -234,12 +248,14 @@ func (pa *PlatformAdapterSealChat) socketSetup() {
 		log.Info("与SealChat服务器断开连接，尝试进行重连")
 		pa.stopHeartbeat()
 		time.Sleep(time.Duration(2) * time.Second)
-		if !pa.tryReconnect(*pa.Socket) {
+		if !pa.tryReconnect(socket) {
 			ep.State = 3
 			log.Errorf("到达连接次数上限，不再进行重连")
 		}
 	}
+	pa.runtimeMu.Lock()
 	pa.Socket = socket
+	pa.runtimeMu.Unlock()
 }
 
 func (pa *PlatformAdapterSealChat) tryReconnect(socket gowebsocket.Socket) bool {
@@ -250,25 +266,32 @@ func (pa *PlatformAdapterSealChat) tryReconnect(socket gowebsocket.Socket) bool 
 	if socket.IsConnected {
 		return true
 	}
-	if pa.Reconnecting {
+	if pa.Reconnecting.Load() {
 		return true
 	}
-	pa.Reconnecting = true
+	pa.Reconnecting.Store(true)
 
 	if !pa.EndPoint.Enable {
-		pa.Reconnecting = false
+		pa.Reconnecting.Store(false)
 		return true
 	}
 
 	if pa.RetryTimes >= pa.RetryTimesLimit {
-		pa.Reconnecting = false
+		pa.Reconnecting.Store(false)
 		return false
 	}
 
 	pa.RetryTimes++
 	log.Infof("尝试重新连接SealChat中[%d/%d]", pa.RetryTimes, pa.RetryTimesLimit)
 	socket = gowebsocket.New(pa.ConnectURL)
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		socket.Close()
+		return false
+	}
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
 	pa.socketSetup()
 	socket.Connect()
 
@@ -296,19 +319,19 @@ func (pa *PlatformAdapterSealChat) startHeartbeat() {
 				if pa.runtimeStopping.Load() {
 					return
 				}
-				if pa.Socket == nil || !pa.Socket.IsConnected {
+				socket := pa.socketSnapshot()
+				if socket == nil || !socket.IsConnected {
 					return
 				}
 				// 发送 Ping
-				pa._sendJSON(pa.Socket, satori.GatewayPayloadStructure{
-					Op:   satori.OpPing,
+				pa._sendJSON(socket, satori.GatewayPayloadStructure{
 					Body: map[string]any{},
 				})
 				// 检查超时（45秒无响应则断开）
 				last := atomic.LoadInt64(&pa.lastPong)
 				if time.Now().Unix()-last > 45 {
 					log.Warn("SealChat 心跳超时，断开连接")
-					pa.Socket.Close()
+					socket.Close()
 					return
 				}
 			case <-stop:
@@ -517,17 +540,19 @@ func FormatDiceIDSealChatGroup(id string) string {
 
 func (pa *PlatformAdapterSealChat) DoRelogin() bool {
 	log := pa.EndPoint.Session.Parent.Logger
-	pa.Reconnecting = true
+	pa.Reconnecting.Store(true)
+	pa.runtimeMu.Lock()
 	if pa.Socket != nil {
 		pa.Socket.Close()
 	}
-
 	socket := gowebsocket.New(pa.ConnectURL)
-	log.Infof("SealChat 重新连接")
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
+
+	log.Infof("SealChat 重新连接")
 	pa.socketSetup()
 	socket.Connect()
-	pa.Reconnecting = false
+	pa.Reconnecting.Store(false)
 	return true
 }
 
@@ -536,29 +561,34 @@ func (pa *PlatformAdapterSealChat) SetEnable(enable bool) {
 	if enable {
 		pa.EndPoint.Enable = true
 		log.Infof("Sealchat 连接中")
+		pa.runtimeMu.Lock()
 		if pa.Socket != nil && pa.Socket.IsConnected {
-			pa.Reconnecting = true
+			pa.Reconnecting.Store(true)
 			pa.Socket.Close()
 			socket := gowebsocket.New(pa.ConnectURL)
 			pa.Socket = &socket
+			pa.runtimeMu.Unlock()
 			pa.socketSetup()
 			socket.Connect()
-			pa.Reconnecting = false
+			pa.Reconnecting.Store(false)
 		} else {
-			pa.Reconnecting = true
+			pa.Reconnecting.Store(true)
 			socket := gowebsocket.New(pa.ConnectURL)
 			pa.Socket = &socket
+			pa.runtimeMu.Unlock()
 			pa.socketSetup()
 			socket.Connect()
-			pa.Reconnecting = false
+			pa.Reconnecting.Store(false)
 		}
 	} else {
 		pa.EndPoint.Enable = false
-		pa.Reconnecting = true
+		pa.Reconnecting.Store(true)
+		pa.runtimeMu.Lock()
 		if pa.Socket != nil {
 			pa.Socket.Close()
 		}
-		pa.Reconnecting = false
+		pa.runtimeMu.Unlock()
+		pa.Reconnecting.Store(false)
 	}
 }
 
@@ -566,11 +596,13 @@ func (pa *PlatformAdapterSealChat) sendAPIWithEcho(api string, data any) (string
 	echo := gonanoid.Must()
 	ch := make(chan any, 1)
 	pa.EchoMap.Store(echo, ch)
-	pa._sendJSON(pa.Socket, &satori.ScApiMsgPayload{
-		Api:  api,
-		Echo: echo,
-		Data: data,
-	})
+	if socket := pa.socketSnapshot(); socket != nil {
+		pa._sendJSON(socket, &satori.ScApiMsgPayload{
+			Api:  api,
+			Echo: echo,
+			Data: data,
+		})
+	}
 	return echo, ch
 }
 
@@ -878,11 +910,13 @@ func (pa *PlatformAdapterSealChat) handleApiRequest(msg satori.ScApiMsgPayload) 
 
 // sendApiResponse 发送 API 响应
 func (pa *PlatformAdapterSealChat) sendApiResponse(echo string, data any) {
-	pa._sendJSON(pa.Socket, &satori.ScApiMsgPayload{
-		Api:  "",
-		Echo: echo,
-		Data: data,
-	})
+	if socket := pa.socketSnapshot(); socket != nil {
+		pa._sendJSON(socket, &satori.ScApiMsgPayload{
+			Api:  "",
+			Echo: echo,
+			Data: data,
+		})
+	}
 }
 
 func (pa *PlatformAdapterSealChat) registerCommands() {

--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -57,7 +57,7 @@ func (pa *PlatformAdapterSlack) Serve() int {
 		log.Errorf("Slack 账号 <%s> 连接断开：%v", pa.EndPoint.UserID, event.Data)
 	})
 	sh.HandleEvents(se.AppMention, func(event *sm.Event, client *sm.Client) {
-		go client.Ack(*event.Request)
+		runDiceRuntimeTask(s.Parent, func() { client.Ack(*event.Request) })
 		e := event.Data.(se.EventsAPIEvent)
 		m := e.InnerEvent.Data.(*se.AppMentionEvent)
 		u := pa.getUser(m.User)
@@ -93,7 +93,7 @@ func (pa *PlatformAdapterSlack) Serve() int {
 	})
 	// Message
 	sh.HandleEvents(se.Message, func(event *sm.Event, client *sm.Client) {
-		go client.Ack(*event.Request)
+		runDiceRuntimeTask(s.Parent, func() { client.Ack(*event.Request) })
 		e := event.Data.(se.EventsAPIEvent)
 		m := e.InnerEvent.Data.(*se.MessageEvent)
 		u := pa.getUser(m.User)
@@ -183,18 +183,18 @@ func (pa *PlatformAdapterSlack) DoRelogin() bool {
 	pa.Client = nil
 	pa.EndPoint.Enable = false
 	pa.EndPoint.State = 0
-	go pa.Serve()
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 	return true
 }
 
 func (pa *PlatformAdapterSlack) SetEnable(enable bool) {
 	if enable {
 		if pa.Client == nil {
-			go pa.Serve()
+			runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 		} else {
 			pa.Client = nil
 			pa.cancel = nil
-			go pa.Serve()
+			runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 		}
 	} else {
 		if pa.cancel != nil {

--- a/dice/platform_adapter_telegram.go
+++ b/dice/platform_adapter_telegram.go
@@ -109,7 +109,7 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 	updates := bot.GetUpdatesChan(updateConfig)
 	pa.ActiveTime = time.Now()
 
-	go func() {
+	runDiceRuntimeTask(d, func() {
 		for update := range updates {
 			if pa.IntentSession == nil {
 				break
@@ -133,7 +133,7 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 						mctx.Player = p
 					}
 				}
-				go pa.EndPoint.Session.OnMessageEdit(mctx, msg)
+				runDiceRuntimeTask(d, func() { pa.EndPoint.Session.OnMessageEdit(mctx, msg) })
 				continue
 			}
 
@@ -156,22 +156,22 @@ func (pa *PlatformAdapterTelegram) Serve() int {
 				for _, member := range msgRaw.NewChatMembers {
 					// 骰子进群
 					if member.ID == bot.Self.ID {
-						go pa.groupAdded(msg, msgRaw)
+						runDiceRuntimeTask(d, func() { pa.groupAdded(msg, msgRaw) })
 					} else {
 						// 新人进群
 						copied := member
-						go pa.groupNewMember(msg, msgRaw, &copied)
+						runDiceRuntimeTask(d, func() { pa.groupNewMember(msg, msgRaw, &copied) })
 					}
 				}
 				continue
 			}
 			if msgRaw.IsCommand() && msgRaw.Text == "/start" && msg.MessageType == "private" {
-				go pa.friendAdded(msg)
+				runDiceRuntimeTask(d, func() { pa.friendAdded(msg) })
 				continue
 			}
-			go pa.EndPoint.Session.Execute(pa.EndPoint, msg, false)
+			runDiceRuntimeTask(d, func() { pa.EndPoint.Session.Execute(pa.EndPoint, msg, false) })
 		}
-	}()
+	})
 	return 0
 }
 
@@ -363,14 +363,14 @@ func (pa *PlatformAdapterTelegram) MemberKick(_ string, _ string) {}
 func (pa *PlatformAdapterTelegram) DoRelogin() bool {
 	pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
 	if pa.IntentSession == nil {
-		go pa.Serve()
+		runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 		return true
 	}
 	if pa.IntentSession != nil {
 		pa.IntentSession.StopReceivingUpdates()
 		pa.IntentSession = nil
 	}
-	go pa.Serve()
+	runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 	return true
 }
 
@@ -379,14 +379,14 @@ func (pa *PlatformAdapterTelegram) SetEnable(enable bool) {
 	if enable {
 		pa.EndPoint.Session.Parent.Logger.Infof("正在启用Telegram服务……")
 		if pa.IntentSession == nil {
-			go pa.Serve()
+			runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 			return
 		}
 		if pa.IntentSession != nil {
 			pa.IntentSession.StopReceivingUpdates()
 			pa.IntentSession = nil
 		}
-		go pa.Serve()
+		runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() { pa.Serve() })
 	} else {
 		if pa.IntentSession != nil {
 			pa.IntentSession.StopReceivingUpdates()

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -1,6 +1,7 @@
 package dice
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -11,6 +12,8 @@ import (
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -32,6 +35,11 @@ type PlatformAdapterWalleQ struct {
 	CurLoginIndex   int                 `json:"curLoginIndex"   yaml:"-"`               // 当前登录序号，如果正在进行的登录不是该Index，证明过时
 
 	WalleQProcess           *procs.Process `json:"-"                    yaml:"-"`
+	processMu               sync.Mutex     `json:"-"                    yaml:"-"`
+	processStarted          bool           `json:"-"                    yaml:"-"`
+	processDone             chan struct{}  `json:"-"                    yaml:"-"`
+	runtimeMu               sync.Mutex     `json:"-"                    yaml:"-"`
+	runtimeStopping         atomic.Bool    `json:"-"                    yaml:"-"`
 	WalleQLoginFailedReason string         `json:"curLoginFailedReason" yaml:"-"` // 当前登录失败原因
 
 	WalleQLoginVerifyCode    string `json:"WalleQLoginVerifyCode"    yaml:"-"`
@@ -170,6 +178,9 @@ type OnebotV12UserInfo struct {
 }
 
 func (pa *PlatformAdapterWalleQ) Serve() int {
+	if pa.runtimeStopping.Load() {
+		return 0
+	}
 	pa.Implementation = "walle-q"
 	ep := pa.EndPoint
 	s := pa.EndPoint.Session
@@ -177,11 +188,33 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 	dm := s.Parent.Parent
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(interrupt)
 
-	pa.InPackWalleQDisconnectedCH = make(chan int, 1)
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		return 0
+	}
+	disconnected := make(chan int, 1)
+	pa.InPackWalleQDisconnectedCH = disconnected
+	pa.runtimeMu.Unlock()
+	defer func() {
+		pa.runtimeMu.Lock()
+		if pa.InPackWalleQDisconnectedCH == disconnected {
+			pa.InPackWalleQDisconnectedCH = nil
+		}
+		pa.runtimeMu.Unlock()
+	}()
 
 	socket := gowebsocket.New(pa.ConnectURL)
+	pa.runtimeMu.Lock()
+	if pa.runtimeStopping.Load() {
+		pa.runtimeMu.Unlock()
+		socket.Close()
+		return 0
+	}
 	pa.Socket = &socket
+	pa.runtimeMu.Unlock()
 
 	socket.OnConnected = func(socket gowebsocket.Socket) {
 		ep.State = 1
@@ -193,7 +226,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 		// refused 不算大事
 		log.Error("onebot connection error: ", err)
 		// }
-		pa.InPackWalleQDisconnectedCH <- 2
+		signalAdapterStop(disconnected, 2)
 	}
 	var lastWelcome *LastWelcomeInfoWQ
 
@@ -245,7 +278,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 
 			time.Sleep(2 * time.Second)
 			groupName := dm.TryGetGroupName(msg.GroupID)
-			go func() {
+			runDiceRuntimeTask(pa.EndPoint.Session.Parent, func() {
 				defer func() {
 					if r := recover(); r != nil {
 						log.Errorf("入群致辞异常: %v 堆栈: %v", r, string(debug.Stack()))
@@ -271,7 +304,7 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 						return func() { ext.OnGroupJoined(ctx, msg) }
 					})
 				}
-			}()
+			})
 			txt := fmt.Sprintf("加入QQ群组: <%s>(%s)", groupName, event.GroupID)
 			log.Info(txt)
 			ctx.Notice(txt, NoticeTypeGroup)
@@ -697,29 +730,32 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 
 	socket.OnDisconnected = func(err error, socket gowebsocket.Socket) {
 		log.Info("onebot 服务的连接被对方关闭 ")
-		pa.InPackWalleQDisconnectedCH <- 1
+		signalAdapterStop(disconnected, 1)
 	}
 
 	socket.Connect()
 	defer func() {
 		log.Info("socket close")
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					log.Error("关闭连接时遭遇异常", r)
-				}
-			}()
-			socket.Close()
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("关闭连接时遭遇异常", r)
+			}
 		}()
+		socket.Close()
+		pa.runtimeMu.Lock()
+		if pa.Socket == &socket {
+			pa.Socket = nil
+		}
+		pa.runtimeMu.Unlock()
 	}()
 
 	for {
 		select {
 		case <-interrupt:
 			log.Info("interrupt")
-			pa.InPackWalleQDisconnectedCH <- 0
+			signalAdapterStop(disconnected, 0)
 			return 0
-		case val := <-pa.InPackWalleQDisconnectedCH:
+		case val := <-disconnected:
 			return val
 		}
 	}
@@ -731,18 +767,21 @@ func (pa *PlatformAdapterWalleQ) DoRelogin() bool {
 	d := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
 	if pa.Socket != nil {
-		go pa.Socket.Close()
+		socket := pa.Socket
+		runDiceRuntimeTask(d, socket.Close)
 		pa.Socket = nil
 	}
 	if pa.UseInPackWalleQ {
 		if pa.InPackWalleQDisconnectedCH != nil {
-			pa.InPackWalleQDisconnectedCH <- -1
+			signalAdapterStop(pa.InPackWalleQDisconnectedCH, -1)
 		}
 		d.Logger.Infof(fmt.Sprintf("重启 Walle-q，账号<%s>(%s)", ep.Nickname, ep.UserID))
 		pa.CurLoginIndex++
 		pa.WalleQState = WqStateCodeInit
-		go WalleQServeProcessKill(d, ep)
-		time.Sleep(10 * time.Second)
+		WalleQServeProcessKill(d, ep)
+		if !waitRuntimeDelay(diceRuntimeContext(d), 10*time.Second) {
+			return false
+		}
 		WalleQServeRemoveSessionToken(d, ep)
 		pa.WalleQLastRestrictedTime = 0
 		WalleQServe(d, ep, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, true)
@@ -760,15 +799,29 @@ func (pa *PlatformAdapterWalleQ) SetEnable(enable bool) {
 
 		if pa.UseInPackWalleQ {
 			WalleQServeProcessKill(d, c)
-			time.Sleep(1 * time.Second)
+			if !waitRuntimeDelay(diceRuntimeContext(d), time.Second) {
+				return
+			}
 			WalleQServe(d, c, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, true)
-			go ServeQQ(d, c)
+			runDiceRuntimeTaskWithContext(d, func(ctx context.Context) {
+				if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+					ServeQQ(d, c)
+				}
+			})
 		} else {
-			go ServeQQ(d, c)
+			runDiceRuntimeTaskWithContext(d, func(ctx context.Context) {
+				if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+					ServeQQ(d, c)
+				}
+			})
 		}
 	} else {
 		c.Enable = false
 		pa.DiceServing = false
+		if pa.Socket != nil {
+			pa.Socket.Close()
+			pa.Socket = nil
+		}
 		if pa.UseInPackWalleQ {
 			WalleQServeProcessKill(d, c)
 		}

--- a/dice/platform_adapter_walleq.go
+++ b/dice/platform_adapter_walleq.go
@@ -177,6 +177,29 @@ type OnebotV12UserInfo struct {
 	Card            string `json:"card"`
 }
 
+func (pa *PlatformAdapterWalleQ) bumpLoginIndexLocked() int {
+	pa.CurLoginIndex++
+	return pa.CurLoginIndex
+}
+
+func (pa *PlatformAdapterWalleQ) bumpLoginIndex() int {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.bumpLoginIndexLocked()
+}
+
+func (pa *PlatformAdapterWalleQ) currentLoginIndex() int {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.CurLoginIndex
+}
+
+func (pa *PlatformAdapterWalleQ) socketSnapshot() *gowebsocket.Socket {
+	pa.runtimeMu.Lock()
+	defer pa.runtimeMu.Unlock()
+	return pa.Socket
+}
+
 func (pa *PlatformAdapterWalleQ) Serve() int {
 	if pa.runtimeStopping.Load() {
 		return 0
@@ -766,17 +789,22 @@ func (pa *PlatformAdapterWalleQ) Serve() int {
 func (pa *PlatformAdapterWalleQ) DoRelogin() bool {
 	d := pa.EndPoint.Session.Parent
 	ep := pa.EndPoint
-	if pa.Socket != nil {
-		socket := pa.Socket
+	pa.runtimeMu.Lock()
+	socket := pa.Socket
+	pa.Socket = nil
+	pa.runtimeMu.Unlock()
+	if socket != nil {
 		runDiceRuntimeTask(d, socket.Close)
-		pa.Socket = nil
 	}
 	if pa.UseInPackWalleQ {
-		if pa.InPackWalleQDisconnectedCH != nil {
-			signalAdapterStop(pa.InPackWalleQDisconnectedCH, -1)
+		pa.runtimeMu.Lock()
+		disconnected := pa.InPackWalleQDisconnectedCH
+		pa.runtimeMu.Unlock()
+		if disconnected != nil {
+			signalAdapterStop(disconnected, -1)
 		}
 		d.Logger.Infof(fmt.Sprintf("重启 Walle-q，账号<%s>(%s)", ep.Nickname, ep.UserID))
-		pa.CurLoginIndex++
+		pa.bumpLoginIndex()
 		pa.WalleQState = WqStateCodeInit
 		WalleQServeProcessKill(d, ep)
 		if !waitRuntimeDelay(diceRuntimeContext(d), 10*time.Second) {
@@ -795,7 +823,9 @@ func (pa *PlatformAdapterWalleQ) SetEnable(enable bool) {
 	c := pa.EndPoint
 	if enable {
 		c.Enable = true
+		pa.runtimeMu.Lock()
 		pa.DiceServing = false
+		pa.runtimeMu.Unlock()
 
 		if pa.UseInPackWalleQ {
 			WalleQServeProcessKill(d, c)
@@ -817,11 +847,13 @@ func (pa *PlatformAdapterWalleQ) SetEnable(enable bool) {
 		}
 	} else {
 		c.Enable = false
+		pa.runtimeMu.Lock()
 		pa.DiceServing = false
 		if pa.Socket != nil {
 			pa.Socket.Close()
 			pa.Socket = nil
 		}
+		pa.runtimeMu.Unlock()
 		if pa.UseInPackWalleQ {
 			WalleQServeProcessKill(d, c)
 		}
@@ -848,7 +880,7 @@ func (pa *PlatformAdapterWalleQ) GetGroupInfoAsync(id string) {
 		"get_group_info",
 	})
 
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 func (pa *PlatformAdapterWalleQ) SendSegmentToGroup(ctx *MsgContext, groupID string, msg []message.IMessageElement, flag string) {
@@ -964,7 +996,7 @@ func (pa *PlatformAdapterWalleQ) QuitGroup(_ *MsgContext, id string) {
 		},
 	})
 
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 func (pa *PlatformAdapterWalleQ) SetGroupCardName(_ *MsgContext, _ string) {
@@ -983,7 +1015,7 @@ func (pa *PlatformAdapterWalleQ) MemberBan(groupID string, userID string, last i
 			groupID, userID, last,
 		},
 	})
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 func (pa *PlatformAdapterWalleQ) MemberKick(groupID string, userID string) {
@@ -997,7 +1029,7 @@ func (pa *PlatformAdapterWalleQ) MemberKick(groupID string, userID string) {
 			groupID, userID,
 		},
 	})
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 func (pa *PlatformAdapterWalleQ) EditMessage(_ *MsgContext, _, _ string) {}
@@ -1070,7 +1102,7 @@ func (pa *PlatformAdapterWalleQ) SendMessage(text string, ty string, id string, 
 			Message:    pa.TextToMessageSegment(text),
 		},
 	})
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 // GetLoginInfo 获取登录号信息
@@ -1080,7 +1112,7 @@ func (pa *PlatformAdapterWalleQ) GetLoginInfo() {
 		Echo:   "get_self_info",
 		Params: &struct{}{},
 	})
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 // GetGroupMemberInfo 获取群成员信息
@@ -1101,7 +1133,7 @@ func (pa *PlatformAdapterWalleQ) GetGroupMemberInfo(groupID string, userID strin
 	})
 
 	d := pa.waitGroupMemberInfoEcho(echo, func() {
-		socketSendText(pa.Socket, string(a))
+		socketSendText(pa.socketSnapshot(), string(a))
 	})
 
 	return &OnebotV12UserInfo{
@@ -1127,7 +1159,7 @@ func (pa *PlatformAdapterWalleQ) SetGroupAddRequest(rid int64, gid string, accep
 		},
 	})
 
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 // SetFriendAddRequest 同意好友
@@ -1148,7 +1180,7 @@ func (pa *PlatformAdapterWalleQ) SetFriendAddRequest(reqID int64, userID string,
 		},
 	})
 
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 // DeleteFriend 删除好友
@@ -1168,7 +1200,7 @@ func (pa *PlatformAdapterWalleQ) DeleteFriend(_ *MsgContext, id string) {
 		},
 	})
 
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 func (pa *PlatformAdapterWalleQ) UpVoiceFile(path string) {
@@ -1182,7 +1214,7 @@ func (pa *PlatformAdapterWalleQ) UpVoiceFile(path string) {
 		Echo:   "upload_file_voice",
 		Params: P{"path", path, "voice"},
 	})
-	socketSendText(pa.Socket, string(a))
+	socketSendText(pa.socketSnapshot(), string(a))
 }
 
 /** 格式化与反格式化 */

--- a/dice/platform_adapter_walleq_helper.go
+++ b/dice/platform_adapter_walleq_helper.go
@@ -131,7 +131,9 @@ func WalleQServeProcessKill(dice *Dice, conn *EndPointInfo) {
 			conn.State = 0
 			pa.WalleQState = 0
 
+			pa.runtimeMu.Lock()
 			pa.DiceServing = false
+			pa.runtimeMu.Unlock()
 			pa.WalleQQrcodeData = nil
 			pa.WalleQLoginDeviceLockURL = ""
 
@@ -152,8 +154,7 @@ func WalleQServeProcessKill(dice *Dice, conn *EndPointInfo) {
 
 func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, isAsyncRun bool) {
 	pa := conn.Adapter.(*PlatformAdapterWalleQ)
-	pa.CurLoginIndex++
-	loginIndex := pa.CurLoginIndex
+	loginIndex := pa.bumpLoginIndex()
 	pa.WalleQState = WqStateCodeInLogin
 	dice.Logger.Debug("WalleQServe begin")
 	workDir := filepath.Join(dice.BaseConfig.DataDir, conn.RelWorkDir)
@@ -223,10 +224,10 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 			return ""
 		}
 		log.Debug(line)
-		if loginIndex != pa.CurLoginIndex {
+		if loginIndex != pa.currentLoginIndex() {
 			// 当前连接已经无用，进程自杀
 			if !isSeldKilling {
-				dice.Logger.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.CurLoginIndex, loginIndex)
+				dice.Logger.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.currentLoginIndex(), loginIndex)
 				// 注: 这里不要调用kill
 				isSeldKilling = true
 				_ = pa.stopWalleQProcessInstance(p)
@@ -314,7 +315,7 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 		if ctx.Err() != nil || pa.runtimeStopping.Load() {
 			return
 		}
-		if loginIndex != pa.CurLoginIndex {
+		if loginIndex != pa.currentLoginIndex() {
 			return
 		}
 

--- a/dice/platform_adapter_walleq_helper.go
+++ b/dice/platform_adapter_walleq_helper.go
@@ -2,6 +2,7 @@ package dice
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +16,32 @@ import (
 
 	"sealdice-core/utils/procs"
 )
+
+func (pa *PlatformAdapterWalleQ) startWalleQProcess(ctx context.Context, process *procs.Process) error {
+	if pa.runtimeStopping.Load() {
+		return context.Canceled
+	}
+	return startManagedProcess(ctx, &pa.processMu, &pa.WalleQProcess, &pa.processStarted, &pa.processDone, process)
+}
+
+func (pa *PlatformAdapterWalleQ) waitWalleQProcess(process *procs.Process) error {
+	return waitManagedProcess(&pa.processMu, &pa.WalleQProcess, &pa.processStarted, &pa.processDone, process)
+}
+
+func (pa *PlatformAdapterWalleQ) stopWalleQProcess() error {
+	return stopManagedProcess(&pa.processMu, &pa.WalleQProcess, &pa.processStarted, nil)
+}
+
+func (pa *PlatformAdapterWalleQ) stopWalleQRuntime() error {
+	pa.runtimeMu.Lock()
+	pa.runtimeStopping.Store(true)
+	pa.runtimeMu.Unlock()
+	return pa.stopWalleQProcess()
+}
+
+func (pa *PlatformAdapterWalleQ) stopWalleQProcessInstance(process *procs.Process) error {
+	return stopManagedProcess(&pa.processMu, &pa.WalleQProcess, &pa.processStarted, process)
+}
 
 const (
 	WqStateCodeInit              = 0
@@ -116,13 +143,8 @@ func WalleQServeProcessKill(dice *Dice, conn *EndPointInfo) {
 				dice.Logger.Info("onebot: 删除已存在的二维码文件")
 			}
 
-			// 注意这个会panic，因此recover捕获了
-			if pa.WalleQProcess != nil {
-				p := pa.WalleQProcess
-				pa.WalleQProcess = nil
-				// sigintwindows.SendCtrlBreak(p.Cmds[0].Process.Pid)
-				_ = p.Stop()
-				_ = p.Wait() // 等待进程退出，因为Stop内部是Kill，这是不等待的
+			if err := pa.stopWalleQProcess(); err != nil {
+				dice.Logger.Error("停止 Walle-Q 进程失败: ", err)
 			}
 		}
 	}()
@@ -197,6 +219,9 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 	isSeldKilling := false
 
 	p.OutputHandler = func(line string, _type string) string {
+		if pa.runtimeStopping.Load() {
+			return ""
+		}
 		log.Debug(line)
 		if loginIndex != pa.CurLoginIndex {
 			// 当前连接已经无用，进程自杀
@@ -204,14 +229,17 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 				dice.Logger.Infof("检测到新的连接序号 %d，当前连接 %d 将自动退出", pa.CurLoginIndex, loginIndex)
 				// 注: 这里不要调用kill
 				isSeldKilling = true
-				_ = p.Stop()
+				_ = pa.stopWalleQProcessInstance(p)
 			}
 			return ""
 		}
 
 		if pa.IsInLogin() {
 			if strings.Contains(line, "扫描二维码登录") {
-				chQrCode <- 1
+				select {
+				case chQrCode <- 1:
+				default:
+				}
 			}
 
 			if strings.Contains(line, "note: run with `RUST_BACKTRACE=1`") {
@@ -224,7 +252,11 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 			}
 
 			if strings.Contains(line, "Walle-Q Login success with") {
-				go ServeQQ(dice, conn)
+				runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+					if ctx.Err() == nil && !pa.runtimeStopping.Load() {
+						ServeQQ(dice, conn)
+					}
+				})
 			}
 		}
 
@@ -234,8 +266,15 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 		return line
 	}
 
-	go func() {
-		<-chQrCode
+	runDiceRuntimeTaskWithContext(dice, func(ctx context.Context) {
+		select {
+		case <-ctx.Done():
+			return
+		case <-chQrCode:
+		}
+		if ctx.Err() != nil || pa.runtimeStopping.Load() {
+			return
+		}
 		if _, err := os.Stat(qrcodeFile); err == nil {
 			log.Info("如控制台二维码不好扫描，可以手动打开 ./data/default/extra/walle-q数字 目录下qrcode.png")
 			qrdata, err := os.ReadFile(qrcodeFile)
@@ -253,16 +292,15 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 				dice.Logger.Info("获取二维码失败，错误为: ", err.Error())
 			}
 		}
-	}()
+	})
 
-	run := func() {
+	run := func(ctx context.Context) {
 		defer func() {
 			if r := recover(); r != nil {
 				dice.Logger.Errorf("onebot: 异常: %v 堆栈: %v", r, string(debug.Stack()))
 			}
 		}()
-		pa.WalleQProcess = p
-		err := p.Start()
+		err := pa.startWalleQProcess(ctx, p)
 
 		if err == nil {
 			if dice.Parent.progressExitGroupWin != 0 && p.Cmd != nil {
@@ -271,7 +309,13 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 					dice.Logger.Warn("添加到进程组失败，若主进程崩溃，walle-q 进程可能需要手动结束")
 				}
 			}
-			err = p.Wait()
+			err = pa.waitWalleQProcess(p)
+		}
+		if ctx.Err() != nil || pa.runtimeStopping.Load() {
+			return
+		}
+		if loginIndex != pa.CurLoginIndex {
+			return
 		}
 
 		if err != nil {
@@ -282,9 +326,9 @@ func WalleQServe(dice *Dice, conn *EndPointInfo, password string, protocol int, 
 	}
 
 	if isAsyncRun {
-		go run()
+		runDiceRuntimeTaskWithContext(dice, run)
 	} else {
-		run()
+		run(diceRuntimeContext(dice))
 	}
 }
 

--- a/dice/runtime_lifecycle.go
+++ b/dice/runtime_lifecycle.go
@@ -1,0 +1,661 @@
+package dice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"sync"
+
+	"sealdice-core/dice/service"
+	"sealdice-core/utils/constant"
+	"sealdice-core/utils/dboperator/engine"
+)
+
+// RuntimeShutdowner is the optional, non-persistent shutdown contract for an
+// adapter. It must stop input, reconnect loops, sockets and owned processes
+// without changing EndPointInfo.Enable.
+type RuntimeShutdowner interface {
+	RuntimeShutdown(context.Context) error
+}
+
+type lifecyclePhase struct {
+	mu   sync.Mutex
+	done chan struct{}
+	err  error
+}
+
+func (phase *lifecyclePhase) run(ctx context.Context, work func(context.Context) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	phase.mu.Lock()
+	if phase.done == nil {
+		phase.done = make(chan struct{})
+		go func(done chan struct{}) {
+			err := runLifecycleWork(ctx, work)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err = errors.Join(err, ctxErr)
+			}
+			phase.mu.Lock()
+			phase.err = err
+			close(done)
+			phase.mu.Unlock()
+		}(phase.done)
+	}
+	done := phase.done
+	phase.mu.Unlock()
+
+	select {
+	case <-done:
+		phase.mu.Lock()
+		err := phase.err
+		phase.mu.Unlock()
+		return err
+	default:
+	}
+
+	select {
+	case <-done:
+		phase.mu.Lock()
+		err := phase.err
+		phase.mu.Unlock()
+		return err
+	case <-ctx.Done():
+		select {
+		case <-done:
+			phase.mu.Lock()
+			err := phase.err
+			phase.mu.Unlock()
+			return err
+		default:
+			return ctx.Err()
+		}
+	}
+}
+
+func runLifecycleWork(ctx context.Context, work func(context.Context) error) (resultErr error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = fmt.Errorf("runtime 生命周期发生异常: %v\n%s", recovered, debug.Stack())
+		}
+	}()
+	return work(ctx)
+}
+
+// Quiesce stops new generation tasks, input sources, reconnect loops and cron
+// jobs, then waits for in-flight work and flushes mutable state. The database
+// remains open so the restore layer can prepare its transaction.
+func (dm *DiceManager) Quiesce(ctx context.Context) error {
+	return dm.quiescePhase.run(ctx, dm.quiesce)
+}
+
+func (dm *DiceManager) quiesce(ctx context.Context) error {
+	dm.runtimeMu.Lock()
+	dm.runtimeClosing = true
+	dm.CleanupFlag.CompareAndSwap(0, 1)
+	cancel := dm.runtimeCancel
+	dm.runtimeMu.Unlock()
+
+	wasReady := dm.IsReady
+	dm.IsReady = false
+	if cancel != nil {
+		cancel()
+	}
+
+	var shutdownErrors []error
+	if dm.Cron != nil {
+		if err := waitCronStopped(ctx, dm.Cron.Stop().Done(), "管理器定时任务"); err != nil {
+			shutdownErrors = append(shutdownErrors, err)
+		}
+	}
+
+	for _, d := range dm.DiceSnapshot() {
+		if d == nil {
+			continue
+		}
+		if d.Cron != nil {
+			if err := waitCronStopped(ctx, d.Cron.Stop().Done(), "骰子定时任务"); err != nil {
+				shutdownErrors = append(shutdownErrors, err)
+			}
+		}
+		if d.JsScriptCron != nil {
+			if err := waitCronStopped(ctx, d.JsScriptCron.Stop().Done(), "JS 定时任务"); err != nil {
+				shutdownErrors = append(shutdownErrors, err)
+			}
+			d.JsScriptCron = nil
+		}
+		if err := d.shutdownAdapters(ctx); err != nil {
+			shutdownErrors = append(shutdownErrors, err)
+		}
+	}
+
+	if err := waitRuntimeTasks(ctx, &dm.runtimeWG); err != nil {
+		shutdownErrors = append(shutdownErrors, err)
+	}
+
+	for _, d := range dm.DiceSnapshot() {
+		if d == nil {
+			continue
+		}
+		if d.AttrsManager != nil && d.AttrsManager.cancel != nil {
+			if err := stopAttrsManager(ctx, d.AttrsManager); err != nil {
+				shutdownErrors = append(shutdownErrors, err)
+			}
+		}
+		if d.IsAlreadyLoadConfig {
+			if d.Config.BanList != nil {
+				d.Config.BanList.SaveChanged(d)
+			}
+			d.Save(true)
+		}
+	}
+	if wasReady {
+		dm.Save()
+	}
+	if err := flushRuntimeWAL(dm.Operator); err != nil {
+		shutdownErrors = append(shutdownErrors, err)
+	}
+	return errors.Join(shutdownErrors...)
+}
+
+func waitCronStopped(ctx context.Context, done <-chan struct{}, name string) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("等待%s停止: %w", name, ctx.Err())
+	}
+}
+
+func waitRuntimeTasks(ctx context.Context, wg *sync.WaitGroup) error {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("等待 Runtime 后台任务停止: %w", ctx.Err())
+	}
+}
+
+func stopAttrsManager(ctx context.Context, manager *AttrsManager) error {
+	done := make(chan struct{})
+	go func() {
+		manager.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("等待属性存储刷新: %w", ctx.Err())
+	}
+}
+
+func flushRuntimeWAL(operator engine.DatabaseOperator) error {
+	if operator == nil {
+		return nil
+	}
+	dbs := []struct {
+		name string
+		db   func() error
+	}{
+		{name: "data", db: func() error {
+			db := operator.GetDataDB(constant.WRITE)
+			if db == nil {
+				return nil
+			}
+			return service.FlushWAL(db)
+		}},
+		{name: "logs", db: func() error {
+			db := operator.GetLogDB(constant.WRITE)
+			if db == nil {
+				return nil
+			}
+			return service.FlushWAL(db)
+		}},
+		{name: "censor", db: func() error {
+			db := operator.GetCensorDB(constant.WRITE)
+			if db == nil {
+				return nil
+			}
+			return service.FlushWAL(db)
+		}},
+	}
+	var flushErrors []error
+	for _, item := range dbs {
+		if err := item.db(); err != nil {
+			flushErrors = append(flushErrors, fmt.Errorf("刷新 %s WAL: %w", item.name, err))
+		}
+	}
+	return errors.Join(flushErrors...)
+}
+
+func (d *Dice) shutdownAdapters(ctx context.Context) error {
+	if d.ImSession == nil {
+		return nil
+	}
+	var shutdownErrors []error
+	for _, endpoint := range append([]*EndPointInfo(nil), d.ImSession.EndPoints...) {
+		if endpoint == nil || endpoint.Adapter == nil {
+			continue
+		}
+		shutdowner, ok := endpoint.Adapter.(RuntimeShutdowner)
+		if !ok {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf(
+				"适配器 %s/%s 不支持 RuntimeShutdown，无法确认资源已关闭",
+				endpoint.Platform,
+				endpoint.ProtocolType,
+			))
+			continue
+		}
+		if err := shutdownAdapter(ctx, shutdowner); err != nil {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf(
+				"关闭适配器 %s/%s: %w",
+				endpoint.Platform,
+				endpoint.ProtocolType,
+				err,
+			))
+		}
+		endpoint.State = StateDisconnected
+	}
+	return errors.Join(shutdownErrors...)
+}
+
+func shutdownAdapter(ctx context.Context, shutdowner RuntimeShutdowner) (resultErr error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = fmt.Errorf("%v\n%s", recovered, debug.Stack())
+		}
+	}()
+	return shutdowner.RuntimeShutdown(ctx)
+}
+
+// Finalize releases JS runtimes, extension storage, help indexes and the
+// database after a successful Quiesce.
+func (dm *DiceManager) Finalize(ctx context.Context) error {
+	if err := dm.Quiesce(ctx); err != nil {
+		return err
+	}
+	return dm.finalizePhase.run(ctx, dm.finalize)
+}
+
+func (dm *DiceManager) finalize(ctx context.Context) error {
+	var finalizeErrors []error
+	for _, d := range dm.DiceSnapshot() {
+		if d == nil {
+			continue
+		}
+		if d.ExtLoopManager != nil {
+			d.jsClear()
+			if err := waitJSLoopStopped(ctx, d); err != nil {
+				finalizeErrors = append(finalizeErrors, err)
+			}
+		}
+		for _, ext := range d.ExtList {
+			if ext != nil && ext.Storage != nil {
+				if err := ext.StorageClose(); err != nil {
+					finalizeErrors = append(finalizeErrors, fmt.Errorf("关闭扩展存储: %w", err))
+				}
+			}
+		}
+		d.IsAlreadyLoadConfig = false
+	}
+
+	if dm.Help != nil {
+		dm.Help.Close()
+		dm.Help = nil
+	}
+	if err := errors.Join(finalizeErrors...); err != nil {
+		return err
+	}
+	if dm.Operator != nil {
+		dm.Operator.Close()
+		dm.Operator = nil
+	}
+	dm.CleanupFlag.Store(2)
+	return nil
+}
+
+func waitJSLoopStopped(ctx context.Context, d *Dice) error {
+	d.jsLoopMu.Lock()
+	done := d.jsLoopDone
+	d.jsLoopMu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("等待 JS Runtime 停止: %w", ctx.Err())
+	}
+}
+
+// Stop performs the two shutdown phases and shares each phase result across
+// all callers. A timed-out first call cannot make a later call return success
+// merely because shutdown had already started.
+func (dm *DiceManager) Stop(ctx context.Context) error {
+	if err := dm.Quiesce(ctx); err != nil {
+		return err
+	}
+	return dm.Finalize(ctx)
+}
+
+func (dm *DiceManager) IsQuiesced() bool {
+	return dm.CleanupFlag.Load() >= 1
+}
+
+// IsStopped reports whether Finalize completed.
+func (dm *DiceManager) IsStopped() bool {
+	return dm.CleanupFlag.Load() >= 2
+}
+
+func (*PlatformAdapterHTTP) RuntimeShutdown(context.Context) error { return nil }
+
+func (pa *PlatformAdapterDiscord) RuntimeShutdown(_ context.Context) error {
+	if pa.IntentSession == nil {
+		return nil
+	}
+	err := pa.IntentSession.Close()
+	pa.IntentSession = nil
+	return err
+}
+
+func (pa *PlatformAdapterDingTalk) RuntimeShutdown(_ context.Context) error {
+	return pa.closeSessionLocked()
+}
+
+func (pa *PlatformAdapterDodo) RuntimeShutdown(ctx context.Context) error {
+	pa.runtimeMu.Lock()
+	pa.runtimeStopping.Store(true)
+	stop := pa.runtimeStop
+	if stop != nil {
+		select {
+		case <-stop:
+		default:
+			close(stop)
+		}
+	}
+	ws := pa.WebSocket
+	done := pa.listenDone
+	pa.WebSocket = nil
+	pa.Client = nil
+	pa.runtimeMu.Unlock()
+	if ws != nil {
+		ws.Close()
+	}
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (pa *PlatformAdapterKook) RuntimeShutdown(_ context.Context) error {
+	if pa.IntentSession == nil {
+		return nil
+	}
+	err := pa.IntentSession.Close()
+	pa.IntentSession = nil
+	return err
+}
+
+func (pa *PlatformAdapterMinecraft) RuntimeShutdown(_ context.Context) error {
+	pa.runtimeStopping.Store(true)
+	pa.Reconnecting = true
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	return nil
+}
+
+func (pa *PlatformAdapterSealChat) RuntimeShutdown(_ context.Context) error {
+	pa.runtimeStopping.Store(true)
+	pa.Reconnecting = true
+	pa.stopHeartbeat()
+	if pa.Socket != nil {
+		pa.Socket.Close()
+		pa.Socket = nil
+	}
+	return nil
+}
+
+func (pa *PlatformAdapterSlack) RuntimeShutdown(_ context.Context) error {
+	if pa.cancel != nil {
+		pa.cancel()
+		pa.cancel = nil
+	}
+	pa.Client = nil
+	return nil
+}
+
+func (pa *PlatformAdapterTelegram) RuntimeShutdown(_ context.Context) error {
+	if pa.IntentSession != nil {
+		pa.IntentSession.StopReceivingUpdates()
+		pa.IntentSession = nil
+	}
+	return nil
+}
+
+func (pa *PlatformAdapterSatori) RuntimeShutdown(_ context.Context) error {
+	if pa.CancelFunc != nil {
+		pa.CancelFunc()
+	}
+	if pa.conn != nil {
+		err := pa.conn.Close()
+		pa.conn = nil
+		return err
+	}
+	return nil
+}
+
+func (pa *PlatformAdapterMilky) RuntimeShutdown(_ context.Context) error {
+	var shutdownErrors []error
+	if err := pa.stopMilkyRuntime(); err != nil {
+		shutdownErrors = append(shutdownErrors, fmt.Errorf("停止内置 Milky 进程: %w", err))
+	}
+	pa.runtimeMu.Lock()
+	session := pa.IntentSession
+	pa.IntentSession = nil
+	pa.runtimeMu.Unlock()
+	if session != nil {
+		if err := session.Close(); err != nil {
+			shutdownErrors = append(shutdownErrors, err)
+		}
+	}
+	return errors.Join(shutdownErrors...)
+}
+
+func (pa *PlatformAdapterGocq) RuntimeShutdown(ctx context.Context) error {
+	var shutdownErrors []error
+	if err := pa.stopGoCqhttpRuntime(); err != nil {
+		shutdownErrors = append(shutdownErrors, fmt.Errorf("停止内置 OneBot 进程: %w", err))
+	}
+	pa.runtimeMu.Lock()
+	pa.CurLoginIndex++
+	pa.diceServing = false
+	disconnected := pa.InPackGoCqhttpDisconnectedCH
+	pa.InPackGoCqhttpDisconnectedCH = nil
+	reverseApp := pa.reverseApp
+	pa.reverseApp = nil
+	socket := pa.Socket
+	pa.Socket = nil
+	pa.runtimeMu.Unlock()
+	signalAdapterStop(disconnected, 0)
+	if reverseApp != nil {
+		if err := reverseApp.Shutdown(ctx); err != nil {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf("关闭反向 OneBot 服务: %w", err))
+		}
+	}
+	if socket != nil {
+		socket.Close()
+	}
+	return errors.Join(shutdownErrors...)
+}
+
+func (pa *PlatformAdapterWalleQ) RuntimeShutdown(_ context.Context) error {
+	var shutdownErrors []error
+	if err := pa.stopWalleQRuntime(); err != nil {
+		shutdownErrors = append(shutdownErrors, fmt.Errorf("停止内置 WalleQ 进程: %w", err))
+	}
+	pa.runtimeMu.Lock()
+	pa.CurLoginIndex++
+	pa.DiceServing = false
+	disconnected := pa.InPackWalleQDisconnectedCH
+	pa.InPackWalleQDisconnectedCH = nil
+	socket := pa.Socket
+	pa.Socket = nil
+	pa.runtimeMu.Unlock()
+	signalAdapterStop(disconnected, 0)
+	if socket != nil {
+		socket.Close()
+	}
+	return errors.Join(shutdownErrors...)
+}
+
+func (pa *PlatformAdapterRed) RuntimeShutdown(_ context.Context) error {
+	pa.runtimeMu.Lock()
+	pa.runtimeStopping.Store(true)
+	pa.DiceServing = false
+	conn := pa.conn
+	pa.conn = nil
+	pa.runtimeMu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.Close()
+}
+
+func (pa *PlatformAdapterOfficialQQ) RuntimeShutdown(ctx context.Context) error {
+	pa.runtimeStopping.Store(true)
+	pa.runtimeMu.Lock()
+	cancel := pa.CancelFunc
+	server := pa.webhookServer
+	qrDone := pa.qrDone
+	pa.runtimeMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	var shutdownErrors []error
+	if server != nil {
+		if err := shutdownRuntimeHTTPServer(ctx, server.Shutdown, server.Close); err != nil {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf("关闭 Official QQ webhook: %w", err))
+		}
+	}
+	if err := waitRuntimeDone(ctx, "Official QQ 扫码任务", qrDone); err != nil {
+		shutdownErrors = append(shutdownErrors, err)
+	}
+
+	pa.runtimeMu.Lock()
+	cancel = pa.CancelFunc
+	server = pa.webhookServer
+	sessionDone := pa.sessionDone
+	webhookDone := pa.webhookDone
+	pa.runtimeMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if server != nil {
+		if err := shutdownRuntimeHTTPServer(ctx, server.Shutdown, server.Close); err != nil {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf("关闭 Official QQ webhook: %w", err))
+		}
+	}
+	if err := waitRuntimeDone(ctx, "Official QQ 会话", sessionDone); err != nil {
+		shutdownErrors = append(shutdownErrors, err)
+	}
+	if err := waitRuntimeDone(ctx, "Official QQ webhook", webhookDone); err != nil {
+		shutdownErrors = append(shutdownErrors, err)
+	}
+	pa.clearQrLoginState()
+	pa.runtimeMu.Lock()
+	pa.Ctx = nil
+	pa.CancelFunc = nil
+	pa.SessionManager = nil
+	pa.webhookServer = nil
+	pa.DiceServing = false
+	pa.runtimeMu.Unlock()
+	return errors.Join(shutdownErrors...)
+}
+
+func (pa *PlatformAdapterOnebot) RuntimeShutdown(ctx context.Context) error {
+	pa.runtimeStopping.Store(true)
+	pa.isShuttingDown = true
+	var shutdownErrors []error
+	if pa.echoServer != nil {
+		if err := shutdownRuntimeHTTPServer(ctx, pa.echoServer.Shutdown, pa.echoServer.Close); err != nil {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf("关闭 OneBot 反向服务: %w", err))
+		}
+	}
+	pa.echoServer = nil
+	if pa.cancel != nil {
+		pa.cancel()
+		pa.cancel = nil
+	}
+	if pa.websocketManager != nil {
+		if err := pa.websocketManager.Shutdown(); err != nil {
+			shutdownErrors = append(shutdownErrors, fmt.Errorf("关闭 OneBot WebSocket: %w", err))
+		}
+		pa.websocketManager = nil
+	}
+	if pa.antPool != nil {
+		pa.antPool.Release()
+		pa.antPool = nil
+	}
+	if pa.groupCache != nil {
+		pa.groupCache.Close()
+		pa.groupCache = nil
+	}
+	if pa.friendRequestDedupeCache != nil {
+		pa.friendRequestDedupeCache.Close()
+		pa.friendRequestDedupeCache = nil
+	}
+	pa.sendEmitter = nil
+	pa.connectionMutex.Lock()
+	pa.isConnecting = false
+	pa.connectionMutex.Unlock()
+	return errors.Join(shutdownErrors...)
+}
+
+func shutdownRuntimeHTTPServer(
+	ctx context.Context,
+	shutdown func(context.Context) error,
+	closeServer func() error,
+) error {
+	if err := shutdown(ctx); err != nil {
+		return closeServer()
+	}
+	return nil
+}
+
+func waitRuntimeDone(ctx context.Context, name string, done <-chan struct{}) error {
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("等待%s停止: %w", name, ctx.Err())
+	}
+}
+
+func signalAdapterStop(ch chan int, value int) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- value:
+	default:
+	}
+}

--- a/dice/runtime_lifecycle.go
+++ b/dice/runtime_lifecycle.go
@@ -30,47 +30,51 @@ func (phase *lifecyclePhase) run(ctx context.Context, work func(context.Context)
 		ctx = context.Background()
 	}
 
-	phase.mu.Lock()
-	if phase.done == nil {
-		phase.done = make(chan struct{})
-		go func(done chan struct{}) {
-			err := runLifecycleWork(ctx, work)
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				err = errors.Join(err, ctxErr)
-			}
-			phase.mu.Lock()
-			phase.err = err
-			close(done)
-			phase.mu.Unlock()
-		}(phase.done)
-	}
-	done := phase.done
-	phase.mu.Unlock()
-
-	select {
-	case <-done:
+	for {
 		phase.mu.Lock()
-		err := phase.err
+		if phase.done == nil {
+			attemptCtx := ctx
+			phase.done = make(chan struct{})
+			go func(done chan struct{}, attemptCtx context.Context) {
+				err := runLifecycleWork(attemptCtx, work)
+				phase.mu.Lock()
+				phase.err = err
+				close(done)
+				phase.mu.Unlock()
+			}(phase.done, attemptCtx)
+		}
+		done := phase.done
 		phase.mu.Unlock()
-		return err
-	default:
-	}
 
-	select {
-	case <-done:
-		phase.mu.Lock()
-		err := phase.err
-		phase.mu.Unlock()
-		return err
-	case <-ctx.Done():
 		select {
 		case <-done:
 			phase.mu.Lock()
 			err := phase.err
+			// A phase that failed only because the attempt context expired can
+			// be retried by a later caller with a fresh context. Genuine
+			// shutdown errors remain sticky.
+			retryable := err != nil &&
+				(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) &&
+				ctx.Err() == nil
+			if retryable {
+				phase.done = nil
+				phase.err = nil
+			}
 			phase.mu.Unlock()
+			if retryable {
+				continue
+			}
 			return err
-		default:
-			return ctx.Err()
+		case <-ctx.Done():
+			select {
+			case <-done:
+				phase.mu.Lock()
+				err := phase.err
+				phase.mu.Unlock()
+				return err
+			default:
+				return ctx.Err()
+			}
 		}
 	}
 }

--- a/dice/runtime_lifecycle.go
+++ b/dice/runtime_lifecycle.go
@@ -363,12 +363,11 @@ func (dm *DiceManager) IsStopped() bool {
 func (*PlatformAdapterHTTP) RuntimeShutdown(context.Context) error { return nil }
 
 func (pa *PlatformAdapterDiscord) RuntimeShutdown(_ context.Context) error {
-	if pa.IntentSession == nil {
+	session := pa.IntentSession
+	if session == nil {
 		return nil
 	}
-	err := pa.IntentSession.Close()
-	pa.IntentSession = nil
-	return err
+	return session.Close()
 }
 
 func (pa *PlatformAdapterDingTalk) RuntimeShutdown(_ context.Context) error {
@@ -406,48 +405,52 @@ func (pa *PlatformAdapterDodo) RuntimeShutdown(ctx context.Context) error {
 }
 
 func (pa *PlatformAdapterKook) RuntimeShutdown(_ context.Context) error {
-	if pa.IntentSession == nil {
+	session := pa.IntentSession
+	if session == nil {
 		return nil
 	}
-	err := pa.IntentSession.Close()
-	pa.IntentSession = nil
-	return err
+	return session.Close()
 }
 
 func (pa *PlatformAdapterMinecraft) RuntimeShutdown(_ context.Context) error {
 	pa.runtimeStopping.Store(true)
-	pa.Reconnecting = true
-	if pa.Socket != nil {
-		pa.Socket.Close()
-		pa.Socket = nil
+	pa.Reconnecting.Store(true)
+	pa.runtimeMu.Lock()
+	socket := pa.Socket
+	pa.Socket = nil
+	pa.runtimeMu.Unlock()
+	if socket != nil {
+		socket.Close()
 	}
 	return nil
 }
 
 func (pa *PlatformAdapterSealChat) RuntimeShutdown(_ context.Context) error {
 	pa.runtimeStopping.Store(true)
-	pa.Reconnecting = true
+	pa.Reconnecting.Store(true)
 	pa.stopHeartbeat()
-	if pa.Socket != nil {
-		pa.Socket.Close()
-		pa.Socket = nil
+	pa.runtimeMu.Lock()
+	socket := pa.Socket
+	pa.Socket = nil
+	pa.runtimeMu.Unlock()
+	if socket != nil {
+		socket.Close()
 	}
 	return nil
 }
 
 func (pa *PlatformAdapterSlack) RuntimeShutdown(_ context.Context) error {
-	if pa.cancel != nil {
-		pa.cancel()
-		pa.cancel = nil
+	cancel := pa.cancel
+	if cancel != nil {
+		cancel()
 	}
-	pa.Client = nil
 	return nil
 }
 
 func (pa *PlatformAdapterTelegram) RuntimeShutdown(_ context.Context) error {
-	if pa.IntentSession != nil {
-		pa.IntentSession.StopReceivingUpdates()
-		pa.IntentSession = nil
+	session := pa.IntentSession
+	if session != nil {
+		session.StopReceivingUpdates()
 	}
 	return nil
 }
@@ -457,9 +460,7 @@ func (pa *PlatformAdapterSatori) RuntimeShutdown(_ context.Context) error {
 		pa.CancelFunc()
 	}
 	if pa.conn != nil {
-		err := pa.conn.Close()
-		pa.conn = nil
-		return err
+		return pa.conn.Close()
 	}
 	return nil
 }
@@ -471,7 +472,6 @@ func (pa *PlatformAdapterMilky) RuntimeShutdown(_ context.Context) error {
 	}
 	pa.runtimeMu.Lock()
 	session := pa.IntentSession
-	pa.IntentSession = nil
 	pa.runtimeMu.Unlock()
 	if session != nil {
 		if err := session.Close(); err != nil {
@@ -487,7 +487,7 @@ func (pa *PlatformAdapterGocq) RuntimeShutdown(ctx context.Context) error {
 		shutdownErrors = append(shutdownErrors, fmt.Errorf("停止内置 OneBot 进程: %w", err))
 	}
 	pa.runtimeMu.Lock()
-	pa.CurLoginIndex++
+	pa.bumpLoginIndexLocked()
 	pa.diceServing = false
 	disconnected := pa.InPackGoCqhttpDisconnectedCH
 	pa.InPackGoCqhttpDisconnectedCH = nil
@@ -514,7 +514,7 @@ func (pa *PlatformAdapterWalleQ) RuntimeShutdown(_ context.Context) error {
 		shutdownErrors = append(shutdownErrors, fmt.Errorf("停止内置 WalleQ 进程: %w", err))
 	}
 	pa.runtimeMu.Lock()
-	pa.CurLoginIndex++
+	pa.bumpLoginIndexLocked()
 	pa.DiceServing = false
 	disconnected := pa.InPackWalleQDisconnectedCH
 	pa.InPackWalleQDisconnectedCH = nil
@@ -594,7 +594,7 @@ func (pa *PlatformAdapterOfficialQQ) RuntimeShutdown(ctx context.Context) error 
 
 func (pa *PlatformAdapterOnebot) RuntimeShutdown(ctx context.Context) error {
 	pa.runtimeStopping.Store(true)
-	pa.isShuttingDown = true
+	pa.isShuttingDown.Store(true)
 	var shutdownErrors []error
 	if pa.echoServer != nil {
 		if err := shutdownRuntimeHTTPServer(ctx, pa.echoServer.Shutdown, pa.echoServer.Close); err != nil {
@@ -612,10 +612,7 @@ func (pa *PlatformAdapterOnebot) RuntimeShutdown(ctx context.Context) error {
 		}
 		pa.websocketManager = nil
 	}
-	if pa.antPool != nil {
-		pa.antPool.Release()
-		pa.antPool = nil
-	}
+	pa.releaseAntPool()
 	if pa.groupCache != nil {
 		pa.groupCache.Close()
 		pa.groupCache = nil

--- a/dice/runtime_lifecycle.go
+++ b/dice/runtime_lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"sealdice-core/dice/service"
 	"sealdice-core/utils/constant"
 	"sealdice-core/utils/dboperator/engine"
+	sealws "sealdice-core/utils/plugin/websocket"
 )
 
 // RuntimeShutdowner is the optional, non-persistent shutdown contract for an
@@ -318,7 +319,12 @@ func (dm *DiceManager) finalize(ctx context.Context) error {
 			}
 		}
 		d.IsAlreadyLoadConfig = false
+		d.DBOperator = nil
 	}
+
+	// Close plugin WebSocket connections once for the whole Runtime instead
+	// of during each Dice's jsClear, which would disconnect sibling Dice.
+	sealws.GlobalConnManager.CloseAll()
 
 	if dm.Help != nil {
 		dm.Help.Close()
@@ -326,6 +332,9 @@ func (dm *DiceManager) finalize(ctx context.Context) error {
 	}
 	if err := errors.Join(finalizeErrors...); err != nil {
 		return err
+	}
+	if dm.progressExitGroupWin != 0 {
+		_ = dm.progressExitGroupWin.Dispose()
 	}
 	if dm.Operator != nil {
 		dm.Operator.Close()

--- a/dice/runtime_lifecycle.go
+++ b/dice/runtime_lifecycle.go
@@ -272,12 +272,21 @@ func (d *Dice) shutdownAdapters(ctx context.Context) error {
 }
 
 func shutdownAdapter(ctx context.Context, shutdowner RuntimeShutdowner) (resultErr error) {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			resultErr = fmt.Errorf("%v\n%s", recovered, debug.Stack())
-		}
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				done <- fmt.Errorf("%v\n%s", recovered, debug.Stack())
+			}
+		}()
+		done <- shutdowner.RuntimeShutdown(ctx)
 	}()
-	return shutdowner.RuntimeShutdown(ctx)
+	select {
+	case resultErr = <-done:
+		return resultErr
+	case <-ctx.Done():
+		return fmt.Errorf("关闭适配器超时: %w", ctx.Err())
+	}
 }
 
 // Finalize releases JS runtimes, extension storage, help indexes and the

--- a/dice/runtime_lifecycle.go
+++ b/dice/runtime_lifecycle.go
@@ -565,6 +565,8 @@ func (pa *PlatformAdapterOfficialQQ) RuntimeShutdown(ctx context.Context) error 
 	cancel := pa.CancelFunc
 	server := pa.webhookServer
 	qrDone := pa.qrDone
+	sessionDone := pa.sessionDone
+	webhookDone := pa.webhookDone
 	pa.runtimeMu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -577,21 +579,6 @@ func (pa *PlatformAdapterOfficialQQ) RuntimeShutdown(ctx context.Context) error 
 	}
 	if err := waitRuntimeDone(ctx, "Official QQ 扫码任务", qrDone); err != nil {
 		shutdownErrors = append(shutdownErrors, err)
-	}
-
-	pa.runtimeMu.Lock()
-	cancel = pa.CancelFunc
-	server = pa.webhookServer
-	sessionDone := pa.sessionDone
-	webhookDone := pa.webhookDone
-	pa.runtimeMu.Unlock()
-	if cancel != nil {
-		cancel()
-	}
-	if server != nil {
-		if err := shutdownRuntimeHTTPServer(ctx, server.Shutdown, server.Close); err != nil {
-			shutdownErrors = append(shutdownErrors, fmt.Errorf("关闭 Official QQ webhook: %w", err))
-		}
 	}
 	if err := waitRuntimeDone(ctx, "Official QQ 会话", sessionDone); err != nil {
 		shutdownErrors = append(shutdownErrors, err)

--- a/dice/runtime_lifecycle_test.go
+++ b/dice/runtime_lifecycle_test.go
@@ -1,0 +1,203 @@
+package dice //nolint:testpackage // Tests exercise unexported Runtime task coordination.
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/panjf2000/ants/v2"
+	"gorm.io/gorm"
+
+	"sealdice-core/utils/constant"
+)
+
+type lifecycleTestOperator struct {
+	closed atomic.Bool
+}
+
+func TestDiceManagerStopSharesTimeoutFailure(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	operator := &lifecycleTestOperator{}
+	manager := &DiceManager{Operator: operator}
+	manager.SetRuntimeContext(ctx, cancel)
+	release := make(chan struct{})
+	manager.goRuntime(func(context.Context) { <-release })
+
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer firstCancel()
+	firstErr := manager.Stop(firstCtx)
+	if !errors.Is(firstErr, context.DeadlineExceeded) {
+		t.Fatalf("first Stop() error = %v, want deadline exceeded", firstErr)
+	}
+	close(release)
+
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), time.Second)
+	defer secondCancel()
+	secondErr := manager.Stop(secondCtx)
+	if secondErr == nil {
+		t.Fatal("second Stop() reported false success after the shared phase timed out")
+	}
+	if operator.closed.Load() {
+		t.Fatal("Finalize ran after Quiesce failed")
+	}
+}
+
+func TestLifecyclePhaseRecordsDeadlineWhenWorkIgnoresCancellation(t *testing.T) {
+	var phase lifecyclePhase
+	release := make(chan struct{})
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer firstCancel()
+	if err := phase.run(firstCtx, func(context.Context) error {
+		<-release
+		return nil
+	}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first run error = %v, want deadline exceeded", err)
+	}
+	close(release)
+
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), time.Second)
+	defer secondCancel()
+	if err := phase.run(secondCtx, func(context.Context) error {
+		t.Fatal("lifecycle work ran more than once")
+		return nil
+	}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("shared phase error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestFinalizeKeepsDatabaseOpenWhenJSLoopDoesNotStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	operator := &lifecycleTestOperator{}
+	manager := &DiceManager{Operator: operator}
+	manager.SetRuntimeContext(ctx, cancel)
+	loopDone := make(chan struct{})
+	instance := &Dice{Parent: manager, ExtLoopManager: NewJsLoopManager(), jsLoopDone: loopDone}
+	manager.Dice = []*Dice{instance}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer stopCancel()
+	err := manager.Stop(stopCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Stop() error = %v, want deadline exceeded", err)
+	}
+	if operator.closed.Load() {
+		t.Fatal("database was closed while the JS Runtime could still be running")
+	}
+	close(loopDone)
+}
+
+func TestValidateDiceConfigNames(t *testing.T) {
+	valid := []BaseConfig{{Name: "default"}, {Name: "测试 骰"}, {Name: ".private"}}
+	if err := ValidateDiceConfigNames(valid); err != nil {
+		t.Fatalf("valid Dice names rejected: %v", err)
+	}
+
+	invalid := [][]BaseConfig{
+		{{Name: ""}},
+		{{Name: "."}},
+		{{Name: ".."}},
+		{{Name: "../escape"}},
+		{{Name: `folder\\child`}},
+		{{Name: "C:drive"}},
+		{{Name: "trailing."}},
+		{{Name: "trailing "}},
+		{{Name: "CON"}},
+		{{Name: "con.txt"}},
+		{{Name: "LPT9"}},
+		{{Name: "bad?name"}},
+		{{Name: "Alpha"}, {Name: "alpha"}},
+	}
+	for _, configs := range invalid {
+		if err := ValidateDiceConfigNames(configs); err == nil {
+			t.Fatalf("unsafe Dice names accepted: %#v", configs)
+		}
+	}
+}
+
+func (*lifecycleTestOperator) Init(context.Context) error           { return nil }
+func (*lifecycleTestOperator) Type() string                         { return "test" }
+func (*lifecycleTestOperator) DBCheck()                             {}
+func (*lifecycleTestOperator) GetDataDB(constant.DBMode) *gorm.DB   { return nil }
+func (*lifecycleTestOperator) GetLogDB(constant.DBMode) *gorm.DB    { return nil }
+func (*lifecycleTestOperator) GetCensorDB(constant.DBMode) *gorm.DB { return nil }
+func (operator *lifecycleTestOperator) Close()                      { operator.closed.Store(true) }
+
+func TestDiceManagerStopCancelsWaitsAndIsIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	operator := &lifecycleTestOperator{}
+	manager := &DiceManager{Operator: operator}
+	manager.SetRuntimeContext(ctx, cancel)
+	taskStopped := make(chan struct{})
+	manager.goRuntime(func(ctx context.Context) {
+		<-ctx.Done()
+		close(taskStopped)
+	})
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+	defer stopCancel()
+	if err := manager.Stop(stopCtx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-taskStopped:
+	default:
+		t.Fatal("runtime task was not awaited")
+	}
+	if !operator.closed.Load() || !manager.IsStopped() {
+		t.Fatal("runtime resources were not closed")
+	}
+	if err := manager.Stop(stopCtx); err != nil {
+		t.Fatalf("second Stop() failed: %v", err)
+	}
+}
+
+func TestOnebotAsyncTaskIsDrainedByRuntimeGate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	manager := &DiceManager{}
+	manager.SetRuntimeContext(ctx, cancel)
+	instance := &Dice{Parent: manager}
+	session := &IMSession{Parent: instance}
+	endpoint := &EndPointInfo{EndPointInfoBase: EndPointInfoBase{Session: session}}
+	pool, err := ants.NewPool(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Release()
+	adapter := &PlatformAdapterOnebot{EndPoint: endpoint, antPool: pool}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	if err := adapter.submitAsync(func() {
+		close(started)
+		<-release
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("OneBot async task did not start")
+	}
+
+	manager.runtimeMu.Lock()
+	manager.runtimeClosing = true
+	manager.runtimeMu.Unlock()
+	cancel()
+	if err := adapter.submitAsync(func() {}); err == nil {
+		t.Fatal("OneBot accepted an async task after Runtime closing began")
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer waitCancel()
+	if err := waitRuntimeTasks(waitCtx, &manager.runtimeWG); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitRuntimeTasks() error = %v, want deadline exceeded", err)
+	}
+	close(release)
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), time.Second)
+	defer drainCancel()
+	if err := waitRuntimeTasks(drainCtx, &manager.runtimeWG); err != nil {
+		t.Fatalf("OneBot async task was not drained: %v", err)
+	}
+}

--- a/dice/runtime_lifecycle_test.go
+++ b/dice/runtime_lifecycle_test.go
@@ -17,7 +17,7 @@ type lifecycleTestOperator struct {
 	closed atomic.Bool
 }
 
-func TestDiceManagerStopSharesTimeoutFailure(t *testing.T) {
+func TestDiceManagerStopRetriesAfterSharedPhaseTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	operator := &lifecycleTestOperator{}
 	manager := &DiceManager{Operator: operator}
@@ -31,20 +31,22 @@ func TestDiceManagerStopSharesTimeoutFailure(t *testing.T) {
 	if !errors.Is(firstErr, context.DeadlineExceeded) {
 		t.Fatalf("first Stop() error = %v, want deadline exceeded", firstErr)
 	}
+	if operator.closed.Load() {
+		t.Fatal("Finalize ran before Quiesce completed")
+	}
 	close(release)
 
 	secondCtx, secondCancel := context.WithTimeout(context.Background(), time.Second)
 	defer secondCancel()
-	secondErr := manager.Stop(secondCtx)
-	if secondErr == nil {
-		t.Fatal("second Stop() reported false success after the shared phase timed out")
+	if err := manager.Stop(secondCtx); err != nil {
+		t.Fatalf("second Stop() should wait for the shared phase result, got: %v", err)
 	}
-	if operator.closed.Load() {
-		t.Fatal("Finalize ran after Quiesce failed")
+	if !operator.closed.Load() {
+		t.Fatal("Finalize did not run after the shared Quiesce completed")
 	}
 }
 
-func TestLifecyclePhaseRecordsDeadlineWhenWorkIgnoresCancellation(t *testing.T) {
+func TestLifecyclePhaseRetriesAfterCallerTimeout(t *testing.T) {
 	var phase lifecyclePhase
 	release := make(chan struct{})
 	firstCtx, firstCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -62,8 +64,40 @@ func TestLifecyclePhaseRecordsDeadlineWhenWorkIgnoresCancellation(t *testing.T) 
 	if err := phase.run(secondCtx, func(context.Context) error {
 		t.Fatal("lifecycle work ran more than once")
 		return nil
+	}); err != nil {
+		t.Fatalf("shared phase result = %v, want nil after work completed", err)
+	}
+}
+
+func TestLifecyclePhaseKeepsReportingTimeoutWhileWorkIsStillRunning(t *testing.T) {
+	var phase lifecyclePhase
+	release := make(chan struct{})
+	firstCtx, firstCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer firstCancel()
+	if err := phase.run(firstCtx, func(context.Context) error {
+		<-release
+		return nil
 	}); !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("shared phase error = %v, want deadline exceeded", err)
+		t.Fatalf("first run error = %v, want deadline exceeded", err)
+	}
+
+	secondCtx, secondCancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer secondCancel()
+	if err := phase.run(secondCtx, func(context.Context) error {
+		t.Fatal("lifecycle work ran more than once")
+		return nil
+	}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second run error = %v, want deadline exceeded while work is unfinished", err)
+	}
+	close(release)
+
+	finalCtx, finalCancel := context.WithTimeout(context.Background(), time.Second)
+	defer finalCancel()
+	if err := phase.run(finalCtx, func(context.Context) error {
+		t.Fatal("lifecycle work ran more than once")
+		return nil
+	}); err != nil {
+		t.Fatalf("final run error = %v, want nil after work completed", err)
 	}
 }
 

--- a/dice/runtime_lifecycle_test.go
+++ b/dice/runtime_lifecycle_test.go
@@ -128,12 +128,21 @@ func TestValidateDiceConfigNames(t *testing.T) {
 		t.Fatalf("valid Dice names rejected: %v", err)
 	}
 
-	invalid := [][]BaseConfig{
+	alwaysInvalid := [][]BaseConfig{
 		{{Name: ""}},
 		{{Name: "."}},
 		{{Name: ".."}},
 		{{Name: "../escape"}},
 		{{Name: `folder\\child`}},
+		{{Name: "bad\x00name"}},
+	}
+	for _, configs := range alwaysInvalid {
+		if err := ValidateDiceConfigNames(configs); err == nil {
+			t.Fatalf("unsafe Dice names accepted: %#v", configs)
+		}
+	}
+
+	portableInvalid := [][]BaseConfig{
 		{{Name: "C:drive"}},
 		{{Name: "trailing."}},
 		{{Name: "trailing "}},
@@ -143,9 +152,9 @@ func TestValidateDiceConfigNames(t *testing.T) {
 		{{Name: "bad?name"}},
 		{{Name: "Alpha"}, {Name: "alpha"}},
 	}
-	for _, configs := range invalid {
-		if err := ValidateDiceConfigNames(configs); err == nil {
-			t.Fatalf("unsafe Dice names accepted: %#v", configs)
+	for _, configs := range portableInvalid {
+		if err := ValidateDiceConfigNamesPortable(configs); err == nil {
+			t.Fatalf("portable-unsafe Dice names accepted: %#v", configs)
 		}
 	}
 }

--- a/dice/service/backup.go
+++ b/dice/service/backup.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"strings"
 
 	"gorm.io/gorm"
@@ -26,9 +27,23 @@ func FlushWAL(db *gorm.DB) error {
 		return nil
 	}
 
-	// 执行 WAL 检查点操作
-	if err := db.Exec("PRAGMA wal_checkpoint(TRUNCATE);").Error; err != nil {
-		return err // 返回错误
+	// SQLite reports a busy checkpoint in the result row instead of returning
+	// an SQL error. Treat any uncheckpointed page as a hard backup failure.
+	var checkpoint struct {
+		Busy         int `gorm:"column:busy"`
+		LogPages     int `gorm:"column:log"`
+		Checkpointed int `gorm:"column:checkpointed"`
+	}
+	if err := db.Raw("PRAGMA wal_checkpoint(TRUNCATE);").Scan(&checkpoint).Error; err != nil {
+		return err
+	}
+	if checkpoint.Busy != 0 || checkpoint.LogPages != checkpoint.Checkpointed {
+		return fmt.Errorf(
+			"sqlite WAL checkpoint 未完成: busy=%d log=%d checkpointed=%d",
+			checkpoint.Busy,
+			checkpoint.LogPages,
+			checkpoint.Checkpointed,
+		)
 	}
 	// 执行内存收缩操作
 	err := db.Exec("PRAGMA shrink_memory;").Error

--- a/dice/service/log_db_nocgo_test.go
+++ b/dice/service/log_db_nocgo_test.go
@@ -3,6 +3,7 @@
 package service_test
 
 import (
+	_ "github.com/ncruces/go-sqlite3/embed"
 	sqlite "github.com/ncruces/go-sqlite3/gormlite"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"

--- a/main.go
+++ b/main.go
@@ -179,6 +179,7 @@ func main() {
 	runtime.SetMutexProfileFraction(opts.MutexProfileRate)
 	runtime.SetBlockProfileRate(opts.BlockProfileRate)
 	if opts.Delay != 0 {
+		fmt.Fprintf(os.Stdout, "延迟启动 %d 秒\n", opts.Delay)
 		time.Sleep(time.Duration(opts.Delay) * time.Second)
 	}
 
@@ -241,8 +242,8 @@ func main() {
 			uiWriter:      uiWriter,
 		})
 		serveAddress := opts.Address
-		_, externalFrontendErr := os.Stat("./frontend_overwrite")
-		useBuiltinUI := externalFrontendErr != nil
+		externalFrontend, externalFrontendErr := os.Stat("./frontend_overwrite")
+		useBuiltinUI := externalFrontendErr != nil || !externalFrontend.IsDir()
 		if !opts.ShowConsole || opts.MultiInstanceOnWindows {
 			hideWindow()
 		}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 // _ "net/http/pprof"
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -14,6 +15,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -28,7 +30,6 @@ import (
 	"sealdice-core/dice"
 	"sealdice-core/dice/service"
 	"sealdice-core/logger"
-	v2 "sealdice-core/migrate/v2"
 	"sealdice-core/static"
 	"sealdice-core/utils/crypto"
 	"sealdice-core/utils/dboperator"
@@ -47,8 +48,35 @@ extensions/
 
 var sealLock = flock.New("sealdice-lock.lock")
 
+var (
+	processCleanupMu sync.Mutex
+	runtimeStopMu    sync.RWMutex
+	runtimeStop      func(context.Context) error
+)
+
+func setRuntimeStopProvider(stop func(context.Context) error) {
+	runtimeStopMu.Lock()
+	runtimeStop = stop
+	runtimeStopMu.Unlock()
+}
+
+func stopCurrentRuntime(ctx context.Context, fallback *dice.DiceManager) error {
+	runtimeStopMu.RLock()
+	stop := runtimeStop
+	runtimeStopMu.RUnlock()
+	if stop != nil {
+		return stop(ctx)
+	}
+	if fallback != nil {
+		return fallback.Stop(ctx)
+	}
+	return nil
+}
+
 func cleanupCreate(diceManager *dice.DiceManager) func() {
 	return func() {
+		processCleanupMu.Lock()
+		defer processCleanupMu.Unlock()
 		log := logger.M()
 		log.Info("程序即将退出，进行清理……")
 		err := recover()
@@ -60,61 +88,14 @@ func cleanupCreate(diceManager *dice.DiceManager) func() {
 				exec.Command("pause") // windows专属
 			}
 		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if stopErr := stopCurrentRuntime(ctx, diceManager); stopErr != nil {
+			log.Errorf("停止 Runtime 失败: %v", stopErr)
+		}
 		err = sealLock.Unlock()
 		if err != nil {
 			log.Errorf("文件锁归还出现异常 %v", err)
-		}
-
-		if !diceManager.CleanupFlag.CompareAndSwap(0, 1) {
-			// 尝试更新cleanup标记，如果已经为1则退出
-			return
-		}
-
-		for _, i := range diceManager.Dice {
-			if i.IsAlreadyLoadConfig {
-				i.Config.BanList.SaveChanged(i)
-				i.Save(true)
-				i.AttrsManager.Stop()
-				for _, j := range i.ExtList {
-					if j.Storage != nil {
-						// 关闭
-						err := j.StorageClose()
-						if err != nil {
-							showWindow()
-							log.Errorf("异常: %v\n堆栈: %v", err, string(debug.Stack()))
-							// 木落没有加该检查 补充上
-							if runtime.GOOS == "windows" {
-								exec.Command("pause") // windows专属
-							}
-						}
-					}
-				}
-				i.IsAlreadyLoadConfig = false
-			}
-		}
-
-		for _, i := range diceManager.Dice {
-			d := i
-			d.DBOperator.Close()
-		}
-
-		// 清理gocqhttp
-		for _, i := range diceManager.Dice {
-			if i.ImSession != nil && i.ImSession.EndPoints != nil {
-				for _, j := range i.ImSession.EndPoints {
-					dice.BuiltinQQServeProcessKill(i, j)
-				}
-			}
-		}
-
-		if diceManager.Help != nil {
-			diceManager.Help.Close()
-		}
-		if diceManager.IsReady {
-			diceManager.Save()
-		}
-		if diceManager.Cron != nil {
-			diceManager.Cron.Stop()
 		}
 	}
 }
@@ -195,6 +176,9 @@ func main() {
 	// 在启动主要组件前开始采样
 	runtime.SetMutexProfileFraction(opts.MutexProfileRate)
 	runtime.SetBlockProfileRate(opts.BlockProfileRate)
+	if opts.Delay != 0 {
+		time.Sleep(time.Duration(opts.Delay) * time.Second)
+	}
 
 	// 提前到最开始初始化所有日志
 	uiWriter := logger.NewUIWriter()
@@ -241,6 +225,28 @@ func main() {
 	if judge {
 		log.Info(fmt.Sprintf("您当前使用的系统为: %s", osr))
 	}
+	_ = os.MkdirAll("./data", 0o755)
+	if restoreErr := dice.RecoverInterruptedRestore(); restoreErr != nil {
+		message := "恢复未完成事务失败，已禁止打开数据库: " + restoreErr.Error()
+		log.Error(message)
+		if statusErr := dice.UpdateRestoreStatusState("degraded", message); statusErr != nil {
+			log.Errorf("写入 degraded 恢复状态失败: %v", statusErr)
+		}
+		supervisor := newRuntimeSupervisor(runtimeBuildOptions{
+			address:       opts.Address,
+			containerMode: opts.ContainerMode,
+			justForTest:   opts.JustForTest,
+			uiWriter:      uiWriter,
+		})
+		serveAddress := opts.Address
+		_, externalFrontendErr := os.Stat("./frontend_overwrite")
+		useBuiltinUI := externalFrontendErr != nil
+		if !opts.ShowConsole || opts.MultiInstanceOnWindows {
+			hideWindow()
+		}
+		serveUnavailableControlPlane(supervisor, serveAddress, true, useBuiltinUI)
+		return
+	}
 	if opts.DBCheck {
 		dboperator.DBCheck()
 		return
@@ -251,21 +257,14 @@ func main() {
 	}
 	deleteOldWrongFile()
 
-	if opts.Delay != 0 {
-		log.Infof("延迟启动 %d 秒", opts.Delay)
-		time.Sleep(time.Duration(opts.Delay) * time.Second)
-	}
-
 	if runtime.GOOS == "android" {
 		fixTimezone()
 	}
 
-	_ = os.MkdirAll("./data", 0o755)
-
 	// 提早初始化是为了读取ServiceName
 
 	// diceManager初始化数据库
-	operator, err := dboperator.GetDatabaseOperator()
+	operator, err := dboperator.NewDatabaseOperator(context.Background())
 	if err != nil {
 		log.Errorf("Failed to init database: %v", err)
 		return
@@ -430,39 +429,39 @@ func main() {
 	//	log.Fatalf("您的146数据库可能存在问题，为保护数据，已经停止执行150升级命令。请尝试联系开发者，并提供你的日志。\n"+
 	//		"数据已回滚，您可暂时使用旧版本等待进一步的修复和更新。您的报错内容为: %v", err)
 	// }
-	err = v2.InitUpgrader(operator)
-	if err != nil {
-		log.Warnf("升级流程出现问题，请检查，问题为: %v", err)
-	}
-
 	if !opts.ShowConsole || opts.MultiInstanceOnWindows {
 		hideWindow()
 	}
 
 	go dice.TryGetBackendURL()
 
-	cleanUp := cleanupCreate(diceManager)
+	// The bootstrap manager only serves pre-runtime commands. Do not persist its
+	// process-level address over a freshly restored dice.yaml while closing it.
+	diceManager.IsReady = false
+	bootstrapStopCtx, bootstrapStopCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	if stopErr := diceManager.Stop(bootstrapStopCtx); stopErr != nil {
+		bootstrapStopCancel()
+		log.Errorf("关闭启动阶段 Runtime 失败: %v", stopErr)
+		return
+	}
+	bootstrapStopCancel()
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{
+		address:       opts.Address,
+		containerMode: opts.ContainerMode,
+		justForTest:   opts.JustForTest,
+		uiWriter:      uiWriter,
+	})
+	setRuntimeStopProvider(supervisor.stop)
+	runtimeManager, err := supervisor.start()
+	if err != nil {
+		log.Errorf("Runtime 启动失败: %v", err)
+		serveUnavailableControlPlane(supervisor, opts.Address, opts.HideUIWhenBoot, useBuiltinUI)
+		return
+	}
+	api.SetRuntimeRestoreFunc(supervisor.enqueueRestore)
+	cleanUp := cleanupCreate(nil)
 	defer dice.CrashLog()
 	defer cleanUp()
-
-	// 初始化核心
-	diceManager.TryCreateDefault()
-	diceManager.InitDice(uiWriter)
-
-	if opts.JustForTest {
-		diceManager.JustForTest = true
-	}
-
-	go func() {
-		// 每5分钟做一次新版本检查
-		for {
-			go CheckVersion(diceManager)
-			time.Sleep(5 * time.Minute)
-		}
-	}()
-	go RebootRequestListen(diceManager)
-	go UpdateRequestListen(diceManager)
-	go UpdateCheckRequestListen(diceManager)
 
 	// 强制清理机制
 	go (func() {
@@ -479,11 +478,12 @@ func main() {
 		log.Infof("由参数输入了服务地址: %s", opts.Address)
 	}
 
-	for _, d := range diceManager.Dice {
-		go diceServe(d)
+	controlPlaneReady := make(chan struct{})
+	go uiServe(runtimeManager, runtimeManager.ServeAddress, opts.HideUIWhenBoot, useBuiltinUI, controlPlaneReady)
+	<-controlPlaneReady
+	if resumeErr := supervisor.enqueueRunnableScheduledRestore(); resumeErr != nil {
+		log.Errorf("启动时续跑恢复任务失败: %v", resumeErr)
 	}
-
-	go uiServe(diceManager, opts.HideUIWhenBoot, useBuiltinUI)
 	// OOM分析工具
 	// err = nil
 	// err = http.ListenAndServe(":9090", nil)
@@ -492,7 +492,38 @@ func main() {
 	// }
 
 	// darwin 的托盘菜单似乎需要在主线程启动才能工作，调整到这里
-	trayInit(diceManager)
+	trayInit(cleanUp)
+}
+
+func serveUnavailableControlPlane(
+	supervisor *runtimeSupervisor,
+	serveAddress string,
+	hideUIWhenBoot bool,
+	useBuiltinUI bool,
+) {
+	if serveAddress == "" {
+		serveAddress = "0.0.0.0:3211"
+	}
+	api.BeginRuntimeMaintenance()
+	api.ReplaceRuntime(nil)
+	api.EndRuntimeMaintenance()
+	setRuntimeStopProvider(supervisor.stop)
+	api.SetRuntimeRestoreFunc(supervisor.enqueueRestore)
+	cleanUp := cleanupCreate(nil)
+	defer dice.CrashLog()
+	defer cleanUp()
+	go func() {
+		interrupt := make(chan os.Signal, 1)
+		signal.Notify(interrupt, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(interrupt)
+		<-interrupt
+		cleanUp()
+		os.Exit(0)
+	}()
+	controlPlaneReady := make(chan struct{})
+	go uiServe(nil, serveAddress, hideUIWhenBoot, useBuiltinUI, controlPlaneReady)
+	<-controlPlaneReady
+	trayInit(cleanUp)
 }
 
 func removeUpdateFiles() {
@@ -506,9 +537,8 @@ func removeUpdateFiles() {
 	_ = os.RemoveAll("./update")
 }
 
-func diceServe(d *dice.Dice) {
+func diceServePrepare(d *dice.Dice) []*dice.EndPointInfo {
 	log := d.Logger
-	defer dice.CrashLog()
 	if len(d.ImSession.EndPoints) == 0 {
 		log.Infof("未检测到任何帐号，请先到“帐号设置”进行添加")
 	}
@@ -524,91 +554,99 @@ func diceServe(d *dice.Dice) {
 
 	dice.TextMapCompatibleCheckAll(d)
 
-	for _, _conn := range d.ImSession.EndPoints {
-		if _conn.Enable {
-			go func(conn *dice.EndPointInfo) {
-				defer dice.ErrorLogAndContinue(d)
-
-				switch conn.Platform {
-				case "QQ":
-					if conn.ProtocolType == "walle-q" {
-						pa := conn.Adapter.(*dice.PlatformAdapterWalleQ)
-						dice.WalleQServe(d, conn, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, false)
-					}
-					if conn.ProtocolType == "onebot" {
-						pa := conn.Adapter.(*dice.PlatformAdapterGocq)
-						if pa.BuiltinMode == "lagrange" {
-							dice.LagrangeServe(d, conn, dice.LagrangeLoginInfo{
-								IsAsyncRun: true,
-							})
-							return
-						}
-						log.Errorf("不支持或已经废弃的内置适配器模式: %s", pa.BuiltinMode)
-					}
-					if conn.ProtocolType == "red" {
-						dice.ServeRed(d, conn)
-					}
-					if conn.ProtocolType == "official" {
-						dice.ServerOfficialQQ(d, conn)
-						// 官方 QQ 已由统一入口启动，避免继续进入通用 QQ 延迟启动流程。
-						return
-					}
-					if conn.ProtocolType == "satori" {
-						dice.ServeSatori(d, conn)
-					}
-					if conn.ProtocolType == "LagrangeGo" {
-						// dice.ServeLagrangeGo(d, conn)
-						return
-					}
-					if conn.ProtocolType == "milky" {
-						pa := conn.Adapter.(*dice.PlatformAdapterMilky)
-						switch pa.BuiltInMode {
-						case "lagrangeV2":
-							if runtime.GOOS == "android" {
-								return
-							}
-							dice.ServeMilkyBuiltIn(d, conn)
-							return
-						case "yogurt":
-							dice.ServeMilkyBuiltIn(d, conn)
-							return
-						default:
-							// 分离
-							dice.ServeMilky(d, conn)
-						}
-						return
-					}
-					if conn.ProtocolType == "pureonebot" {
-						dice.ServePureOnebot(d, conn)
-						return
-					}
-					time.Sleep(10 * time.Second) // 稍作等待再连接
-					dice.ServeQQ(d, conn)
-				case "DISCORD":
-					dice.ServeDiscord(d, conn)
-				case "KOOK":
-					dice.ServeKook(d, conn)
-				case "TG":
-					dice.ServeTelegram(d, conn)
-				case "MC":
-					dice.ServeMinecraft(d, conn)
-				case "DODO":
-					dice.ServeDodo(d, conn)
-				case "SLACK":
-					dice.ServeSlack(d, conn)
-				case "DINGTALK":
-					dice.ServeDingTalk(d, conn)
-				case "SEALCHAT":
-					dice.ServeSealChat(d, conn)
-				}
-			}(_conn)
+	connections := make([]*dice.EndPointInfo, 0, len(d.ImSession.EndPoints))
+	for _, conn := range d.ImSession.EndPoints {
+		if conn.Enable {
+			connections = append(connections, conn)
 		} else {
-			_conn.State = 0 // 重置状态
+			conn.State = 0 // 重置状态
 		}
+	}
+	return connections
+}
+
+func diceServeEndpoint(ctx context.Context, d *dice.Dice, conn *dice.EndPointInfo) {
+	defer dice.ErrorLogAndContinue(d)
+	if ctx.Err() != nil {
+		return
+	}
+	log := d.Logger
+	switch conn.Platform {
+	case "QQ":
+		if conn.ProtocolType == "walle-q" {
+			pa := conn.Adapter.(*dice.PlatformAdapterWalleQ)
+			dice.WalleQServe(d, conn, pa.InPackWalleQPassword, pa.InPackWalleQProtocol, false)
+		}
+		if conn.ProtocolType == "onebot" {
+			pa := conn.Adapter.(*dice.PlatformAdapterGocq)
+			if pa.BuiltinMode == "lagrange" {
+				dice.LagrangeServe(d, conn, dice.LagrangeLoginInfo{IsAsyncRun: true})
+				return
+			}
+			log.Errorf("不支持或已经废弃的内置适配器模式: %s", pa.BuiltinMode)
+		}
+		if conn.ProtocolType == "red" {
+			dice.ServeRed(d, conn)
+		}
+		if conn.ProtocolType == "official" {
+			dice.ServerOfficialQQ(d, conn)
+			return
+		}
+		if conn.ProtocolType == "satori" {
+			dice.ServeSatori(d, conn)
+		}
+		if conn.ProtocolType == "LagrangeGo" {
+			return
+		}
+		if conn.ProtocolType == "milky" {
+			pa := conn.Adapter.(*dice.PlatformAdapterMilky)
+			switch pa.BuiltInMode {
+			case "lagrangeV2":
+				if runtime.GOOS == "android" {
+					return
+				}
+				dice.ServeMilkyBuiltIn(d, conn)
+			case "yogurt":
+				dice.ServeMilkyBuiltIn(d, conn)
+			default:
+				dice.ServeMilky(d, conn)
+			}
+			return
+		}
+		if conn.ProtocolType == "pureonebot" {
+			dice.ServePureOnebot(d, conn)
+			return
+		}
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		if conn.Enable {
+			dice.ServeQQ(d, conn)
+		}
+	case "DISCORD":
+		dice.ServeDiscord(d, conn)
+	case "KOOK":
+		dice.ServeKook(d, conn)
+	case "TG":
+		dice.ServeTelegram(d, conn)
+	case "MC":
+		dice.ServeMinecraft(d, conn)
+	case "DODO":
+		dice.ServeDodo(d, conn)
+	case "SLACK":
+		dice.ServeSlack(d, conn)
+	case "DINGTALK":
+		dice.ServeDingTalk(d, conn)
+	case "SEALCHAT":
+		dice.ServeSealChat(d, conn)
 	}
 }
 
-func uiServe(dm *dice.DiceManager, hideUI bool, useBuiltin bool) {
+func uiServe(dm *dice.DiceManager, serveAddress string, hideUI bool, useBuiltin bool, ready chan<- struct{}) {
 	log := logger.M()
 	log.Info("即将启动webui")
 	// Echo instance
@@ -618,7 +656,7 @@ func uiServe(dm *dice.DiceManager, hideUI bool, useBuiltin bool) {
 	e.Use(logger.EchoLogMiddleware())
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		Skipper:      middleware.DefaultSkipper,
-		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, "token"},
+		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, "token", "X-Seal-Restore-Operation", "X-Seal-Restore-Token"},
 		AllowOrigins: []string{"*"},
 		AllowMethods: []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPatch, http.MethodPost, http.MethodDelete},
 	}))
@@ -656,9 +694,12 @@ func uiServe(dm *dice.DiceManager, hideUI bool, useBuiltin bool) {
 	}
 
 	api.Bind(e, dm)
+	if ready != nil {
+		close(ready)
+	}
 	e.HideBanner = true // 关闭banner，原因是banner图案会改变终端光标位置
 
-	httpServe(e, dm, hideUI)
+	httpServe(e, serveAddress, hideUI)
 }
 
 //

--- a/main.go
+++ b/main.go
@@ -469,7 +469,7 @@ func main() {
 	})
 	cleanUp := cleanupCreate(nil)
 	defer dice.CrashLog()
-	defer cleanUp()
+	defer func() { _ = cleanUp() }()
 
 	// 强制清理机制
 	go (func() {
@@ -477,7 +477,7 @@ func main() {
 		signal.Notify(interrupt, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 		<-interrupt
-		cleanUp()
+		_ = cleanUp()
 		log.Info("程序即将退出，再见")
 		os.Exit(0)
 	})()
@@ -527,13 +527,13 @@ func serveUnavailableControlPlane(
 	})
 	cleanUp := cleanupCreate(nil)
 	defer dice.CrashLog()
-	defer cleanUp()
+	defer func() { _ = cleanUp() }()
 	go func() {
 		interrupt := make(chan os.Signal, 1)
 		signal.Notify(interrupt, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(interrupt)
 		<-interrupt
-		cleanUp()
+		_ = cleanUp()
 		os.Exit(0)
 	}()
 	controlPlaneReady := make(chan struct{})

--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func stopCurrentRuntime(ctx context.Context, fallback *dice.DiceManager) error {
 	return nil
 }
 
-func cleanupCreate(diceManager *dice.DiceManager) func() {
-	return func() {
+func cleanupCreate(diceManager *dice.DiceManager) func() error {
+	return func() error {
 		processCleanupMu.Lock()
 		defer processCleanupMu.Unlock()
 		log := logger.M()
@@ -91,12 +91,14 @@ func cleanupCreate(diceManager *dice.DiceManager) func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if stopErr := stopCurrentRuntime(ctx, diceManager); stopErr != nil {
-			log.Errorf("停止 Runtime 失败: %v", stopErr)
+			log.Errorf("停止 Runtime 失败，保留进程文件锁: %v", stopErr)
+			return stopErr
 		}
-		err = sealLock.Unlock()
-		if err != nil {
-			log.Errorf("文件锁归还出现异常 %v", err)
+		if unlockErr := sealLock.Unlock(); unlockErr != nil {
+			log.Errorf("文件锁归还出现异常 %v", unlockErr)
+			return unlockErr
 		}
+		return nil
 	}
 }
 
@@ -459,6 +461,11 @@ func main() {
 		return
 	}
 	api.SetRuntimeRestoreFunc(supervisor.enqueueRestore)
+	api.SetRuntimeForceStopFunc(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = stopCurrentRuntime(ctx, nil)
+	})
 	cleanUp := cleanupCreate(nil)
 	defer dice.CrashLog()
 	defer cleanUp()
@@ -479,7 +486,10 @@ func main() {
 	}
 
 	controlPlaneReady := make(chan struct{})
-	go uiServe(runtimeManager, runtimeManager.ServeAddress, opts.HideUIWhenBoot, useBuiltinUI, controlPlaneReady)
+	go uiServe(runtimeManager, runtimeManager.ServeAddress, opts.HideUIWhenBoot, useBuiltinUI, controlPlaneReady, func(address string) {
+		supervisor.updateListenAddress(address)
+		runtimeManager.SetRuntimeServeAddress(address, address)
+	})
 	<-controlPlaneReady
 	if resumeErr := supervisor.enqueueRunnableScheduledRestore(); resumeErr != nil {
 		log.Errorf("启动时续跑恢复任务失败: %v", resumeErr)
@@ -492,7 +502,7 @@ func main() {
 	// }
 
 	// darwin 的托盘菜单似乎需要在主线程启动才能工作，调整到这里
-	trayInit(cleanUp)
+	trayInit(func() { _ = cleanUp() })
 }
 
 func serveUnavailableControlPlane(
@@ -509,6 +519,11 @@ func serveUnavailableControlPlane(
 	api.EndRuntimeMaintenance()
 	setRuntimeStopProvider(supervisor.stop)
 	api.SetRuntimeRestoreFunc(supervisor.enqueueRestore)
+	api.SetRuntimeForceStopFunc(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = stopCurrentRuntime(ctx, nil)
+	})
 	cleanUp := cleanupCreate(nil)
 	defer dice.CrashLog()
 	defer cleanUp()
@@ -521,9 +536,9 @@ func serveUnavailableControlPlane(
 		os.Exit(0)
 	}()
 	controlPlaneReady := make(chan struct{})
-	go uiServe(nil, serveAddress, hideUIWhenBoot, useBuiltinUI, controlPlaneReady)
+	go uiServe(nil, serveAddress, hideUIWhenBoot, useBuiltinUI, controlPlaneReady, nil)
 	<-controlPlaneReady
-	trayInit(cleanUp)
+	trayInit(func() { _ = cleanUp() })
 }
 
 func removeUpdateFiles() {
@@ -646,7 +661,14 @@ func diceServeEndpoint(ctx context.Context, d *dice.Dice, conn *dice.EndPointInf
 	}
 }
 
-func uiServe(dm *dice.DiceManager, serveAddress string, hideUI bool, useBuiltin bool, ready chan<- struct{}) {
+func uiServe(
+	dm *dice.DiceManager,
+	serveAddress string,
+	hideUI bool,
+	useBuiltin bool,
+	ready chan<- struct{},
+	onServeAddressChanged func(string),
+) {
 	log := logger.M()
 	log.Info("即将启动webui")
 	// Echo instance
@@ -699,7 +721,7 @@ func uiServe(dm *dice.DiceManager, serveAddress string, hideUI bool, useBuiltin 
 	}
 	e.HideBanner = true // 关闭banner，原因是banner图案会改变终端光标位置
 
-	httpServe(e, serveAddress, hideUI)
+	httpServe(e, serveAddress, hideUI, onServeAddressChanged)
 }
 
 //

--- a/migrate/v2/v150/v150_attrs.go
+++ b/migrate/v2/v150/v150_attrs.go
@@ -417,6 +417,8 @@ func attrsUserMigrate(db *gorm.DB) (int, int, int, error) {
 }
 
 func V150AttrsMigrate(dboperator operator.DatabaseOperator, logf func(string)) error {
+	// Runtime 热重载可能在同一进程中再次迁移较旧的备份。
+	sheetIdBindByGroupUserId = make(map[string]string)
 	log := zap.S().Named(logger.LogKeyDatabase)
 	err := dataDBInit(dboperator, logf)
 	if err != nil {

--- a/runtime_supervisor.go
+++ b/runtime_supervisor.go
@@ -239,6 +239,11 @@ func (supervisor *runtimeSupervisor) build() (runtimeResult *applicationRuntime,
 	if listenAddress == "" {
 		listenAddress = configuredAddress
 	}
+	// A command-line --address keeps its historical persistence behavior:
+	// it becomes the configured address for the next process start too.
+	if supervisor.options.address != "" {
+		configuredAddress = listenAddress
+	}
 	manager.SetRuntimeServeAddress(listenAddress, configuredAddress)
 	manager.InitDice(supervisor.options.uiWriter)
 	manager.JustForTest = supervisor.options.justForTest
@@ -322,6 +327,14 @@ func (supervisor *runtimeSupervisor) publish(runtimeInstance *applicationRuntime
 	supervisor.current = runtimeInstance
 	api.ReplaceRuntime(runtimeInstance.manager)
 	runtimeInstance.start()
+}
+
+// updateListenAddress records a runtime-selected fallback port so future
+// Runtime generations and reboots keep using it.
+func (supervisor *runtimeSupervisor) updateListenAddress(address string) {
+	supervisor.mu.Lock()
+	supervisor.listenAddress = address
+	supervisor.mu.Unlock()
 }
 
 func (supervisor *runtimeSupervisor) start() (*dice.DiceManager, error) {

--- a/runtime_supervisor.go
+++ b/runtime_supervisor.go
@@ -163,7 +163,8 @@ type runtimeSupervisor struct {
 	restoreRunFn     func(context.Context, string) error
 	restoreQueueMu   sync.Mutex
 	restoreWake      chan struct{}
-	restoreQueuedID  string
+	restoreQueue     []string
+	restoreQueued    map[string]struct{}
 	restoreActiveID  string
 	restoreCancel    context.CancelFunc
 	restoreDone      chan struct{}
@@ -172,7 +173,11 @@ type runtimeSupervisor struct {
 }
 
 func newRuntimeSupervisor(options runtimeBuildOptions) *runtimeSupervisor {
-	supervisor := &runtimeSupervisor{options: options, restoreWake: make(chan struct{}, 1)}
+	supervisor := &runtimeSupervisor{
+		options:       options,
+		restoreWake:   make(chan struct{}, 1),
+		restoreQueued: map[string]struct{}{},
+	}
 	supervisor.state.Store("stopped")
 	supervisor.buildFn = supervisor.build
 	supervisor.validateFn = validateApplicationRuntime
@@ -398,8 +403,11 @@ func (supervisor *runtimeSupervisor) restore(ctx context.Context, expectedOperat
 	operationID := runnableOperationID
 	sourceName := restoreStatus.SourceName
 	logger.M().Infow("[备份恢复] 开始执行 Runtime 恢复", "operationId", operationID, "source", sourceName)
-	if err := api.BeginRuntimeMaintenanceContext(ctx); err != nil {
-		return fmt.Errorf("等待 Runtime API 请求排空: %w", err)
+	maintenanceCtx, maintenanceCancel := context.WithTimeout(ctx, 30*time.Second)
+	maintenanceErr := api.BeginRuntimeMaintenanceContext(maintenanceCtx)
+	maintenanceCancel()
+	if maintenanceErr != nil {
+		return fmt.Errorf("等待 Runtime API 请求排空: %w", maintenanceErr)
 	}
 	defer api.EndRuntimeMaintenance()
 
@@ -522,11 +530,16 @@ func (supervisor *runtimeSupervisor) enqueueRestore(operationID string) bool {
 		supervisor.restoreQueueMu.Unlock()
 		return false
 	}
-	if supervisor.restoreActiveID == operationID || supervisor.restoreQueuedID == operationID {
+	if supervisor.restoreActiveID == operationID {
 		supervisor.restoreQueueMu.Unlock()
 		return true
 	}
-	supervisor.restoreQueuedID = operationID
+	if _, queued := supervisor.restoreQueued[operationID]; queued {
+		supervisor.restoreQueueMu.Unlock()
+		return true
+	}
+	supervisor.restoreQueued[operationID] = struct{}{}
+	supervisor.restoreQueue = append(supervisor.restoreQueue, operationID)
 	supervisor.restoreQueueMu.Unlock()
 	select {
 	case supervisor.restoreWake <- struct{}{}:
@@ -561,14 +574,19 @@ func (supervisor *runtimeSupervisor) restoreWorker(ctx context.Context, done cha
 		case <-supervisor.restoreWake:
 		}
 		for {
+			if ctx.Err() != nil {
+				return
+			}
 			supervisor.restoreQueueMu.Lock()
-			operationID := supervisor.restoreQueuedID
-			supervisor.restoreQueuedID = ""
-			supervisor.restoreActiveID = operationID
-			supervisor.restoreQueueMu.Unlock()
-			if operationID == "" {
+			if len(supervisor.restoreQueue) == 0 {
+				supervisor.restoreQueueMu.Unlock()
 				break
 			}
+			operationID := supervisor.restoreQueue[0]
+			supervisor.restoreQueue = supervisor.restoreQueue[1:]
+			delete(supervisor.restoreQueued, operationID)
+			supervisor.restoreActiveID = operationID
+			supervisor.restoreQueueMu.Unlock()
 
 			if err := supervisor.runRestoreQueueItem(ctx, operationID); err != nil {
 				logger.M().Errorw(
@@ -579,9 +597,9 @@ func (supervisor *runtimeSupervisor) restoreWorker(ctx context.Context, done cha
 			}
 			supervisor.restoreQueueMu.Lock()
 			supervisor.restoreActiveID = ""
-			hasQueued := supervisor.restoreQueuedID != ""
+			hasQueued := len(supervisor.restoreQueue) > 0
 			supervisor.restoreQueueMu.Unlock()
-			if !hasQueued {
+			if !hasQueued || ctx.Err() != nil {
 				break
 			}
 		}
@@ -709,6 +727,8 @@ func (supervisor *runtimeSupervisor) updateRestoreStatusSafely(state string, mes
 func (supervisor *runtimeSupervisor) stopRestoreWorker(ctx context.Context) error {
 	supervisor.restoreQueueMu.Lock()
 	supervisor.restoreStopped = true
+	supervisor.restoreQueue = nil
+	supervisor.restoreQueued = map[string]struct{}{}
 	cancel := supervisor.restoreCancel
 	done := supervisor.restoreDone
 	supervisor.restoreQueueMu.Unlock()

--- a/runtime_supervisor.go
+++ b/runtime_supervisor.go
@@ -1,0 +1,826 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"sealdice-core/api"
+	"sealdice-core/dice"
+	"sealdice-core/logger"
+	v2 "sealdice-core/migrate/v2"
+	"sealdice-core/utils/constant"
+	"sealdice-core/utils/dboperator"
+)
+
+type runtimeBuildOptions struct {
+	address       string
+	containerMode bool
+	justForTest   bool
+	uiWriter      *logger.UIWriter
+}
+
+type runtimeEndpointStart struct {
+	dice     *dice.Dice
+	endpoint *dice.EndPointInfo
+}
+
+type applicationRuntime struct {
+	manager  *dice.DiceManager
+	ctx      context.Context
+	cancel   context.CancelFunc
+	startMu  sync.Mutex
+	prepared bool
+	started  bool
+	starts   []runtimeEndpointStart
+}
+
+type restoreRuntimePhase string
+
+const (
+	restorePhaseMaintenance restoreRuntimePhase = "maintenance"
+	restorePhaseQuiesce     restoreRuntimePhase = "quiesce"
+	restorePhasePrepare     restoreRuntimePhase = "prepare"
+	restorePhaseFinalize    restoreRuntimePhase = "finalize"
+	restorePhaseApply       restoreRuntimePhase = "apply"
+	restorePhaseBuild       restoreRuntimePhase = "build"
+	restorePhaseCommit      restoreRuntimePhase = "commit"
+	restorePhasePublish     restoreRuntimePhase = "publish"
+	restorePhaseMark        restoreRuntimePhase = "mark"
+	restorePhaseRollback    restoreRuntimePhase = "rollback"
+)
+
+func (runtime *applicationRuntime) prepareStart() (resultErr error) {
+	runtime.startMu.Lock()
+	defer runtime.startMu.Unlock()
+	if runtime.prepared {
+		return nil
+	}
+	if runtime.manager == nil {
+		return errors.New("runtime manager 为空")
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = fmt.Errorf("准备 Runtime 启动任务时发生异常: %v", recovered)
+		}
+	}()
+	for _, currentDice := range runtime.manager.DiceSnapshot() {
+		if currentDice == nil || currentDice.ImSession == nil {
+			continue
+		}
+		for _, endpoint := range diceServePrepare(currentDice) {
+			runtime.starts = append(runtime.starts, runtimeEndpointStart{dice: currentDice, endpoint: endpoint})
+		}
+	}
+	runtime.prepared = true
+	return nil
+}
+
+// start only publishes already-prepared work. All validation that can fail is
+// completed before the restore commit point.
+func (runtime *applicationRuntime) start() {
+	runtime.startMu.Lock()
+	if runtime.started {
+		runtime.startMu.Unlock()
+		return
+	}
+	runtime.started = true
+	starts := append([]runtimeEndpointStart(nil), runtime.starts...)
+	runtime.startMu.Unlock()
+
+	for _, item := range starts {
+		currentDice := item.dice
+		endpoint := item.endpoint
+		runtime.manager.GoRuntime(func(ctx context.Context) {
+			diceServeEndpoint(ctx, currentDice, endpoint)
+		})
+	}
+	runtime.manager.GoRuntime(func(ctx context.Context) {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				CheckVersionContext(ctx, runtime.manager)
+			}
+		}
+	})
+	runtime.manager.GoRuntime(func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-runtime.manager.RebootRequestChan:
+				go doReboot(runtime.manager)
+				return
+			case <-runtime.manager.UpdateCheckRequestChan:
+				CheckVersionContext(ctx, runtime.manager)
+			case currentDice := <-runtime.manager.UpdateRequestChan:
+				updatePack, err := downloadUpdate(runtime.manager, currentDice.Logger)
+				if err != nil {
+					runtime.manager.UpdateDownloadedChan <- err.Error()
+					continue
+				}
+				runtime.manager.UpdateDownloadedChan <- ""
+				if runtime.manager.UpdateSealdiceByFile != nil {
+					runtime.manager.UpdateSealdiceByFile(updatePack)
+				}
+			}
+		}
+	})
+}
+
+func (runtime *applicationRuntime) stop(ctx context.Context) error {
+	if runtime == nil || runtime.manager == nil {
+		return nil
+	}
+	return runtime.manager.Stop(ctx)
+}
+
+type runtimeSupervisor struct {
+	mu               sync.Mutex
+	current          *applicationRuntime
+	options          runtimeBuildOptions
+	listenAddress    string
+	state            atomic.Value
+	buildFn          func() (*applicationRuntime, error)
+	validateFn       func(*applicationRuntime) error
+	prepareFn        func(*dice.DiceManager) error
+	applyFn          func() error
+	commitFn         func() error
+	markSucceededFn  func() error
+	rollbackFn       func(string) error
+	committedFn      func() (bool, error)
+	runnableIDFn     func() (string, error)
+	restoreCapableFn func(*dice.DiceManager) error
+	getStatusFn      func() dice.RestoreStatus
+	statusFn         func(string, string) error
+	restoreRunFn     func(context.Context, string) error
+	restoreQueueMu   sync.Mutex
+	restoreWake      chan struct{}
+	restoreQueuedID  string
+	restoreActiveID  string
+	restoreCancel    context.CancelFunc
+	restoreDone      chan struct{}
+	restoreOnce      sync.Once
+	restoreStopped   bool
+}
+
+func newRuntimeSupervisor(options runtimeBuildOptions) *runtimeSupervisor {
+	supervisor := &runtimeSupervisor{options: options, restoreWake: make(chan struct{}, 1)}
+	supervisor.state.Store("stopped")
+	supervisor.buildFn = supervisor.build
+	supervisor.validateFn = validateApplicationRuntime
+	supervisor.prepareFn = dice.PrepareScheduledRestore
+	supervisor.applyFn = dice.ApplyScheduledRestore
+	supervisor.commitFn = dice.CommitScheduledRestore
+	supervisor.markSucceededFn = dice.MarkScheduledRestoreSucceeded
+	supervisor.rollbackFn = dice.RollbackScheduledRestore
+	supervisor.committedFn = dice.HasCommittedRestore
+	supervisor.runnableIDFn = dice.RunnableScheduledRestoreOperationID
+	supervisor.restoreCapableFn = validateRestoreRuntime
+	supervisor.getStatusFn = dice.GetRestoreStatus
+	supervisor.statusFn = dice.UpdateRestoreStatusState
+	supervisor.restoreRunFn = supervisor.restore
+	return supervisor
+}
+
+func (supervisor *runtimeSupervisor) build() (runtimeResult *applicationRuntime, resultErr error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	operator, err := dboperator.NewDatabaseOperator(context.Background())
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("初始化数据库: %w", err)
+	}
+	manager := &dice.DiceManager{Operator: operator, ContainerMode: supervisor.options.containerMode}
+	manager.SetRuntimeContext(ctx, cancel)
+	runtimeResult = &applicationRuntime{manager: manager, ctx: ctx, cancel: cancel}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = fmt.Errorf("初始化 Runtime 时发生异常: %v", recovered)
+		}
+		if resultErr != nil {
+			cleanupErr := discardRuntime(runtimeResult)
+			resultErr = errors.Join(resultErr, cleanupErr)
+			runtimeResult = nil
+		}
+	}()
+
+	manager.LoadDice()
+	if err = v2.InitUpgrader(operator); err != nil {
+		return nil, fmt.Errorf("执行数据库迁移: %w", err)
+	}
+	manager.TryCreateDefault()
+	configs := make([]dice.BaseConfig, 0, len(manager.DiceSnapshot()))
+	for _, instance := range manager.DiceSnapshot() {
+		if instance == nil {
+			return nil, errors.New("runtime 包含空 Dice 实例")
+		}
+		configs = append(configs, instance.BaseConfig)
+	}
+	if err = dice.ValidateDiceConfigNames(configs); err != nil {
+		return nil, fmt.Errorf("校验 Dice 数据目录名称: %w", err)
+	}
+	configuredAddress := manager.ServeAddress
+	listenAddress := supervisor.listenAddress
+	if listenAddress == "" {
+		listenAddress = supervisor.options.address
+	}
+	if listenAddress == "" {
+		listenAddress = configuredAddress
+	}
+	manager.SetRuntimeServeAddress(listenAddress, configuredAddress)
+	manager.InitDice(supervisor.options.uiWriter)
+	manager.JustForTest = supervisor.options.justForTest
+	manager.UpdateSealdiceByFile = func(packName string) bool {
+		if checkErr := CheckUpdater(manager); checkErr != nil {
+			logger.M().Error("升级程序检查失败: ", checkErr.Error())
+			return false
+		}
+		return UpdateByFile(manager, packName, false)
+	}
+	manager.IsReady = true
+	return runtimeResult, nil
+}
+
+func validateApplicationRuntime(runtime *applicationRuntime) error {
+	if runtime == nil || runtime.manager == nil {
+		return errors.New("runtime 构造结果为空")
+	}
+	if runtime.manager.Operator == nil {
+		return errors.New("runtime 数据库未初始化")
+	}
+	if !runtime.manager.IsReady {
+		return errors.New("runtime manager 尚未就绪")
+	}
+	instances := runtime.manager.DiceSnapshot()
+	if len(instances) == 0 || instances[0] == nil {
+		return errors.New("runtime 未包含可发布的 Dice 实例")
+	}
+	primary := instances[0]
+	if primary.Parent != runtime.manager || primary.ImSession == nil || primary.ImSession.Parent != primary {
+		return errors.New("runtime Dice 实例关联不完整")
+	}
+	configs := make([]dice.BaseConfig, 0, len(instances))
+	for _, instance := range instances {
+		if instance == nil {
+			return errors.New("runtime 包含空 Dice 实例")
+		}
+		configs = append(configs, instance.BaseConfig)
+	}
+	if err := dice.ValidateDiceConfigNames(configs); err != nil {
+		return fmt.Errorf("runtime Dice 名称不安全: %w", err)
+	}
+	if runtime.manager.IsQuiesced() {
+		return errors.New("runtime 在发布前已经进入关闭阶段")
+	}
+	return nil
+}
+
+func (supervisor *runtimeSupervisor) buildValidatedRuntime() (
+	runtimeInstance *applicationRuntime,
+	resultErr error,
+) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = errors.Join(
+				fmt.Errorf("runtime 构造或验证异常: %v", recovered),
+				discardRuntime(runtimeInstance),
+			)
+			runtimeInstance = nil
+		}
+	}()
+
+	var err error
+	runtimeInstance, err = supervisor.buildFn()
+	if err != nil {
+		return nil, err
+	}
+	if err = supervisor.validateFn(runtimeInstance); err != nil {
+		return nil, errors.Join(err, discardRuntime(runtimeInstance))
+	}
+	if err = runtimeInstance.prepareStart(); err != nil {
+		return nil, errors.Join(err, discardRuntime(runtimeInstance))
+	}
+	return runtimeInstance, nil
+}
+
+func (supervisor *runtimeSupervisor) publish(runtimeInstance *applicationRuntime) {
+	if supervisor.listenAddress == "" {
+		supervisor.listenAddress = runtimeInstance.manager.ServeAddress
+	}
+	supervisor.current = runtimeInstance
+	api.ReplaceRuntime(runtimeInstance.manager)
+	runtimeInstance.start()
+}
+
+func (supervisor *runtimeSupervisor) start() (*dice.DiceManager, error) {
+	supervisor.mu.Lock()
+	defer supervisor.mu.Unlock()
+	if supervisor.current != nil {
+		return supervisor.current.manager, nil
+	}
+	supervisor.state.Store("starting")
+	runtimeInstance, err := supervisor.buildValidatedRuntime()
+	if err != nil {
+		api.ReplaceRuntime(nil)
+		supervisor.state.Store("degraded")
+		_ = supervisor.statusFn("degraded", "Runtime 启动失败，数据未发布: "+err.Error())
+		return nil, err
+	}
+	supervisor.publish(runtimeInstance)
+	supervisor.state.Store("running")
+	committed, committedErr := supervisor.committedFn()
+	if committedErr != nil {
+		supervisor.state.Store("degraded")
+		_ = supervisor.statusFn("degraded", "Runtime 已启动，但无法确认已提交恢复事务: "+committedErr.Error())
+		logger.M().Errorw("[备份恢复] Runtime 已启动，但无法确认已提交事务", "error", committedErr)
+	} else if committed {
+		if markErr := supervisor.markSucceededFn(); markErr != nil {
+			supervisor.state.Store("degraded")
+			_ = supervisor.statusFn("degraded", "数据已提交且 Runtime 已启动，但成功状态清理失败: "+markErr.Error())
+			logger.M().Errorw("[备份恢复] 已提交事务成功状态清理失败", "error", markErr)
+		}
+	}
+	return runtimeInstance.manager, nil
+}
+
+func (supervisor *runtimeSupervisor) restore(ctx context.Context, expectedOperationID string) (resultErr error) {
+	supervisor.mu.Lock()
+	defer supervisor.mu.Unlock()
+	restoreStatus := supervisor.getStatusFn()
+	runnableOperationID, runnableErr := supervisor.runnableIDFn()
+	if runnableErr != nil {
+		return supervisor.degradeRunning("检查可续跑恢复任务失败", runnableErr)
+	}
+	if expectedOperationID != "" && runnableOperationID != "" && expectedOperationID != runnableOperationID {
+		logger.M().Warnw(
+			"[备份恢复] 丢弃过期的 Runtime 恢复排队项",
+			"queuedOperationId", expectedOperationID,
+			"currentOperationId", runnableOperationID,
+		)
+		return nil
+	}
+	if isTerminalRestoreState(restoreStatus.State) && runnableOperationID == "" {
+		return nil
+	}
+	committed, committedErr := supervisor.committedFn()
+	if committedErr != nil {
+		return fmt.Errorf("确认恢复提交状态: %w", committedErr)
+	}
+	if committed {
+		if supervisor.current == nil {
+			return errors.New("恢复数据已提交，但 Runtime 尚未发布")
+		}
+		return supervisor.markSucceededFn()
+	}
+	if runnableOperationID == "" {
+		return errors.New("没有可执行的恢复任务")
+	}
+	if expectedOperationID != "" && expectedOperationID != runnableOperationID {
+		return nil
+	}
+	if supervisor.current == nil {
+		return errors.New("runtime 尚未启动")
+	}
+	if err := supervisor.restoreCapableFn(supervisor.current.manager); err != nil {
+		return supervisor.degradeRunning("当前 Runtime 不支持执行本地恢复任务", err)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	operationID := runnableOperationID
+	sourceName := restoreStatus.SourceName
+	logger.M().Infow("[备份恢复] 开始执行 Runtime 恢复", "operationId", operationID, "source", sourceName)
+	if err := api.BeginRuntimeMaintenanceContext(ctx); err != nil {
+		return fmt.Errorf("等待 Runtime API 请求排空: %w", err)
+	}
+	defer api.EndRuntimeMaintenance()
+
+	oldRuntime := supervisor.current
+	var newRuntime *applicationRuntime
+	phase := restorePhaseMaintenance
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = supervisor.handleRestorePanic(
+				phase,
+				operationID,
+				oldRuntime,
+				newRuntime,
+				recovered,
+			)
+		}
+	}()
+
+	phase = restorePhaseQuiesce
+	supervisor.state.Store("quiescing")
+	_ = supervisor.statusFn("quiescing", "正在停止新输入并刷新 Runtime 数据")
+	phaseCtx, phaseCancel := context.WithTimeout(ctx, 30*time.Second)
+	quiesceErr := oldRuntime.manager.Quiesce(phaseCtx)
+	phaseCancel()
+	if quiesceErr != nil {
+		return supervisor.degradeStopped("静默当前 Runtime 失败，已拒绝应用备份", quiesceErr)
+	}
+
+	phase = restorePhasePrepare
+	if err := supervisor.prepareFn(oldRuntime.manager); err != nil {
+		phase = restorePhaseFinalize
+		phaseCtx, phaseCancel = context.WithTimeout(context.Background(), 30*time.Second)
+		finalizeErr := oldRuntime.manager.Finalize(phaseCtx)
+		phaseCancel()
+		if finalizeErr != nil {
+			return supervisor.degradeStopped("准备恢复失败，且当前 Runtime 无法完全释放", errors.Join(err, finalizeErr))
+		}
+		supervisor.current = nil
+		api.ReplaceRuntime(nil)
+		phase = restorePhaseRollback
+		return supervisor.rollbackAndRestart("准备恢复失败", err)
+	}
+
+	phase = restorePhaseFinalize
+	phaseCtx, phaseCancel = context.WithTimeout(ctx, 30*time.Second)
+	finalizeErr := oldRuntime.manager.Finalize(phaseCtx)
+	phaseCancel()
+	if finalizeErr != nil {
+		return supervisor.degradeStopped("释放当前 Runtime 失败，已拒绝应用备份", finalizeErr)
+	}
+	supervisor.current = nil
+	api.ReplaceRuntime(nil)
+
+	phase = restorePhaseApply
+	supervisor.state.Store("applying")
+	if err := supervisor.applyFn(); err != nil {
+		phase = restorePhaseRollback
+		return supervisor.rollbackAndRestart("应用备份失败", err)
+	}
+
+	phase = restorePhaseBuild
+	supervisor.state.Store("starting")
+	_ = supervisor.statusFn("starting", "备份已应用，正在验证新 Runtime")
+	var err error
+	newRuntime, err = supervisor.buildValidatedRuntime()
+	if err != nil {
+		phase = restorePhaseRollback
+		return supervisor.rollbackAndRestart("恢复后的 Runtime 初始化失败", err)
+	}
+
+	phase = restorePhaseCommit
+	if err = supervisor.commitFn(); err != nil {
+		cleanupErr := discardRuntime(newRuntime)
+		return supervisor.degradeStopped(
+			"恢复提交结果不确定，数据可能已提交，禁止回滚",
+			errors.Join(err, cleanupErr),
+		)
+	}
+
+	// Commit is the irreversible boundary. From this point onward no rollback is
+	// allowed; publish/start consists only of prevalidated, non-failing steps.
+	phase = restorePhasePublish
+	supervisor.publish(newRuntime)
+	phase = restorePhaseMark
+	if err = supervisor.markSucceededFn(); err != nil {
+		supervisor.state.Store("degraded")
+		message := "数据已提交且 Runtime 已发布，但成功状态清理失败: " + err.Error()
+		_ = supervisor.statusFn("degraded", message)
+		logger.M().Errorw("[备份恢复] 提交后的状态清理失败，禁止回滚", "operationId", operationID, "error", err)
+		return errors.New(message)
+	}
+	supervisor.state.Store("running")
+	logger.M().Infow("[备份恢复] 恢复成功，Runtime 已重新运行", "operationId", operationID, "source", sourceName)
+	return nil
+}
+
+func (supervisor *runtimeSupervisor) enqueueRunnableScheduledRestore() error {
+	operationID, err := supervisor.runnableIDFn()
+	if err != nil {
+		supervisor.mu.Lock()
+		defer supervisor.mu.Unlock()
+		return supervisor.degradeRunning("检查启动时待续跑恢复任务失败", err)
+	}
+	if operationID == "" {
+		return nil
+	}
+	if !supervisor.enqueueRestore(operationID) {
+		return errors.New("runtime 恢复队列已经停止")
+	}
+	return nil
+}
+
+func (supervisor *runtimeSupervisor) enqueueRestore(operationID string) bool {
+	if operationID == "" {
+		return false
+	}
+	supervisor.startRestoreWorker()
+	supervisor.restoreQueueMu.Lock()
+	if supervisor.restoreStopped {
+		supervisor.restoreQueueMu.Unlock()
+		return false
+	}
+	if supervisor.restoreActiveID == operationID || supervisor.restoreQueuedID == operationID {
+		supervisor.restoreQueueMu.Unlock()
+		return true
+	}
+	supervisor.restoreQueuedID = operationID
+	supervisor.restoreQueueMu.Unlock()
+	select {
+	case supervisor.restoreWake <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func (supervisor *runtimeSupervisor) startRestoreWorker() {
+	supervisor.restoreOnce.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
+		supervisor.restoreQueueMu.Lock()
+		if supervisor.restoreStopped {
+			supervisor.restoreQueueMu.Unlock()
+			cancel()
+			return
+		}
+		supervisor.restoreCancel = cancel
+		supervisor.restoreDone = done
+		supervisor.restoreQueueMu.Unlock()
+		go supervisor.restoreWorker(ctx, done)
+	})
+}
+
+func (supervisor *runtimeSupervisor) restoreWorker(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-supervisor.restoreWake:
+		}
+		for {
+			supervisor.restoreQueueMu.Lock()
+			operationID := supervisor.restoreQueuedID
+			supervisor.restoreQueuedID = ""
+			supervisor.restoreActiveID = operationID
+			supervisor.restoreQueueMu.Unlock()
+			if operationID == "" {
+				break
+			}
+
+			if err := supervisor.runRestoreQueueItem(ctx, operationID); err != nil {
+				logger.M().Errorw(
+					"[备份恢复] Runtime 恢复流程结束，但恢复未成功",
+					"operationId", operationID,
+					"error", err,
+				)
+			}
+			supervisor.restoreQueueMu.Lock()
+			supervisor.restoreActiveID = ""
+			hasQueued := supervisor.restoreQueuedID != ""
+			supervisor.restoreQueueMu.Unlock()
+			if !hasQueued {
+				break
+			}
+		}
+	}
+}
+
+func (supervisor *runtimeSupervisor) runRestoreQueueItem(ctx context.Context, operationID string) (resultErr error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			resultErr = supervisor.failClosedRestorePanic(operationID, recovered)
+		}
+	}()
+	return supervisor.restoreRunFn(ctx, operationID)
+}
+
+func (supervisor *runtimeSupervisor) handleRestorePanic(
+	phase restoreRuntimePhase,
+	operationID string,
+	oldRuntime *applicationRuntime,
+	newRuntime *applicationRuntime,
+	recovered any,
+) error {
+	panicErr := fmt.Errorf("runtime 恢复在 %s 阶段异常: %v", phase, recovered)
+	message := panicErr.Error()
+	api.ReplaceRuntime(nil)
+	supervisor.state.Store("degraded")
+	supervisor.updateRestoreStatusSafely("degraded", message)
+	logger.M().Errorw(
+		"[备份恢复] Runtime 恢复阶段发生异常",
+		"operationId", operationID,
+		"phase", phase,
+		"error", panicErr,
+	)
+
+	switch phase {
+	case restorePhasePrepare:
+		if oldRuntime == nil || oldRuntime.manager == nil {
+			return panicErr
+		}
+		finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		finalizeErr := oldRuntime.manager.Finalize(finalizeCtx)
+		finalizeCancel()
+		if finalizeErr != nil {
+			return errors.Join(panicErr, fmt.Errorf("prepare 异常后释放旧 Runtime: %w", finalizeErr))
+		}
+		supervisor.current = nil
+		return supervisor.rollbackAndRestart("准备恢复时发生异常", panicErr)
+
+	case restorePhaseApply, restorePhaseBuild:
+		cleanupErr := discardRuntime(newRuntime)
+		supervisor.current = nil
+		return supervisor.rollbackAndRestart(
+			fmt.Sprintf("恢复 %s 阶段发生异常", phase),
+			errors.Join(panicErr, cleanupErr),
+		)
+
+	case restorePhaseCommit:
+		cleanupErr := discardRuntime(newRuntime)
+		supervisor.current = nil
+		message = "恢复提交结果不确定，数据可能已提交，禁止回滚"
+		supervisor.updateRestoreStatusSafely("degraded", message+": "+panicErr.Error())
+		return errors.Join(fmt.Errorf("%s: %w", message, panicErr), cleanupErr)
+
+	case restorePhasePublish, restorePhaseMark:
+		failedRuntime := supervisor.current
+		if failedRuntime == nil {
+			failedRuntime = newRuntime
+		}
+		supervisor.current = nil
+		cleanupErr := discardRuntime(failedRuntime)
+		message = "数据已提交，但发布后的 Runtime 发生异常，禁止回滚并保持不可用"
+		supervisor.updateRestoreStatusSafely("degraded", message+": "+panicErr.Error())
+		return errors.Join(fmt.Errorf("%s: %w", message, panicErr), cleanupErr)
+
+	case restorePhaseRollback:
+		failedRuntime := supervisor.current
+		supervisor.current = nil
+		cleanupErr := discardRuntime(failedRuntime)
+		message = "回滚后的 Runtime 发布异常，保持不可用"
+		supervisor.updateRestoreStatusSafely("degraded", message+": "+panicErr.Error())
+		return errors.Join(fmt.Errorf("%s: %w", message, panicErr), cleanupErr)
+
+	default:
+		return panicErr
+	}
+}
+
+func (supervisor *runtimeSupervisor) failClosedRestorePanic(operationID string, recovered any) error {
+	panicErr := fmt.Errorf("runtime 恢复 worker 异常: %v", recovered)
+	supervisor.mu.Lock()
+	defer supervisor.mu.Unlock()
+
+	api.BeginRuntimeMaintenance()
+	defer func() {
+		api.ReplaceRuntime(nil)
+		api.EndRuntimeMaintenance()
+	}()
+	api.ReplaceRuntime(nil)
+
+	supervisor.state.Store("degraded")
+	supervisor.updateRestoreStatusSafely("degraded", panicErr.Error())
+	logger.M().Errorw(
+		"[备份恢复] Runtime 恢复 worker 触发 fail-closed",
+		"operationId", operationID,
+		"error", panicErr,
+	)
+	return panicErr
+}
+
+func (supervisor *runtimeSupervisor) updateRestoreStatusSafely(state string, message string) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.M().Errorw(
+				"[备份恢复] 写入恢复状态时发生异常",
+				"state", state,
+				"error", recovered,
+			)
+		}
+	}()
+	if err := supervisor.statusFn(state, message); err != nil {
+		logger.M().Errorw("[备份恢复] 写入恢复状态失败", "state", state, "error", err)
+	}
+}
+
+func (supervisor *runtimeSupervisor) stopRestoreWorker(ctx context.Context) error {
+	supervisor.restoreQueueMu.Lock()
+	supervisor.restoreStopped = true
+	cancel := supervisor.restoreCancel
+	done := supervisor.restoreDone
+	supervisor.restoreQueueMu.Unlock()
+	if cancel == nil || done == nil {
+		return nil
+	}
+	cancel()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("等待 runtime 恢复 worker 停止: %w", ctx.Err())
+	}
+}
+
+func isTerminalRestoreState(state string) bool {
+	switch state {
+	case "succeeded", "failed", "rolled_back", "degraded":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateRestoreRuntime(manager *dice.DiceManager) error {
+	if manager == nil || manager.Operator == nil {
+		return errors.New("runtime 数据库未初始化")
+	}
+	databaseType := manager.Operator.Type()
+	if databaseType != constant.SQLITE {
+		return fmt.Errorf("恢复仅支持 SQLite，当前数据库类型为 %q", databaseType)
+	}
+	return nil
+}
+
+func (supervisor *runtimeSupervisor) rollbackAndRestart(prefix string, cause error) error {
+	message := fmt.Sprintf("%s: %v", prefix, cause)
+	operationID := supervisor.getStatusFn().OperationID
+	supervisor.state.Store("rolling_back")
+	_ = supervisor.statusFn("rolling_back", message)
+	rollbackErr := supervisor.rollbackFn(message)
+	if rollbackErr != nil {
+		return supervisor.degradeStopped(
+			message+"；回滚失败，禁止构造 Runtime",
+			errors.Join(cause, rollbackErr),
+		)
+	}
+
+	fallback, rebuildErr := supervisor.buildValidatedRuntime()
+	if rebuildErr != nil {
+		return supervisor.degradeStopped(message+"；回滚后的 Runtime 无法启动", errors.Join(cause, rebuildErr))
+	}
+	supervisor.publish(fallback)
+	supervisor.state.Store("running")
+	logger.M().Warnw("[备份恢复] 恢复未完成，已回滚并重新发布原 Runtime", "operationId", operationID, "stage", prefix)
+	return cause
+}
+
+func (supervisor *runtimeSupervisor) degradeStopped(message string, cause error) error {
+	api.ReplaceRuntime(nil)
+	supervisor.state.Store("degraded")
+	_ = supervisor.statusFn("degraded", message+": "+cause.Error())
+	logger.M().Errorw("[备份恢复] Runtime 进入 degraded", "message", message, "error", cause)
+	return fmt.Errorf("%s: %w", message, cause)
+}
+
+func (supervisor *runtimeSupervisor) degradeRunning(message string, cause error) error {
+	supervisor.state.Store("degraded")
+	_ = supervisor.statusFn("degraded", message+": "+cause.Error())
+	logger.M().Errorw("[备份恢复] Runtime 保持运行但恢复状态进入 degraded", "message", message, "error", cause)
+	return fmt.Errorf("%s: %w", message, cause)
+}
+
+func discardRuntime(runtimeInstance *applicationRuntime) error {
+	if runtimeInstance == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return runtimeInstance.stop(ctx)
+}
+
+func (supervisor *runtimeSupervisor) stop(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := supervisor.stopRestoreWorker(ctx); err != nil {
+		return err
+	}
+	supervisor.mu.Lock()
+	defer supervisor.mu.Unlock()
+
+	if err := api.BeginRuntimeMaintenanceContext(ctx); err != nil {
+		return fmt.Errorf("等待 Runtime API 请求排空: %w", err)
+	}
+	defer func() {
+		api.ReplaceRuntime(nil)
+		api.EndRuntimeMaintenance()
+	}()
+	api.ReplaceRuntime(nil)
+
+	if supervisor.current == nil {
+		supervisor.state.Store("stopped")
+		return nil
+	}
+	supervisor.state.Store("stopping")
+	err := supervisor.current.stop(ctx)
+	if err != nil {
+		supervisor.state.Store("degraded")
+		return err
+	}
+	supervisor.current = nil
+	supervisor.state.Store("stopped")
+	return nil
+}

--- a/runtime_supervisor_test.go
+++ b/runtime_supervisor_test.go
@@ -1,0 +1,810 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"sealdice-core/api"
+	"sealdice-core/dice"
+	"sealdice-core/utils/constant"
+)
+
+type supervisorTestOperator struct {
+	closed atomic.Bool
+	dbType string
+}
+
+func TestDiceServeEndpointCancelsDelayedQQStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &dice.Dice{Logger: zap.NewNop().Sugar()}
+	endpoint := &dice.EndPointInfo{EndPointInfoBase: dice.EndPointInfoBase{
+		Platform: "QQ", ProtocolType: "unknown", Enable: true,
+	}}
+	done := make(chan struct{})
+	go func() {
+		diceServeEndpoint(ctx, d, endpoint)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("delayed QQ startup ignored Runtime cancellation")
+	}
+}
+
+func (*supervisorTestOperator) Init(context.Context) error { return nil }
+func (operator *supervisorTestOperator) Type() string {
+	if operator.dbType == "" {
+		return constant.SQLITE
+	}
+	return operator.dbType
+}
+func (*supervisorTestOperator) DBCheck()                             {}
+func (*supervisorTestOperator) GetDataDB(constant.DBMode) *gorm.DB   { return nil }
+func (*supervisorTestOperator) GetLogDB(constant.DBMode) *gorm.DB    { return nil }
+func (*supervisorTestOperator) GetCensorDB(constant.DBMode) *gorm.DB { return nil }
+func (operator *supervisorTestOperator) Close()                      { operator.closed.Store(true) }
+
+func newSupervisorTestRuntime() *applicationRuntime {
+	ctx, cancel := context.WithCancel(context.Background())
+	manager := &dice.DiceManager{
+		Operator: &supervisorTestOperator{},
+		IsReady:  true,
+	}
+	primary := &dice.Dice{Parent: manager, Logger: zap.NewNop().Sugar(), BaseConfig: dice.BaseConfig{Name: "default"}}
+	primary.ImSession = &dice.IMSession{Parent: primary}
+	manager.Dice = []*dice.Dice{primary}
+	manager.SetRuntimeContext(ctx, cancel)
+	return &applicationRuntime{manager: manager, ctx: ctx, cancel: cancel}
+}
+
+func assertPublishedRuntime(t *testing.T, expected *dice.DiceManager) {
+	t.Helper()
+	type runtimeSnapshot struct {
+		manager *dice.DiceManager
+		ok      bool
+	}
+	result := make(chan runtimeSnapshot, 1)
+	go func() {
+		var published *dice.DiceManager
+		ok := api.WithCurrentRuntime(func(manager *dice.DiceManager) {
+			published = manager
+		})
+		result <- runtimeSnapshot{manager: published, ok: ok}
+	}()
+	select {
+	case snapshot := <-result:
+		if !snapshot.ok || snapshot.manager != expected {
+			t.Fatalf("published Runtime = %p, available=%v, want %p", snapshot.manager, snapshot.ok, expected)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("API Runtime gate remained locked")
+	}
+}
+
+func assertRuntimeUnavailable(t *testing.T) {
+	t.Helper()
+	maintenanceCtx, maintenanceCancel := context.WithTimeout(context.Background(), time.Second)
+	defer maintenanceCancel()
+	if err := api.BeginRuntimeMaintenanceContext(maintenanceCtx); err != nil {
+		t.Fatalf("API Runtime gate remained locked: %v", err)
+	}
+	api.EndRuntimeMaintenance()
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- api.WithCurrentRuntime(func(*dice.DiceManager) {})
+	}()
+	select {
+	case available := <-result:
+		if available {
+			t.Fatal("API Runtime unexpectedly remained available")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("API Runtime gate remained locked")
+	}
+}
+
+func TestRuntimeSupervisorStopDrainsAPIReadersBeforeClosingDatabase(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	runtimeInstance := newSupervisorTestRuntime()
+	runtimeInstance.manager.IsReady = false
+	operator := runtimeInstance.manager.Operator.(*supervisorTestOperator)
+	supervisor.current = runtimeInstance
+	api.ReplaceRuntime(runtimeInstance.manager)
+
+	readerEntered := make(chan struct{})
+	releaseReader := make(chan struct{})
+	readerDone := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseReader) })
+	go func() {
+		api.WithCurrentRuntime(func(*dice.DiceManager) {
+			close(readerEntered)
+			<-releaseReader
+		})
+		close(readerDone)
+	}()
+	select {
+	case <-readerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("API reader did not acquire the Runtime gate")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), time.Second)
+		defer stopCancel()
+		stopDone <- supervisor.stop(stopCtx)
+	}()
+	select {
+	case err := <-stopDone:
+		t.Fatalf("stop returned before the API reader drained: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if operator.closed.Load() {
+		t.Fatal("database closed while an API reader still held the Runtime gate")
+	}
+
+	releaseOnce.Do(func() { close(releaseReader) })
+	select {
+	case <-readerDone:
+	case <-time.After(time.Second):
+		t.Fatal("API reader did not finish")
+	}
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stop did not finish after the API reader drained")
+	}
+	if !operator.closed.Load() {
+		t.Fatal("database was not closed after API readers drained")
+	}
+	assertRuntimeUnavailable(t)
+}
+
+func TestRuntimeSupervisorStopTimesOutBeforeClosingDatabase(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	runtimeInstance := newSupervisorTestRuntime()
+	runtimeInstance.manager.IsReady = false
+	operator := runtimeInstance.manager.Operator.(*supervisorTestOperator)
+	supervisor.current = runtimeInstance
+	supervisor.state.Store("running")
+	api.ReplaceRuntime(runtimeInstance.manager)
+
+	readerEntered := make(chan struct{})
+	releaseReader := make(chan struct{})
+	readerDone := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseReader) })
+		_ = supervisor.stop(context.Background())
+	})
+	go func() {
+		api.WithCurrentRuntime(func(*dice.DiceManager) {
+			close(readerEntered)
+			<-releaseReader
+		})
+		close(readerDone)
+	}()
+	select {
+	case <-readerEntered:
+	case <-time.After(time.Second):
+		t.Fatal("API reader did not acquire the Runtime gate")
+	}
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	startedAt := time.Now()
+	err := supervisor.stop(stopCtx)
+	stopCancel()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stop error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 500*time.Millisecond {
+		t.Fatalf("stop ignored its context while draining API readers: %v", elapsed)
+	}
+	if operator.closed.Load() {
+		t.Fatal("database closed after Runtime gate acquisition timed out")
+	}
+	if supervisor.current != runtimeInstance || supervisor.state.Load() != "running" {
+		t.Fatal("Runtime changed after gate acquisition timed out")
+	}
+	assertPublishedRuntime(t, runtimeInstance.manager)
+
+	releaseOnce.Do(func() { close(releaseReader) })
+	select {
+	case <-readerDone:
+	case <-time.After(time.Second):
+		t.Fatal("API reader did not finish")
+	}
+	retryCtx, retryCancel := context.WithTimeout(context.Background(), time.Second)
+	defer retryCancel()
+	if err = supervisor.stop(retryCtx); err != nil {
+		t.Fatalf("stop retry failed after the API reader drained: %v", err)
+	}
+	if !operator.closed.Load() {
+		t.Fatal("database remained open after the successful stop retry")
+	}
+	assertRuntimeUnavailable(t)
+}
+
+func TestRuntimeSupervisorRollsBackPreCommitPanics(t *testing.T) {
+	for _, panicPhase := range []string{"prepare", "apply", "build"} {
+		t.Run(panicPhase, func(t *testing.T) {
+			supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+			configureRunnableRestore(supervisor, "pending")
+			supervisor.committedFn = func() (bool, error) { return false, nil }
+			oldRuntime := newSupervisorTestRuntime()
+			fallback := newSupervisorTestRuntime()
+			supervisor.current = oldRuntime
+			api.ReplaceRuntime(oldRuntime.manager)
+			supervisor.prepareFn = func(*dice.DiceManager) error {
+				if panicPhase == "prepare" {
+					panic("injected prepare panic")
+				}
+				return nil
+			}
+			supervisor.applyFn = func() error {
+				if panicPhase == "apply" {
+					panic("injected apply panic")
+				}
+				return nil
+			}
+			buildCalls := 0
+			supervisor.buildFn = func() (*applicationRuntime, error) {
+				buildCalls++
+				if panicPhase == "build" && buildCalls == 1 {
+					panic("injected build panic")
+				}
+				return fallback, nil
+			}
+			supervisor.commitFn = func() error { return nil }
+			supervisor.markSucceededFn = func() error { return nil }
+			rolledBack := false
+			supervisor.rollbackFn = func(string) error {
+				rolledBack = true
+				return nil
+			}
+			supervisor.statusFn = func(string, string) error { return nil }
+			t.Cleanup(func() { _ = supervisor.stop(context.Background()) })
+
+			if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+				t.Fatal("restore unexpectedly succeeded after injected panic")
+			}
+			if !rolledBack {
+				t.Fatal("pre-commit panic did not trigger rollback")
+			}
+			if supervisor.current != fallback || supervisor.state.Load() != "running" {
+				t.Fatal("fallback Runtime was not published after pre-commit panic")
+			}
+			assertPublishedRuntime(t, fallback.manager)
+		})
+	}
+}
+
+func TestRuntimeSupervisorFailsClosedAfterCommitPanics(t *testing.T) {
+	for _, panicPhase := range []string{"commit", "mark"} {
+		t.Run(panicPhase, func(t *testing.T) {
+			supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+			configureRunnableRestore(supervisor, "pending")
+			supervisor.committedFn = func() (bool, error) { return false, nil }
+			oldRuntime := newSupervisorTestRuntime()
+			candidate := newSupervisorTestRuntime()
+			supervisor.current = oldRuntime
+			api.ReplaceRuntime(oldRuntime.manager)
+			supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+			supervisor.applyFn = func() error { return nil }
+			supervisor.buildFn = func() (*applicationRuntime, error) { return candidate, nil }
+			supervisor.commitFn = func() error {
+				if panicPhase == "commit" {
+					panic("injected commit panic")
+				}
+				return nil
+			}
+			supervisor.markSucceededFn = func() error {
+				panic("injected mark panic")
+			}
+			rolledBack := false
+			supervisor.rollbackFn = func(string) error {
+				rolledBack = true
+				return nil
+			}
+			supervisor.statusFn = func(string, string) error { return nil }
+			t.Cleanup(func() { _ = supervisor.stop(context.Background()) })
+
+			if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+				t.Fatal("restore unexpectedly succeeded after injected panic")
+			}
+			if rolledBack {
+				t.Fatal("restore rolled back after the commit boundary")
+			}
+			if supervisor.current != nil || supervisor.state.Load() != "degraded" {
+				t.Fatal("post-commit panic did not leave Runtime degraded and unpublished")
+			}
+			if !candidate.manager.IsStopped() {
+				t.Fatal("candidate Runtime was not stopped after post-commit panic")
+			}
+			assertRuntimeUnavailable(t)
+		})
+	}
+}
+
+func TestRuntimeSupervisorWorkerPanicFailsClosed(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	runtimeInstance := newSupervisorTestRuntime()
+	supervisor.current = runtimeInstance
+	api.ReplaceRuntime(runtimeInstance.manager)
+	supervisor.statusFn = func(string, string) error { return nil }
+	supervisor.restoreRunFn = func(context.Context, string) error {
+		panic("injected outer worker panic")
+	}
+	t.Cleanup(func() { _ = supervisor.stop(context.Background()) })
+
+	if err := supervisor.runRestoreQueueItem(context.Background(), "test-operation"); err == nil {
+		t.Fatal("worker panic was not reported")
+	}
+	if supervisor.state.Load() != "degraded" {
+		t.Fatal("worker panic did not mark Runtime degraded")
+	}
+	assertRuntimeUnavailable(t)
+}
+
+func TestRuntimeSupervisorMarksCommittedRestoreAfterPublish(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	candidate := newSupervisorTestRuntime()
+	supervisor.buildFn = func() (*applicationRuntime, error) { return candidate, nil }
+	supervisor.committedFn = func() (bool, error) { return true, nil }
+	marked := false
+	supervisor.markSucceededFn = func() error {
+		if supervisor.current != candidate {
+			t.Fatal("committed restore was marked before supervisor publication")
+		}
+		published := api.WithCurrentRuntime(func(manager *dice.DiceManager) {
+			if manager != candidate.manager {
+				t.Fatal("API published a different Runtime before marking restore success")
+			}
+		})
+		if !published {
+			t.Fatal("committed restore was marked before API publication")
+		}
+		marked = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	manager, err := supervisor.start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manager != candidate.manager || !marked {
+		t.Fatal("committed restore was not marked after publishing its Runtime")
+	}
+}
+
+func TestRuntimeSupervisorRejectsExternalDatabaseBeforeQuiesce(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	runtimeInstance := newSupervisorTestRuntime()
+	operator := runtimeInstance.manager.Operator.(*supervisorTestOperator)
+	operator.dbType = constant.MYSQL
+	supervisor.current = runtimeInstance
+	prepareCalled := false
+	supervisor.prepareFn = func(*dice.DiceManager) error {
+		prepareCalled = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+		t.Fatal("restore() unexpectedly accepted an external database Runtime")
+	}
+	if prepareCalled {
+		t.Fatal("restore preparation ran before rejecting the external database")
+	}
+	if !runtimeInstance.manager.IsReady {
+		t.Fatal("external database rejection quiesced the running Runtime")
+	}
+	if operator.closed.Load() {
+		t.Fatal("external database rejection closed the running database")
+	}
+	if supervisor.current != runtimeInstance {
+		t.Fatal("external database rejection replaced the running Runtime")
+	}
+}
+
+func TestRuntimeSupervisorRejectsEmptyCandidateBeforeCommit(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	supervisor.current = newSupervisorTestRuntime()
+	invalid := newSupervisorTestRuntime()
+	invalid.manager.Dice = nil
+	supervisor.buildFn = func() (*applicationRuntime, error) { return invalid, nil }
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	committed := false
+	supervisor.commitFn = func() error {
+		committed = true
+		return nil
+	}
+	supervisor.markSucceededFn = func() error { return nil }
+	rolledBack := false
+	supervisor.rollbackFn = func(string) error {
+		rolledBack = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+		t.Fatal("restore() unexpectedly accepted an empty candidate")
+	}
+	if committed {
+		t.Fatal("empty candidate reached the commit boundary")
+	}
+	if !rolledBack {
+		t.Fatal("empty candidate failure was not rolled back")
+	}
+}
+
+func TestRuntimeSupervisorRejectsUnsafeDiceNameBeforeCommit(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	supervisor.current = newSupervisorTestRuntime()
+	invalid := newSupervisorTestRuntime()
+	invalid.manager.Dice[0].BaseConfig.Name = "../escape"
+	supervisor.buildFn = func() (*applicationRuntime, error) { return invalid, nil }
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	committed := false
+	supervisor.commitFn = func() error {
+		committed = true
+		return nil
+	}
+	supervisor.markSucceededFn = func() error { return nil }
+	supervisor.rollbackFn = func(string) error { return nil }
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+		t.Fatal("restore() unexpectedly accepted an unsafe Dice name")
+	}
+	if committed {
+		t.Fatal("unsafe Dice name reached the commit boundary")
+	}
+}
+
+func configureRunnableRestore(supervisor *runtimeSupervisor, state string) {
+	supervisor.runnableIDFn = func() (string, error) { return "test-operation", nil }
+	supervisor.getStatusFn = func() dice.RestoreStatus {
+		return dice.RestoreStatus{State: state, OperationID: "test-operation", SourceName: "source.zip"}
+	}
+}
+
+func TestRuntimeSupervisorRollsBackAndRebuildsAfterBuildFailure(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	supervisor.current = newSupervisorTestRuntime()
+	fallback := newSupervisorTestRuntime()
+	buildCalls := 0
+	supervisor.buildFn = func() (*applicationRuntime, error) {
+		buildCalls++
+		if buildCalls == 1 {
+			return nil, errors.New("injected start failure")
+		}
+		return fallback, nil
+	}
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	supervisor.commitFn = func() error { return nil }
+	supervisor.markSucceededFn = func() error { return nil }
+	rolledBack := false
+	supervisor.rollbackFn = func(string) error {
+		rolledBack = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	err := supervisor.restore(context.Background(), "test-operation")
+	if err == nil {
+		t.Fatal("restore() unexpectedly succeeded")
+	}
+	if !rolledBack || buildCalls != 2 {
+		t.Fatalf("rollback=%v buildCalls=%d, want true/2", rolledBack, buildCalls)
+	}
+	if supervisor.current != fallback || supervisor.state.Load() != "running" {
+		t.Fatal("fallback Runtime was not installed")
+	}
+}
+
+func TestRuntimeSupervisorStaysDegradedWhenRollbackFails(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	supervisor.current = newSupervisorTestRuntime()
+	buildCalls := 0
+	supervisor.buildFn = func() (*applicationRuntime, error) {
+		buildCalls++
+		return nil, errors.New("injected start failure")
+	}
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	supervisor.commitFn = func() error { return nil }
+	supervisor.markSucceededFn = func() error { return nil }
+	supervisor.rollbackFn = func(string) error { return errors.New("injected rollback failure") }
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() { api.ReplaceRuntime(nil) })
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+		t.Fatal("restore() unexpectedly succeeded")
+	}
+	if buildCalls != 1 {
+		t.Fatalf("build calls = %d, want 1", buildCalls)
+	}
+	if supervisor.current != nil || supervisor.state.Load() != "degraded" {
+		t.Fatal("Runtime was rebuilt after rollback failure")
+	}
+}
+
+func TestRuntimeSupervisorDoesNotRollbackAfterCommit(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	supervisor.current = newSupervisorTestRuntime()
+	candidate := newSupervisorTestRuntime()
+	supervisor.buildFn = func() (*applicationRuntime, error) { return candidate, nil }
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	supervisor.commitFn = func() error { return nil }
+	supervisor.markSucceededFn = func() error { return errors.New("injected mark failure") }
+	rolledBack := false
+	supervisor.rollbackFn = func(string) error {
+		rolledBack = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+		t.Fatal("restore() unexpectedly succeeded")
+	}
+	if rolledBack {
+		t.Fatal("restore rolled back after the commit boundary")
+	}
+	if supervisor.current != candidate || supervisor.state.Load() != "degraded" {
+		t.Fatal("committed Runtime was not retained in degraded state")
+	}
+}
+
+func TestRuntimeSupervisorDoesNotRollbackWhenCommitResultIsAmbiguous(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	supervisor.current = newSupervisorTestRuntime()
+	candidate := newSupervisorTestRuntime()
+	supervisor.buildFn = func() (*applicationRuntime, error) { return candidate, nil }
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	supervisor.commitFn = func() error { return errors.New("injected commit fsync failure") }
+	supervisor.markSucceededFn = func() error { return nil }
+	rolledBack := false
+	supervisor.rollbackFn = func(string) error {
+		rolledBack = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() { api.ReplaceRuntime(nil) })
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err == nil {
+		t.Fatal("restore() unexpectedly succeeded")
+	}
+	if rolledBack {
+		t.Fatal("restore rolled back after an ambiguous commit result")
+	}
+	if supervisor.current != nil || supervisor.state.Load() != "degraded" {
+		t.Fatal("ambiguous commit result did not leave Runtime unavailable and degraded")
+	}
+	if !candidate.manager.IsStopped() {
+		t.Fatal("candidate Runtime was not discarded after commit uncertainty")
+	}
+}
+
+func TestRuntimeSupervisorPreparesBeforeFinalize(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "pending")
+	oldRuntime := newSupervisorTestRuntime()
+	oldOperator := oldRuntime.manager.Operator.(*supervisorTestOperator)
+	supervisor.current = oldRuntime
+	candidate := newSupervisorTestRuntime()
+	var order []string
+	supervisor.prepareFn = func(*dice.DiceManager) error {
+		if oldOperator.closed.Load() {
+			t.Fatal("database closed before PrepareScheduledRestore")
+		}
+		order = append(order, "prepare")
+		return nil
+	}
+	supervisor.applyFn = func() error {
+		if !oldOperator.closed.Load() {
+			t.Fatal("database still open during ApplyScheduledRestore")
+		}
+		order = append(order, "apply")
+		return nil
+	}
+	supervisor.buildFn = func() (*applicationRuntime, error) {
+		order = append(order, "build")
+		return candidate, nil
+	}
+	supervisor.commitFn = func() error {
+		order = append(order, "commit")
+		return nil
+	}
+	supervisor.markSucceededFn = func() error {
+		order = append(order, "mark")
+		return nil
+	}
+	supervisor.rollbackFn = func(string) error { return nil }
+	supervisor.statusFn = func(string, string) error { return nil }
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	if err := supervisor.restore(context.Background(), "test-operation"); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"prepare", "apply", "build", "commit", "mark"}
+	if fmt.Sprint(order) != fmt.Sprint(want) {
+		t.Fatalf("restore order = %v, want %v", order, want)
+	}
+}
+
+func TestRuntimeSupervisorResumesPendingBeforeStatusWasWritten(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	configureRunnableRestore(supervisor, "idle")
+	supervisor.current = newSupervisorTestRuntime()
+	candidate := newSupervisorTestRuntime()
+	supervisor.prepareFn = func(*dice.DiceManager) error { return nil }
+	supervisor.applyFn = func() error { return nil }
+	supervisor.buildFn = func() (*applicationRuntime, error) { return candidate, nil }
+	supervisor.commitFn = func() error { return nil }
+	supervisor.markSucceededFn = func() error { return nil }
+	supervisor.rollbackFn = func(string) error { return nil }
+	supervisor.statusFn = func(string, string) error { return nil }
+	completed := make(chan error, 1)
+	restoreRun := supervisor.restoreRunFn
+	supervisor.restoreRunFn = func(ctx context.Context, operationID string) error {
+		err := restoreRun(ctx, operationID)
+		completed <- err
+		return err
+	}
+	t.Cleanup(func() {
+		api.ReplaceRuntime(nil)
+		_ = supervisor.stop(context.Background())
+	})
+
+	if err := supervisor.enqueueRunnableScheduledRestore(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-completed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the startup restore queue")
+	}
+	supervisor.mu.Lock()
+	current := supervisor.current
+	supervisor.mu.Unlock()
+	if current != candidate || supervisor.state.Load() != "running" {
+		t.Fatal("runnable pending restore was not resumed from an idle external status")
+	}
+}
+
+func TestRuntimeSupervisorRestoreQueueCoalescesActiveOperation(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	started := make(chan struct{})
+	release := make(chan struct{})
+	completed := make(chan struct{})
+	var calls atomic.Int32
+	var startedOnce sync.Once
+	var completedOnce sync.Once
+	supervisor.restoreRunFn = func(ctx context.Context, operationID string) error {
+		if operationID != "same-operation" {
+			t.Errorf("operationID = %q", operationID)
+		}
+		calls.Add(1)
+		startedOnce.Do(func() { close(started) })
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-release:
+			completedOnce.Do(func() { close(completed) })
+			return nil
+		}
+	}
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		_ = supervisor.stop(context.Background())
+	})
+
+	if !supervisor.enqueueRestore("same-operation") {
+		t.Fatal("initial enqueue was rejected")
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("restore worker did not start")
+	}
+	for range 100 {
+		if !supervisor.enqueueRestore("same-operation") {
+			t.Fatal("coalesced enqueue was rejected")
+		}
+	}
+	close(release)
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("restore worker did not complete")
+	}
+	time.Sleep(10 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("restore calls = %d, want 1", got)
+	}
+}
+
+func TestRuntimeSupervisorDropsStaleQueuedOperation(t *testing.T) {
+	supervisor := newRuntimeSupervisor(runtimeBuildOptions{})
+	supervisor.current = newSupervisorTestRuntime()
+	supervisor.getStatusFn = func() dice.RestoreStatus {
+		return dice.RestoreStatus{State: "pending", OperationID: "new-operation"}
+	}
+	supervisor.runnableIDFn = func() (string, error) { return "new-operation", nil }
+	prepared := false
+	supervisor.prepareFn = func(*dice.DiceManager) error {
+		prepared = true
+		return nil
+	}
+	supervisor.statusFn = func(string, string) error { return nil }
+
+	if err := supervisor.restore(context.Background(), "stale-operation"); err != nil {
+		t.Fatal(err)
+	}
+	if prepared {
+		t.Fatal("stale queued operation executed the current pending restore")
+	}
+}

--- a/tray_common.go
+++ b/tray_common.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fy0/systray"
 
+	"sealdice-core/api"
 	"sealdice-core/dice"
 )
 
@@ -41,14 +42,25 @@ type trayAccountMenu struct {
 }
 
 func formatTrayTooltip(dm *dice.DiceManager, version, port string) string {
-	text := dice.NormalizeTrayTooltipPrefix(dm.GetTrayTooltip())
+	text := ""
+	if dm != nil {
+		text = dice.NormalizeTrayTooltipPrefix(dm.GetTrayTooltip())
+	}
 	if text == "" {
 		text = defaultTrayTooltip
 	}
 	return fmt.Sprintf("%s %s #%s", text, version, port)
 }
 
-func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
+func currentTrayTooltip(version, port string) string {
+	tooltip := formatTrayTooltip(nil, version, port)
+	api.WithCurrentRuntime(func(manager *dice.DiceManager) {
+		tooltip = formatTrayTooltip(manager, version, port)
+	})
+	return tooltip
+}
+
+func startTrayAccountMenu(openAccountSettings func()) {
 	root := systray.AddMenuItem("账号列表", "查看已配置的平台账号")
 	menu := &trayAccountMenu{
 		root:                root,
@@ -62,19 +74,25 @@ func startTrayAccountMenu(dm *dice.DiceManager, openAccountSettings func()) {
 		}
 	}()
 
-	menu.refresh(dm.DiceSnapshot())
+	menu.refresh(currentTrayAccountTitles())
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 		for range ticker.C {
-			menu.refresh(dm.DiceSnapshot())
+			menu.refresh(currentTrayAccountTitles())
 		}
 	}()
 }
 
-func (menu *trayAccountMenu) refresh(instances []*dice.Dice) {
-	titles := loadTrayAccountTitles(instances)
+func currentTrayAccountTitles() []string {
+	var titles []string
+	api.WithCurrentRuntime(func(manager *dice.DiceManager) {
+		titles = loadTrayAccountTitles(manager.DiceSnapshot())
+	})
+	return titles
+}
 
+func (menu *trayAccountMenu) refresh(titles []string) {
 	for len(menu.account) < len(titles) {
 		item := menu.root.AddSubMenuItem(titles[len(menu.account)], "")
 		go func(item *systray.MenuItem) {

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -100,7 +100,7 @@ func onExit() {
 	// clean up hear
 }
 
-func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
+func httpServe(e *echo.Echo, serveAddress string, hideUI bool, _ func(string)) {
 	log := logger.M()
 	portStr := defaultTrayPort
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE

--- a/tray_darwin.go
+++ b/tray_darwin.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -21,10 +22,10 @@ import (
 	"sealdice-core/logger"
 )
 
-var theDm *dice.DiceManager
+var trayCleanup func()
 
-func trayInit(dm *dice.DiceManager) {
-	theDm = dm
+func trayInit(cleanup func()) {
+	trayCleanup = cleanup
 	runtime.LockOSThread()
 	systray.Run(onReady, onExit)
 }
@@ -59,18 +60,18 @@ func executeWin(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-var systrayQuited bool = false
+var systrayQuited atomic.Bool
 
 func onReady() {
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("海豹核心")
-	systray.SetTooltip(formatTrayTooltip(theDm, ver, getTrayPort()))
+	systray.SetTooltip(currentTrayTooltip(ver, getTrayPort()))
 
 	mOpen := systray.AddMenuItem("打开界面", "开启WebUI")
 	mOpen.SetIcon(icon.Data)
 	mOpenExeDir := systray.AddMenuItem("打开海豹目录", "访达访问程序所在目录")
-	startTrayAccountMenu(theDm, func() {
+	startTrayAccountMenu(func() {
 		_ = exec.Command(`open`, `http://localhost:`+getTrayPort()+`/#/connect`).Start()
 	})
 	mQuit := systray.AddMenuItem("退出", "退出程序")
@@ -86,8 +87,8 @@ func onReady() {
 		case <-mOpenExeDir.ClickedCh:
 			_ = exec.Command(`open`, filepath.Dir(os.Args[0])).Start()
 		case <-mQuit.ClickedCh:
-			systrayQuited = true
-			cleanupCreate(theDm)()
+			systrayQuited.Store(true)
+			trayCleanup()
 			systray.Quit()
 			time.Sleep(3 * time.Second)
 			os.Exit(0)
@@ -99,7 +100,7 @@ func onExit() {
 	// clean up hear
 }
 
-func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
+func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
 	log := logger.M()
 	portStr := defaultTrayPort
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
@@ -107,17 +108,17 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 	go func() {
 		for {
 			time.Sleep(5 * time.Second)
-			if systrayQuited {
+			if systrayQuited.Load() {
 				break
 			}
 			runtime.LockOSThread()
-			systray.SetTooltip(formatTrayTooltip(dm, ver, getTrayPort()))
+			systray.SetTooltip(currentTrayTooltip(ver, getTrayPort()))
 			runtime.UnlockOSThread()
 		}
 	}()
 
 	rePort := regexp.MustCompile(`:(\d+)$`)
-	m := rePort.FindStringSubmatch(dm.ServeAddress)
+	m := rePort.FindStringSubmatch(serveAddress)
 	if len(m) > 0 {
 		portStr = m[1]
 		setTrayPort(portStr)
@@ -125,16 +126,16 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 
 	ln, err := net.Listen("tcp", ":"+portStr)
 	if err != nil {
-		log.Errorf("端口已被占用，即将自动退出: %s", dm.ServeAddress)
+		log.Errorf("端口已被占用，即将自动退出: %s", serveAddress)
 		runtime.Goexit()
 	}
 	_ = ln.Close()
 
 	// exec.Command(`cmd`, `/c`, `start`, fmt.Sprintf(`http://localhost:%s`, portStr)).Start()
 	log.Infof("如果浏览器没有自动打开，请手动访问:\nhttp://localhost:%s", portStr)
-	err = e.Start(dm.ServeAddress)
+	err = e.Start(serveAddress)
 	if err != nil {
-		log.Errorf("端口已被占用，即将自动退出: %s", dm.ServeAddress)
+		log.Errorf("端口已被占用，即将自动退出: %s", serveAddress)
 		return
 	}
 }

--- a/tray_others.go
+++ b/tray_others.go
@@ -12,11 +12,10 @@ import (
 
 	"github.com/labstack/echo/v4"
 
-	"sealdice-core/dice"
 	"sealdice-core/logger"
 )
 
-func trayInit(dm *dice.DiceManager) {
+func trayInit(_ func()) {
 	select {}
 }
 
@@ -38,26 +37,26 @@ func showMsgBox(title string, message string) {
 	logger.M().Info(title, message)
 }
 
-func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
+func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
 	log := logger.M()
 	portStr := "3211"
 	rePort := regexp.MustCompile(`:(\d+)$`)
-	m := rePort.FindStringSubmatch(dm.ServeAddress)
+	m := rePort.FindStringSubmatch(serveAddress)
 	if len(m) > 0 {
 		portStr = m[1]
 	}
 
 	ln, err := net.Listen("tcp", ":"+portStr)
 	if err != nil {
-		log.Errorf("端口已被占用，即将自动退出: %s", dm.ServeAddress)
+		log.Errorf("端口已被占用，即将自动退出: %s", serveAddress)
 		runtime.Goexit()
 	}
 	_ = ln.Close()
 
 	log.Infof("如果浏览器没有自动打开，请手动访问:\nhttp://localhost:%s", portStr)
-	err = e.Start(dm.ServeAddress)
+	err = e.Start(serveAddress)
 	if err != nil {
-		log.Errorf("端口已被占用，即将自动退出: %s", dm.ServeAddress)
+		log.Errorf("端口已被占用，即将自动退出: %s", serveAddress)
 		return
 	}
 }

--- a/tray_others.go
+++ b/tray_others.go
@@ -37,7 +37,7 @@ func showMsgBox(title string, message string) {
 	logger.M().Info(title, message)
 }
 
-func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
+func httpServe(e *echo.Echo, serveAddress string, hideUI bool, _ func(string)) {
 	log := logger.M()
 	portStr := "3211"
 	rePort := regexp.MustCompile(`:(\d+)$`)

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -188,7 +188,7 @@ func onExit() {
 	// clean up here
 }
 
-func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
+func httpServe(e *echo.Echo, serveAddress string, hideUI bool, onServeAddressChanged func(string)) {
 	log := logger.M()
 	portStr := defaultTrayPort
 	// runtime.LockOSThread()
@@ -243,6 +243,9 @@ func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
 			if ret == win.IDYES {
 				newPort := 3000 + rand.Int()%4000
 				serveAddress = fmt.Sprintf("0.0.0.0:%d", newPort)
+				if onServeAddressChanged != nil {
+					onServeAddressChanged(serveAddress)
+				}
 				continue
 			} else {
 				log.Errorf("端口已被占用，即将自动退出: %s", serveAddress)

--- a/tray_windows.go
+++ b/tray_windows.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -35,10 +36,10 @@ func showWindow() {
 	win.ShowWindow(win.GetConsoleWindow(), win.SW_SHOW)
 }
 
-var theDM *dice.DiceManager
+var trayCleanup func()
 
-func trayInit(dm *dice.DiceManager) {
-	theDM = dm
+func trayInit(cleanup func()) {
+	trayCleanup = cleanup
 	// 确保能收到系统消息，从而避免不能弹出菜单
 	runtime.LockOSThread()
 	systray.Run(onReady, onExit)
@@ -99,18 +100,18 @@ func getAutoStart() *autostart.App {
 	return nil
 }
 
-var systrayQuited bool = false
+var systrayQuited atomic.Bool
 
 func onReady() {
 	log := logger.M()
 	ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("海豹TRPG骰点核心")
-	systray.SetTooltip(formatTrayTooltip(theDM, ver, getTrayPort()))
+	systray.SetTooltip(currentTrayTooltip(ver, getTrayPort()))
 
 	mOpen := systray.AddMenuItem("打开界面", "开启WebUI")
 	mOpenExeDir := systray.AddMenuItem("打开海豹目录", "资源管理器访问程序所在目录")
-	startTrayAccountMenu(theDM, func() {
+	startTrayAccountMenu(func() {
 		_ = exec.Command(`cmd`, `/c`, `start`, `http://localhost:`+getTrayPort()+`/#/connect`).Start()
 	})
 	mShowHide := systray.AddMenuItemCheckbox("显示终端窗口", "显示终端窗口", false)
@@ -147,8 +148,8 @@ func onReady() {
 			_ = exec.Command(`cmd`, `/c`, `explorer`, filepath.Dir(os.Args[0])).Start()
 		case <-mQuit.ClickedCh:
 			systray.Quit()
-			systrayQuited = true
-			cleanupCreate(theDM)()
+			systrayQuited.Store(true)
+			trayCleanup()
 			time.Sleep(3 * time.Second)
 			os.Exit(0)
 		case <-mAutoBoot.ClickedCh:
@@ -187,7 +188,7 @@ func onExit() {
 	// clean up here
 }
 
-func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
+func httpServe(e *echo.Echo, serveAddress string, hideUI bool) {
 	log := logger.M()
 	portStr := defaultTrayPort
 	// runtime.LockOSThread()
@@ -196,11 +197,11 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 		ver := dice.VERSION_MAIN + dice.VERSION_PRERELEASE
 		for {
 			time.Sleep(5 * time.Second)
-			if systrayQuited {
+			if systrayQuited.Load() {
 				break
 			}
 			runtime.LockOSThread()
-			systray.SetTooltip(formatTrayTooltip(dm, ver, getTrayPort()))
+			systray.SetTooltip(currentTrayTooltip(ver, getTrayPort()))
 			runtime.UnlockOSThread()
 		}
 	}()
@@ -226,14 +227,14 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 
 	for {
 		rePort := regexp.MustCompile(`:(\d+)$`)
-		m := rePort.FindStringSubmatch(dm.ServeAddress)
+		m := rePort.FindStringSubmatch(serveAddress)
 		if len(m) > 0 {
 			portStr = m[1]
 		}
 		// 同步托盘菜单使用的端口，确保自定义端口和自动换端口后链接正确。
 		setTrayPort(portStr)
 
-		err := e.Start(dm.ServeAddress)
+		err := e.Start(serveAddress)
 
 		if err != nil {
 			s1, _ := syscall.UTF16PtrFromString("海豹TRPG骰点核心")
@@ -241,10 +242,10 @@ func httpServe(e *echo.Echo, dm *dice.DiceManager, hideUI bool) {
 			ret := win.MessageBox(0, s2, s1, win.MB_YESNO|win.MB_ICONWARNING|win.MB_DEFBUTTON2)
 			if ret == win.IDYES {
 				newPort := 3000 + rand.Int()%4000
-				dm.ServeAddress = fmt.Sprintf("0.0.0.0:%d", newPort)
+				serveAddress = fmt.Sprintf("0.0.0.0:%d", newPort)
 				continue
 			} else {
-				log.Errorf("端口已被占用，即将自动退出: %s", dm.ServeAddress)
+				log.Errorf("端口已被占用，即将自动退出: %s", serveAddress)
 				os.Exit(0)
 			}
 		} else {

--- a/update.go
+++ b/update.go
@@ -77,35 +77,6 @@ func downloadUpdate(dm *dice.DiceManager, log *zap.SugaredLogger) (string, error
 	return packFn, nil
 }
 
-func RebootRequestListen(dm *dice.DiceManager) {
-	<-dm.RebootRequestChan
-	doReboot(dm)
-}
-
-func UpdateCheckRequestListen(dm *dice.DiceManager) {
-	for {
-		<-dm.UpdateCheckRequestChan
-		CheckVersion(dm)
-	}
-}
-
-func UpdateRequestListen(dm *dice.DiceManager) {
-	curDice := <-dm.UpdateRequestChan
-	log := curDice.Logger
-	updatePackFn, err := downloadUpdate(dm, log)
-	if err == nil {
-		dm.UpdateDownloadedChan <- ""
-		time.Sleep(2 * time.Second)
-		log.Info("进行升级准备工作")
-
-		dm.UpdateSealdiceByFile(updatePackFn)
-		// 旧版本行为: 将新升级包里的主程序复制到当前目录，命名为 auto_update.exe 或 auto_update
-		// 然后重启主程序
-	} else {
-		dm.UpdateDownloadedChan <- err.Error()
-	}
-}
-
 func doReboot(dm *dice.DiceManager) {
 	log := logger.M()
 	executablePath, err := os.Executable()

--- a/update.go
+++ b/update.go
@@ -1,16 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -107,32 +108,39 @@ func UpdateRequestListen(dm *dice.DiceManager) {
 
 func doReboot(dm *dice.DiceManager) {
 	log := logger.M()
-	executablePath, err := filepath.Abs(os.Args[0])
-	if err != nil {
-		return
-	}
-
-	binary, err := exec.LookPath(executablePath)
+	executablePath, err := os.Executable()
 	if err != nil {
 		log.Errorf("Restart Error: %s", err)
 		return
 	}
+	binary, err := filepath.Abs(executablePath)
+	if err != nil {
+		log.Errorf("Restart Error: %s", err)
+		return
+	}
+	probe, err := os.Open(binary)
+	if err != nil {
+		log.Errorf("Restart Error: %s", err)
+		return
+	}
+	_ = probe.Close()
+
+	restartArgs := buildRestartArgs(os.Args[1:], "1")
 	platform := runtime.GOOS
 	if platform == "windows" {
+		restartArgs = buildRestartArgs(os.Args[1:], "3")
+	}
+	if platform == "windows" {
 		cleanupCreate(dm)()
-
-		// name, _ := filepath.Abs(binary)
-		// err = exec.Command(`cmd`, `/C`, "start", name, "--delay=15").Start()
-		cmd := executeWin(binary, "--delay=15")
+		cmd := executeWin(binary, restartArgs...)
 		err := cmd.Start()
 		if err != nil {
 			log.Errorf("Restart error: %s %v", binary, err)
 		}
 	} else {
-		// 手动cleanup
 		cleanupCreate(dm)()
-		// os.Args[1:]...
-		execErr := syscall.Exec(binary, []string{os.Args[0], "--delay=25"}, os.Environ()) //nolint:gosec
+		execArgs := append([]string{os.Args[0]}, restartArgs...)
+		execErr := syscall.Exec(binary, execArgs, os.Environ()) //nolint:gosec
 		if execErr != nil {
 			log.Errorf("Restart error: %s %v", binary, execErr)
 		}
@@ -140,8 +148,29 @@ func doReboot(dm *dice.DiceManager) {
 	os.Exit(0)
 }
 
-func checkVersionBase(backendUrl string, dm *dice.DiceManager) *dice.VersionInfo {
-	resp, err := http.Get(backendUrl + "/dice/api/version?versionCode=" + strconv.FormatInt(dm.AppVersionCode, 10) + "&v=" + strconv.FormatInt(rand.Int63(), 10))
+func buildRestartArgs(args []string, delay string) []string {
+	restartArgs := make([]string, 0, len(args)+1)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--delay" {
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "--delay=") {
+			continue
+		}
+		restartArgs = append(restartArgs, arg)
+	}
+	return append(restartArgs, "--delay="+delay)
+}
+
+func checkVersionBase(ctx context.Context, backendUrl string, dm *dice.DiceManager) *dice.VersionInfo {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, backendUrl+"/dice/api/version?versionCode="+strconv.FormatInt(dm.AppVersionCode, 10)+"&v="+strconv.FormatInt(rand.Int63(), 10), nil)
+	if err != nil {
+		return nil
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(request)
 	if err != nil {
 		// logger.Errorf("获取新版本失败: %s", err.Error())
 		return nil
@@ -160,12 +189,16 @@ func checkVersionBase(backendUrl string, dm *dice.DiceManager) *dice.VersionInfo
 }
 
 func CheckVersion(dm *dice.DiceManager) *dice.VersionInfo {
+	return CheckVersionContext(context.Background(), dm)
+}
+
+func CheckVersionContext(ctx context.Context, dm *dice.DiceManager) *dice.VersionInfo {
 	if runtime.GOOS == "android" {
 		return nil
 	}
 	// 逐个尝试所有后端地址
 	for _, i := range dice.BackendUrls {
-		ret := checkVersionBase(i, dm)
+		ret := checkVersionBase(ctx, i, dm)
 		if ret != nil {
 			return ret
 		}

--- a/update.go
+++ b/update.go
@@ -131,14 +131,20 @@ func doReboot(dm *dice.DiceManager) {
 		restartArgs = buildRestartArgs(os.Args[1:], "3")
 	}
 	if platform == "windows" {
-		cleanupCreate(dm)()
+		if cleanupErr := cleanupCreate(dm)(); cleanupErr != nil {
+			log.Errorf("清理失败，取消重启: %v", cleanupErr)
+			return
+		}
 		cmd := executeWin(binary, restartArgs...)
 		err := cmd.Start()
 		if err != nil {
 			log.Errorf("Restart error: %s %v", binary, err)
 		}
 	} else {
-		cleanupCreate(dm)()
+		if cleanupErr := cleanupCreate(dm)(); cleanupErr != nil {
+			log.Errorf("清理失败，取消重启: %v", cleanupErr)
+			return
+		}
 		execArgs := append([]string{os.Args[0]}, restartArgs...)
 		execErr := syscall.Exec(binary, execArgs, os.Environ()) //nolint:gosec
 		if execErr != nil {

--- a/update_test.go
+++ b/update_test.go
@@ -14,8 +14,8 @@ func TestBuildRestartArgsPreservesDeploymentOptions(t *testing.T) {
 }
 
 func TestBuildRestartArgsRemovesSplitDelay(t *testing.T) {
-	input := []string{"--delay", "15", "--hide-ui-when-boot"}
-	want := []string{"--hide-ui-when-boot", "--delay=3"}
+	input := []string{"--delay", "15", "--hide-ui"}
+	want := []string{"--hide-ui", "--delay=3"}
 	if got := buildRestartArgs(input, "3"); !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildRestartArgs() = %#v, want %#v", got, want)
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildRestartArgsPreservesDeploymentOptions(t *testing.T) {
+	input := []string{"--container-mode", "--address", "127.0.0.1:3211", "--delay=25", "--log-level", "2"}
+	want := []string{"--container-mode", "--address", "127.0.0.1:3211", "--log-level", "2", "--delay=1"}
+	if got := buildRestartArgs(input, "1"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildRestartArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildRestartArgsRemovesSplitDelay(t *testing.T) {
+	input := []string{"--delay", "15", "--hide-ui-when-boot"}
+	want := []string{"--hide-ui-when-boot", "--delay=3"}
+	if got := buildRestartArgs(input, "3"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildRestartArgs() = %#v, want %#v", got, want)
+	}
+}

--- a/update_updater.go
+++ b/update_updater.go
@@ -187,7 +187,7 @@ func UpdateByFile(dm *dice.DiceManager, packName string, syncMode bool) bool {
 				}
 
 				time.Sleep(5 * time.Second)
-				cleanupCreate(dm)()
+				_ = cleanupCreate(dm)()
 				os.Exit(0)
 			}
 			if syncMode {

--- a/utils/dboperator/db.go
+++ b/utils/dboperator/db.go
@@ -2,6 +2,7 @@ package dboperator
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sync"
 
@@ -22,28 +23,44 @@ var (
 )
 
 // initEngine 初始化数据库引擎，仅执行一次
-func initEngine() {
+func newEngine() operator.DatabaseOperator {
 	log := zap.S().Named(logger.LogKeyDatabase)
 
 	dbType := os.Getenv("DB_TYPE")
 	switch dbType {
 	case constant.SQLITE:
 		log.Info("当前选择使用: SQLITE数据库")
-		engine = &sqlite.SQLiteEngine{}
+		return &sqlite.SQLiteEngine{}
 	case constant.MYSQL:
 		log.Info("当前选择使用: MYSQL数据库")
-		engine = &mysql.MYSQLEngine{}
+		return &mysql.MYSQLEngine{}
 	case constant.POSTGRESQL:
 		log.Info("当前选择使用: POSTGRESQL数据库")
-		engine = &pgsql.PGSQLEngine{}
+		return &pgsql.PGSQLEngine{}
 	default:
 		log.Warn("未配置数据库类型，默认使用: SQLITE数据库")
-		engine = &sqlite.SQLiteEngine{}
+		return &sqlite.SQLiteEngine{}
 	}
-	// TODO: 使用统一管理的context，以确保在程序关闭时，可以正确销毁数据库的context从而优雅退出
-	errEngineInstance = engine.Init(context.Background())
+}
+
+// NewDatabaseOperator 创建一个独立的数据库引擎实例。
+// Runtime 重建必须使用新实例，不能复用已关闭的包级单例。
+func NewDatabaseOperator(ctx context.Context) (operator.DatabaseOperator, error) {
+	engineInstance := newEngine()
+	if engineInstance == nil {
+		return nil, errors.New("database engine factory returned nil")
+	}
+	if err := engineInstance.Init(ctx); err != nil {
+		engineInstance.Close()
+		return nil, err
+	}
+	return engineInstance, nil
+}
+
+func initEngine() {
+	engine, errEngineInstance = NewDatabaseOperator(context.Background())
 	if errEngineInstance != nil {
-		log.Error("数据库引擎初始化失败:", errEngineInstance)
+		zap.S().Named(logger.LogKeyDatabase).Error("数据库引擎初始化失败:", errEngineInstance)
 	}
 }
 

--- a/utils/dboperator/db.go
+++ b/utils/dboperator/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"os"
-	"sync"
 
 	"go.uber.org/zap"
 
@@ -16,13 +15,6 @@ import (
 	"sealdice-core/utils/dboperator/engine/sqlite"
 )
 
-var (
-	engine            operator.DatabaseOperator
-	once              sync.Once
-	errEngineInstance error
-)
-
-// initEngine 初始化数据库引擎，仅执行一次
 func newEngine() operator.DatabaseOperator {
 	log := zap.S().Named(logger.LogKeyDatabase)
 
@@ -57,31 +49,14 @@ func NewDatabaseOperator(ctx context.Context) (operator.DatabaseOperator, error)
 	return engineInstance, nil
 }
 
-func initEngine() {
-	engine, errEngineInstance = NewDatabaseOperator(context.Background())
-	if errEngineInstance != nil {
-		zap.S().Named(logger.LogKeyDatabase).Error("数据库引擎初始化失败:", errEngineInstance)
-	}
-}
-
-// getEngine 获取数据库引擎，确保只初始化一次
-func getEngine() (operator.DatabaseOperator, error) {
-	once.Do(initEngine)
-	return engine, errEngineInstance
-}
-
-// GetDatabaseOperator 初始化数据和日志数据库
-func GetDatabaseOperator() (operator.DatabaseOperator, error) {
-	return getEngine()
-}
-
 // DBCheck 检查数据库状态
 func DBCheck() {
 	log := zap.S().Named(logger.LogKeyDatabase)
-	dbEngine, err := getEngine()
+	dbEngine, err := NewDatabaseOperator(context.Background())
 	if err != nil {
-		log.Error("数据库引擎获取失败:", err)
+		log.Error("数据库引擎初始化失败:", err)
 		return
 	}
+	defer dbEngine.Close()
 	dbEngine.DBCheck()
 }

--- a/utils/dboperator/db_test.go
+++ b/utils/dboperator/db_test.go
@@ -1,0 +1,21 @@
+package dboperator_test
+
+import (
+	"context"
+	"testing"
+
+	"sealdice-core/utils/constant"
+	"sealdice-core/utils/dboperator"
+)
+
+func TestNewDatabaseOperatorMissingExternalDSNDoesNotPanic(t *testing.T) {
+	for _, databaseType := range []string{constant.MYSQL, constant.POSTGRESQL} {
+		t.Run(databaseType, func(t *testing.T) {
+			t.Setenv("DB_TYPE", databaseType)
+			t.Setenv("DB_DSN", "")
+			if _, err := dboperator.NewDatabaseOperator(context.Background()); err == nil {
+				t.Fatal("NewDatabaseOperator() unexpectedly succeeded")
+			}
+		})
+	}
+}

--- a/utils/dboperator/engine/mysql/engine_mysql.go
+++ b/utils/dboperator/engine/mysql/engine_mysql.go
@@ -26,10 +26,20 @@ type MYSQLEngine struct {
 
 func (s *MYSQLEngine) Close() {
 	log := zap.S().Named(logger.LogKeyDatabase)
+	if s == nil || s.DB == nil {
+		return
+	}
 
 	db, err := s.DB.DB()
 	if err != nil {
 		log.Errorf("failed to close db: %v", err)
+		return
+	}
+	s.DB = nil
+	s.dataDB = nil
+	s.logsDB = nil
+	s.censorDB = nil
+	if db == nil {
 		return
 	}
 	err = db.Close()

--- a/utils/dboperator/engine/pgsql/engine_pgsql.go
+++ b/utils/dboperator/engine/pgsql/engine_pgsql.go
@@ -26,9 +26,19 @@ type PGSQLEngine struct {
 
 func (s *PGSQLEngine) Close() {
 	log := zap.S().Named(logger.LogKeyDatabase)
+	if s == nil || s.DB == nil {
+		return
+	}
 	db, err := s.DB.DB()
 	if err != nil {
 		log.Errorf("failed to close db: %v", err)
+		return
+	}
+	s.DB = nil
+	s.dataDB = nil
+	s.logsDB = nil
+	s.censorDB = nil
+	if db == nil {
 		return
 	}
 	err = db.Close()

--- a/utils/dboperator/engine/sqlite/engine_sqlite.go
+++ b/utils/dboperator/engine/sqlite/engine_sqlite.go
@@ -39,6 +39,9 @@ const (
 )
 
 func (s *SQLiteEngine) Close() {
+	if s == nil {
+		return
+	}
 	log := zap.S().Named(logger.LogKeyDatabase)
 
 	s.mu.Lock()
@@ -46,6 +49,9 @@ func (s *SQLiteEngine) Close() {
 
 	// 关闭 readList 中的连接
 	for name, db := range s.readList {
+		if db == nil {
+			continue
+		}
 		sqlDB, err := db.DB()
 		if err != nil {
 			log.Errorf("failed to get sql.DB for %s: %v", name, err)
@@ -58,6 +64,9 @@ func (s *SQLiteEngine) Close() {
 
 	// 关闭 writeList 中的连接
 	for name, db := range s.writeList {
+		if db == nil {
+			continue
+		}
 		sqlDB, err := db.DB()
 		if err != nil {
 			log.Errorf("failed to get sql.DB for %s: %v", name, err)
@@ -67,6 +76,8 @@ func (s *SQLiteEngine) Close() {
 			log.Errorf("failed to close db %s: %v", name, err)
 		}
 	}
+	s.readList = nil
+	s.writeList = nil
 }
 
 func (s *SQLiteEngine) getDBByModeAndKey(mode constant.DBMode, key dbName) *gorm.DB {


### PR DESCRIPTION
## Summary by Sourcery

引入一个对进程安全的、具备事务性的运行时备份与恢复生命周期机制，包含运行时监管、v2 备份清单，以及用于进程内恢复的健壮安全检查。

New Features:
- 添加运行时监管器和生命周期 API，用于在不重启主进程的情况下重建并热切换 Dice 运行时。
- 引入进程内备份上传、恢复以及状态查询的 HTTP API，支持幂等的请求 ID 和安全的状态令牌。
- 将备份归档升级为 v2 清单格式，包含按文件的 SHA-256、大小元数据，以及严格的 ZIP 路径校验。
- 实现按运行时的任务管理及适配器关闭语义，以安全地使运行时静默、完成并停止。

Bug Fixes:
- 防止删除当前被恢复事务使用的备份，并确保在崩溃后恢复状态能够被安全地重建。
- 收紧 SQLite WAL 检查点处理逻辑，对不完整的检查点直接失败，而不是静默继续。

Enhancements:
- 重构备份创建流程，使其在磁盘上严格串行、内容可验证且具备原子性，并采用安全文件模式和目录同步。
- 让适配器进程和 WebSocket 客户端具备运行时感知能力，以便在关闭时干净退出，不在不同代之间泄露资源。
- 确保托盘提示和账号菜单从当前已发布的运行时读取数据，而不是使用过期的进程内状态。
- 改进版本检查与重启逻辑，复用现有标志位，同时在各平台之间统一延迟处理方式。

Tests:
- 增加针对备份归档检查、v2 清单验证、恢复日志记录、回滚语义以及运行时监管器行为的大量测试。
- 增加平台特定测试，用于原子文件替换、重启参数重建以及数据库操作器初始化错误处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a process-safe, transactional runtime backup and restore lifecycle with runtime supervision, v2 backup manifests, and robust safety checks for in-process recovery.

New Features:
- Add a runtime supervisor and lifecycle APIs to rebuild and hot-swap Dice runtimes without restarting the main process.
- Introduce in-process backup upload, restore, and status query HTTP APIs with idempotent request IDs and secure status tokens.
- Upgrade backup archives to a v2 manifest format with per-file SHA-256, size metadata, and strict ZIP path validation.
- Implement per-runtime task management and adapter shutdown semantics to quiesce, finalize, and stop runtimes safely.

Bug Fixes:
- Prevent deletion of backups currently used by restore transactions and ensure restore state is recovered safely after crashes.
- Tighten SQLite WAL checkpoint handling to fail on incomplete checkpoints instead of silently continuing.

Enhancements:
- Refactor backup creation to be strictly serialized, content-verified, and atomic on disk with secure file modes and directory syncs.
- Make adapter processes and WebSocket clients runtime-aware so they stop cleanly on shutdown and do not leak resources across generations.
- Ensure tray tooltips and account menus read from the currently published runtime instead of stale in-process state.
- Improve version check and reboot logic to reuse existing flags while normalizing delay handling across platforms.

Tests:
- Add extensive tests for backup archive inspection, v2 manifest validation, restore journaling, rollback semantics, and runtime supervisor behavior.
- Add platform-specific tests for atomic file replacement, restart argument reconstruction, and database operator initialization error handling.

</details>