### PR TITLE
feat(adapter): CQ码解析统一处理 + 修正 sealpack 包内资源路径解析

### DIFF
--- a/dice/dice_help.go
+++ b/dice/dice_help.go
@@ -800,7 +800,8 @@ func (m *HelpManager) GetContent(item *docengine.HelpTextItem, depth int) string
 	if depth > 7 {
 		return "{递归层数过多，不予显示}"
 	}
-	txt := item.Content
+	// 帮助文档中的 ./ 资源路径始终相对于该条目的来源文件。
+	txt := rewriteRelativeResourcePaths(item.From, item.Content)
 	re := regexp.MustCompile(`\{[^}\n]+\}`)
 	matched := re.FindAllStringSubmatchIndex(txt, -1)
 	if len(matched) == 0 {

--- a/dice/dice_help_internal_test.go
+++ b/dice/dice_help_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"sealdice-core/dice/docengine"
@@ -187,6 +188,32 @@ func TestHelpManagerLoadHelpDocUnescapesXlsxContent(t *testing.T) {
 	}
 	if got, want := searchEngine.added[0].Content, "first\nsecond"; got != want {
 		t.Fatalf("loaded XLSX content = %q, want %q", got, want)
+	}
+}
+
+func TestHelpManagerGetContentResolvesResourcesRelativeToSource(t *testing.T) {
+	packageRoot := filepath.Join(t.TempDir(), "cache", "packages", "author", "help-package")
+	source := filepath.Join(packageRoot, "helpdoc", "rules.xlsx")
+	item := &docengine.HelpTextItem{
+		From: source,
+		Content: "entry [图:./../assets/card.png] " +
+			"[CQ:video,file=./../assets/video.mp4,cache=0]",
+	}
+
+	got := (&HelpManager{}).GetContent(item, 0)
+	wantImage, err := filepath.Abs(filepath.Join(packageRoot, "assets", "card.png"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantVideo, err := filepath.Abs(filepath.Join(packageRoot, "assets", "video.mp4"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "[图:"+filepath.ToSlash(wantImage)+"]") {
+		t.Fatalf("help content image path was not resolved: %q", got)
+	}
+	if !strings.Contains(got, "file="+filepath.ToSlash(wantVideo)) || !strings.Contains(got, "cache=0") {
+		t.Fatalf("help content CQ video path or parameters were not preserved: %q", got)
 	}
 }
 

--- a/dice/ext_deck.go
+++ b/dice/ext_deck.go
@@ -950,37 +950,6 @@ func deckStringFormat(ctx *MsgContext, deckInfo *DeckInfo, s string) (string, er
 	re = regexp.MustCompile(`\[.+?]`)
 	m = re.FindAllStringIndex(s, -1)
 
-	cqSolve := func(cq *CQCommand) {
-		fn, exists := cq.Args["file"]
-		if exists {
-			if strings.HasPrefix(fn, "./") {
-				pathPrefix, err := filepath.Rel(".", filepath.Dir(deckInfo.Filename))
-				if err == nil {
-					fn = filepath.Join(pathPrefix, fn[2:])
-					fn = strings.ReplaceAll(fn, `\`, "/")
-					cq.Args["file"] = fn
-				}
-			}
-		}
-	}
-
-	imgSolve := func(text string) string {
-		reImg := regexp.MustCompile(`\[(img|图|文本|text|语音|voice|视频|video):(.+?)]`) // [img:] 或 [图:]
-		m := reImg.FindStringSubmatch(text)
-		if m != nil {
-			fn := m[2]
-			if strings.HasPrefix(fn, "./") {
-				pathPrefix, err := filepath.Rel(".", filepath.Dir(deckInfo.Filename))
-				if err == nil {
-					fn = filepath.Join(pathPrefix, fn[2:])
-					fn = strings.ReplaceAll(fn, `\`, "/")
-					return "[" + m[1] + ":" + fn + "]"
-				}
-			}
-		}
-		return text
-	}
-
 	for _i := len(m) - 1; _i >= 0; _i-- {
 		i := m[_i]
 
@@ -989,10 +958,7 @@ func deckStringFormat(ctx *MsgContext, deckInfo *DeckInfo, s string) (string, er
 			continue
 		}
 
-		if strings.HasPrefix(text, "[图:") ||
-			strings.HasPrefix(text, "[img:") ||
-			strings.HasPrefix(text, "[文本:") ||
-			strings.HasPrefix(text, "[语音:") {
+		if isResourceCode(text) {
 			continue
 		}
 
@@ -1007,8 +973,8 @@ func deckStringFormat(ctx *MsgContext, deckInfo *DeckInfo, s string) (string, er
 		// s = s[:i[0]] + text + s[i[1]:]
 	}
 
-	s = CQRewrite(s, cqSolve)
-	s = ImageRewrite(s, imgSolve)
+	// 在进入消息解析前，按牌堆文件位置固定 ./ 资源路径。
+	s = rewriteRelativeResourcePaths(deckInfo.Filename, s)
 
 	s = strings.ReplaceAll(s, "\n", `\n`)
 	if ctx.Dice.getTargetVmEngineVersion(VMVersionDeck) == "v1" {

--- a/dice/ext_deck_resource_test.go
+++ b/dice/ext_deck_resource_test.go
@@ -1,0 +1,91 @@
+//nolint:testpackage
+package dice
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestIsResourceCodeRecognizesAllAliases(t *testing.T) {
+	resourceCodes := []string{
+		"[图:./card.png]",
+		"[img:./card.png]",
+		"[文本:./card.txt]",
+		"[text:./card.txt]",
+		"[语音:./voice.wav]",
+		"[voice:./voice.wav]",
+		"[视频:./video.mp4]",
+		"[video:./video.mp4]",
+	}
+	for _, code := range resourceCodes {
+		if !isResourceCode(code) {
+			t.Fatalf("resource code %q was treated as a deck expression", code)
+		}
+	}
+	if isResourceCode("[1d20]") {
+		t.Fatal("dice expression was treated as a resource code")
+	}
+}
+
+func TestRewriteRelativeResourcePathsUsesDeckSourceDirectory(t *testing.T) {
+	packageRoot := filepath.Join(t.TempDir(), "cache", "packages", "author", "package")
+	deckFilename := filepath.Join(packageRoot, "decks", "main.json")
+	tests := []struct {
+		name     string
+		alias    string
+		resource string
+		want     string
+	}{
+		{name: "image", alias: "图", resource: "./../assets/card.png", want: filepath.Join(packageRoot, "assets", "card.png")},
+		{name: "text", alias: "text", resource: "./../assets/card.txt", want: filepath.Join(packageRoot, "assets", "card.txt")},
+		{name: "voice", alias: "语音", resource: `.\..\assets\voice.wav`, want: filepath.Join(packageRoot, "assets", "voice.wav")},
+		{name: "video", alias: "video", resource: "./../assets/video.mp4", want: filepath.Join(packageRoot, "assets", "video.mp4")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := rewriteRelativeResourcePaths(deckFilename, "["+test.alias+":"+test.resource+"]")
+			wantPath, err := filepath.Abs(test.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := "[" + test.alias + ":" + filepath.ToSlash(wantPath) + "]"
+			if got != want {
+				t.Fatalf("rewriteRelativeResourcePaths() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRewriteRelativeResourcePathsHandlesCQAndCrossPackageReferences(t *testing.T) {
+	packagesRoot := filepath.Join(t.TempDir(), "cache", "packages")
+	deckFilename := filepath.Join(packagesRoot, "author", "source", "decks", "main.json")
+	rewritten := rewriteRelativeResourcePaths(
+		deckFilename,
+		"[CQ:video,file=./../../../other/target/assets/video.mp4,cache=0]",
+	)
+	cq := CQParse(rewritten)
+	if cq.Type != "video" || cq.Args["cache"] != "0" {
+		t.Fatalf("CQ parameters were not preserved: %#v", cq)
+	}
+	want, err := filepath.Abs(filepath.Join(packagesRoot, "other", "target", "assets", "video.mp4"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cq.Args["file"] != filepath.ToSlash(want) {
+		t.Fatalf("CQ file path = %q, want %q", cq.Args["file"], filepath.ToSlash(want))
+	}
+}
+
+func TestResolveRelativeResourcePathLeavesNonRelativeReferencesUnchanged(t *testing.T) {
+	deckFilename := filepath.Join(t.TempDir(), "decks", "main.json")
+	for _, resource := range []string{
+		"assets/card.png",
+		"https://example.com/card.png",
+		"base64://Y2FyZA==",
+		"opaque-resource-id",
+	} {
+		if got := resolveRelativeResourcePath(deckFilename, resource); got != resource {
+			t.Fatalf("resolveRelativeResourcePath(%q) = %q, want unchanged", resource, got)
+		}
+	}
+}

--- a/dice/platform_adapter_onebot_message_test.go
+++ b/dice/platform_adapter_onebot_message_test.go
@@ -1,0 +1,46 @@
+//nolint:testpackage
+package dice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	"sealdice-core/message"
+)
+
+func TestConvertSealMsgToMessageChainUsesFileElementURL(t *testing.T) {
+	fileURL := "file:///absolute/path/document.txt"
+	chain, cqMessage := convertSealMsgToMessageChain([]message.IMessageElement{
+		&message.FileElement{File: "document.txt", URL: fileURL},
+	})
+
+	if len(chain) != 1 {
+		t.Fatalf("message chain length = %d, want 1", len(chain))
+	}
+	if got := gjson.GetBytes(chain[0].Data, "file").String(); got != fileURL {
+		t.Fatalf("OneBot file value = %q, want %q", got, fileURL)
+	}
+	if !strings.Contains(cqMessage, "file="+fileURL) {
+		t.Fatalf("CQ message = %q, want absolute file URL", cqMessage)
+	}
+}
+
+func TestConvertSealMsgToMessageChainPreservesDefaultResourceParameters(t *testing.T) {
+	elements := message.ConvertStringMessage("[CQ:video,file=opaque-video-id,cache=0,timeout=30]")
+	if len(elements) != 1 {
+		t.Fatalf("element count = %d, want 1", len(elements))
+	}
+
+	chain, _ := convertSealMsgToMessageChain(elements)
+	if len(chain) != 1 || chain[0].Type != "video" {
+		t.Fatalf("message chain = %#v, want one video segment", chain)
+	}
+	data := gjson.ParseBytes(chain[0].Data)
+	if data.Get("file").String() != "opaque-video-id" ||
+		data.Get("cache").String() != "0" ||
+		data.Get("timeout").String() != "30" {
+		t.Fatalf("video data was changed: %s", chain[0].Data)
+	}
+}

--- a/dice/platform_adapter_onebot_util.go
+++ b/dice/platform_adapter_onebot_util.go
@@ -923,9 +923,10 @@ func convertSealMsgToMessageChain(msg []message.IMessageElement) (schema.Message
 			if !ok {
 				continue
 			}
-			fileVal := res.File
+			// URL 保存可直接发送的完整资源引用；File 对本地文件通常只有文件名。
+			fileVal := res.URL
 			if fileVal == "" {
-				fileVal = res.URL
+				fileVal = res.File
 			}
 			if fileVal == "" {
 				continue

--- a/dice/resource_path.go
+++ b/dice/resource_path.go
@@ -1,0 +1,61 @@
+package dice
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var resourceCodePrefixes = []string{
+	"[图:", "[img:",
+	"[文本:", "[text:",
+	"[语音:", "[voice:",
+	"[视频:", "[video:",
+}
+
+var resourceCodePattern = regexp.MustCompile(`\[(img|图|文本|text|语音|voice|视频|video):(.+?)]`)
+
+func isResourceCode(text string) bool {
+	for _, prefix := range resourceCodePrefixes {
+		if strings.HasPrefix(text, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveRelativeResourcePath(sourceFilename, resourcePath string) string {
+	trimmed := strings.TrimSpace(resourcePath)
+	normalized := strings.ReplaceAll(trimmed, `\`, "/")
+	if sourceFilename == "" || !strings.HasPrefix(normalized, "./") {
+		return resourcePath
+	}
+
+	// 相对资源路径以内容来源文件为基准。这里先转成绝对路径，避免包被放入
+	// cache/packages 后，后续消息解析又按进程工作目录解释路径。
+	resolved, err := filepath.Abs(filepath.Join(filepath.Dir(sourceFilename), filepath.FromSlash(normalized)))
+	if err != nil {
+		return resourcePath
+	}
+	return filepath.ToSlash(resolved)
+}
+
+func rewriteRelativeResourcePaths(sourceFilename, text string) string {
+	// CQ 码可能包含额外参数，使用 CQRewrite 只改写 file 字段并保留其余参数。
+	cqSolve := func(cq *CQCommand) {
+		if filename, exists := cq.Args["file"]; exists {
+			cq.Args["file"] = resolveRelativeResourcePath(sourceFilename, filename)
+		}
+	}
+
+	sealCodeSolve := func(code string) string {
+		match := resourceCodePattern.FindStringSubmatch(code)
+		if match == nil {
+			return code
+		}
+		return "[" + match[1] + ":" + resolveRelativeResourcePath(sourceFilename, match[2]) + "]"
+	}
+
+	text = CQRewrite(text, cqSolve)
+	return ImageRewrite(text, sealCodeSolve)
+}

--- a/message/message.go
+++ b/message/message.go
@@ -158,6 +158,22 @@ func (t *DefaultElement) Type() ElementType {
 }
 
 func (t *DefaultElement) FromCQData(dMap map[string]string) error {
+	// 未注册的 CQ 资源类型也可能携带本地文件，发送前统一规范化其路径。
+	if rawFile, exists := dMap["file"]; exists && strings.TrimSpace(dMap["url"]) == "" {
+		normalized, err := NormalizeLocalResourcePath(rawFile)
+		if err != nil {
+			return err
+		}
+		if normalized != rawFile {
+			cloned := make(map[string]string, len(dMap))
+			for key, value := range dMap {
+				cloned[key] = value
+			}
+			cloned["file"] = normalized
+			dMap = cloned
+		}
+	}
+
 	marshal, err := sonic.Marshal(dMap)
 	if err != nil {
 		return err
@@ -386,6 +402,108 @@ func normalizeRemoteURL(raw string) (string, error) {
 	return parsed.String(), nil
 }
 
+func isPassthroughResourceReference(raw string) bool {
+	lower := strings.ToLower(raw)
+	return strings.HasPrefix(lower, "http://") ||
+		strings.HasPrefix(lower, "https://") ||
+		strings.HasPrefix(lower, "base64://")
+}
+
+func localPathFromResourceReference(raw string) (string, error) {
+	if !strings.HasPrefix(strings.ToLower(raw), "file://") {
+		return raw, nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil || !strings.EqualFold(parsed.Scheme, "file") {
+		return "", &CQFileError{Kind: CQFileErrInvalidURL, Raw: raw, Cause: err}
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", &CQFileError{Kind: CQFileErrInvalidURL, Raw: raw, Cause: errors.New("file URL cannot contain query or fragment")}
+	}
+
+	localPath := parsed.Path
+	if parsed.Host != "" && !strings.EqualFold(parsed.Host, "localhost") {
+		localPath = "//" + parsed.Host + parsed.Path
+	}
+	// net/url 已完成路径解码；Windows 盘符还需要去掉 URL 路径的前导斜杠。
+	if runtime.GOOS == "windows" && len(localPath) >= 3 && localPath[0] == '/' && localPath[2] == ':' {
+		localPath = localPath[1:]
+	}
+	return filepath.FromSlash(localPath), nil
+}
+
+func pathWithinRoot(candidate, root string) bool {
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func localPathToFileURL(absolutePath string) string {
+	fileURLPath := filepath.ToSlash(absolutePath)
+	// Windows 盘符必须写成 /C:/...，url.URL 才会生成标准的 file:///C:/...。
+	if runtime.GOOS == "windows" && !strings.HasPrefix(fileURLPath, "/") {
+		fileURLPath = "/" + fileURLPath
+	}
+	return (&url.URL{Scheme: "file", Path: fileURLPath}).String()
+}
+
+func normalizeLocalFileReference(raw string) (string, string, os.FileInfo, error) {
+	localPath, err := localPathFromResourceReference(raw)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	absolutePath, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", "", nil, &CQFileError{Kind: CQFileErrInvalidURL, Raw: raw, Normalized: localPath, Cause: err}
+	}
+	absolutePath = filepath.Clean(absolutePath)
+
+	// 本地资源仍只允许来自程序目录或系统临时目录。filepath.Rel 能正确区分
+	// 同名前缀的相邻目录，避免简单字符串前缀判断造成越界。
+	cwd, cwdErr := os.Getwd()
+	tempDir, tempErr := filepath.Abs(os.TempDir())
+	allowed := cwdErr == nil && pathWithinRoot(absolutePath, filepath.Clean(cwd))
+	allowed = allowed || tempErr == nil && pathWithinRoot(absolutePath, filepath.Clean(tempDir))
+	if !allowed {
+		return "", "", nil, &CQFileError{Kind: CQFileErrRestricted, Raw: raw, Normalized: absolutePath}
+	}
+
+	info, err := os.Stat(absolutePath) //nolint:gosec
+	if err != nil {
+		return "", "", nil, &CQFileError{Kind: CQFileErrUnavailable, Raw: raw, Normalized: absolutePath, Cause: err}
+	}
+	return localPathToFileURL(absolutePath), absolutePath, info, nil
+}
+
+// NormalizeLocalResourcePath 将本地资源引用规范化为绝对 file URL。
+// 此过程只检查路径和文件状态，不读取文件内容，也不会转换为 Base64；远程 URL、
+// Base64 数据及适配器使用的不透明资源 ID 均保持原样。
+func NormalizeLocalResourcePath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || isPassthroughResourceReference(raw) {
+		return raw, nil
+	}
+	if strings.Contains(raw, "://") && !strings.HasPrefix(strings.ToLower(raw), "file://") {
+		return raw, nil
+	}
+
+	isLocal := strings.HasPrefix(strings.ToLower(raw), "file://")
+	if !isLocal {
+		_, err := os.Stat(raw)
+		isLocal = err == nil
+	}
+	if !isLocal {
+		return raw, nil
+	}
+
+	normalized, _, _, err := normalizeLocalFileReference(raw)
+	return normalized, err
+}
+
 func FilepathToFileElement(fp string) (*FileElement, error) {
 	fp = strings.TrimSpace(fp)
 
@@ -451,60 +569,28 @@ func FilepathToFileElement(fp string) (*FileElement, error) {
 		}
 		return r, nil
 	} else {
-		// 本地文件路径处理
-		localPath := fp
-
-		// 处理 file:// URL
-		if strings.HasPrefix(fp, "file://") {
-			fu, err := url.Parse(fp)
-			if err != nil {
-				return nil, &CQFileError{Kind: CQFileErrInvalidURL, Raw: fp, Cause: err}
-			}
-			// 对路径进行URL解码，处理%20等编码的中文/空格
-			localPath, _ = url.PathUnescape(fu.Path)
-			if runtime.GOOS == `windows` && strings.HasPrefix(localPath, "/") {
-				localPath = localPath[1:]
-			}
-			localPath = filepath.FromSlash(localPath)
-		}
-
-		info, err := os.Stat(localPath) //nolint:gosec
+		// 本地文件路径处理。路径解析和访问范围校验与其他本地资源保持一致。
+		fileURL, absolutePath, info, err := normalizeLocalFileReference(fp)
 		if err != nil {
-			return nil, &CQFileError{Kind: CQFileErrUnavailable, Raw: fp, Normalized: localPath, Cause: err}
+			return nil, err
 		}
 		if info.Size() == 0 || info.Size() >= maxFileSize {
-			return nil, &CQFileError{Kind: CQFileErrInvalidSize, Raw: fp, Normalized: localPath}
+			return nil, &CQFileError{Kind: CQFileErrInvalidSize, Raw: fp, Normalized: absolutePath}
 		}
-		afn, err := filepath.Abs(localPath)
+		filesuffix := path.Ext(absolutePath)
+		content, err := os.ReadFile(absolutePath) //nolint:gosec
 		if err != nil {
-			return nil, &CQFileError{Kind: CQFileErrInvalidURL, Raw: fp, Normalized: localPath, Cause: err}
-		}
-		cwd, _ := os.Getwd()
-		if !strings.HasPrefix(afn, cwd) && !strings.HasPrefix(afn, os.TempDir()) {
-			return nil, &CQFileError{Kind: CQFileErrRestricted, Raw: fp, Normalized: afn}
-		}
-		filesuffix := path.Ext(localPath)
-		content, err := os.ReadFile(localPath) //nolint:gosec
-		if err != nil {
-			return nil, &CQFileError{Kind: CQFileErrUnavailable, Raw: fp, Normalized: localPath, Cause: err}
+			return nil, &CQFileError{Kind: CQFileErrUnavailable, Raw: fp, Normalized: absolutePath, Cause: err}
 		}
 		contenttype := mime.TypeByExtension(filesuffix)
 		if len(contenttype) == 0 {
 			contenttype = "application/octet-stream"
 		}
-		fileURLPath := filepath.ToSlash(afn)
-		if runtime.GOOS == `windows` && !strings.HasPrefix(fileURLPath, "/") {
-			fileURLPath = "/" + fileURLPath
-		}
-		fileURL := url.URL{
-			Scheme: "file",
-			Path:   fileURLPath,
-		}
 		r := &FileElement{
 			Stream:      bytes.NewReader(content),
 			ContentType: contenttype,
 			File:        info.Name(),
-			URL:         fileURL.String(),
+			URL:         fileURL,
 		}
 		return r, nil
 	}
@@ -555,7 +641,7 @@ func SealCodeToCqCode(text string) string {
 
 	fn = strings.TrimSpace(fn)
 
-	if strings.HasPrefix(fn, "file://") || strings.HasPrefix(fn, "http://") || strings.HasPrefix(fn, "https://") {
+	if isPassthroughResourceReference(fn) {
 		u, err := url.Parse(fn)
 		if err != nil {
 			return text
@@ -567,30 +653,24 @@ func SealCodeToCqCode(text string) string {
 		return cq.Compile()
 	}
 
-	afn, err := filepath.Abs(fn)
+	normalized, _, _, err := normalizeLocalFileReference(fn)
 	if err != nil {
-		return text // 不是文件路径，不管
+		var fileErr *CQFileError
+		if errors.As(err, &fileErr) {
+			if fileErr.Kind == CQFileErrUnavailable && errors.Is(fileErr.Cause, os.ErrNotExist) {
+				return "[找不到图片/文件]"
+			}
+			if fileErr.Kind == CQFileErrRestricted {
+				return "[图片/文件指向非当前程序目录，已禁止]"
+			}
+		}
+		return text
 	}
-	cwd, _ := os.Getwd()
-	if strings.HasPrefix(afn, cwd) {
-		if _, err := os.Stat(afn); errors.Is(err, os.ErrNotExist) {
-			return "[找不到图片/文件]"
-		}
-		// 这里使用绝对路径，windows上gocqhttp会裁掉一个斜杠，所以我这里加一个
-		if runtime.GOOS == `windows` {
-			afn = "/" + afn
-		}
-		u := url.URL{
-			Scheme: "file",
-			Path:   filepath.ToSlash(afn),
-		}
-		cq := CQCommand{
-			Type: cqType,
-			Args: map[string]string{"file": u.String()},
-		}
-		return cq.Compile()
+	cq := CQCommand{
+		Type: cqType,
+		Args: map[string]string{"file": normalized},
 	}
-	return "[图片/文件指向非当前程序目录，已禁止]"
+	return cq.Compile()
 }
 
 // convertConfig ConvertStringMessage的配置

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -1,10 +1,15 @@
 package message_test
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -85,5 +90,234 @@ func TestConvertStringMessageCQParamUnescape(t *testing.T) {
 	}
 	if want := "a&b[x]"; tts.Content != want {
 		t.Fatalf("tts content = %q, want %q", tts.Content, want)
+	}
+}
+
+func localPathFromFileURL(t *testing.T, raw string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse file URL %q: %v", raw, err)
+	}
+	if parsed.Scheme != "file" {
+		t.Fatalf("resource URL scheme = %q, want file", parsed.Scheme)
+	}
+	localPath := filepath.FromSlash(parsed.Path)
+	if runtime.GOOS == "windows" && len(localPath) >= 3 && localPath[0] == filepath.Separator && localPath[2] == ':' {
+		localPath = localPath[1:]
+	}
+	return filepath.Clean(localPath)
+}
+
+func writeResourceFile(t *testing.T, name string) string {
+	t.Helper()
+
+	filename := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(filename, []byte("resource"), 0o600); err != nil {
+		t.Fatalf("write resource file: %v", err)
+	}
+	return filename
+}
+
+func defaultElementData(t *testing.T, element message.IMessageElement) map[string]string {
+	t.Helper()
+
+	defaultElement, ok := element.(*message.DefaultElement)
+	if !ok {
+		t.Fatalf("element type = %T, want *message.DefaultElement", element)
+	}
+	data := map[string]string{}
+	if err := json.Unmarshal(defaultElement.Data, &data); err != nil {
+		t.Fatalf("unmarshal default element data: %v", err)
+	}
+	return data
+}
+
+func TestNormalizeLocalResourcePath(t *testing.T) {
+	filename := writeResourceFile(t, "card with space.png")
+	wantPath, err := filepath.Abs(filename)
+	if err != nil {
+		t.Fatalf("resolve expected absolute path: %v", err)
+	}
+
+	normalized, err := message.NormalizeLocalResourcePath(filename)
+	if err != nil {
+		t.Fatalf("NormalizeLocalResourcePath() error = %v", err)
+	}
+	if got := localPathFromFileURL(t, normalized); got != filepath.Clean(wantPath) {
+		t.Fatalf("normalized local path = %q, want %q", got, filepath.Clean(wantPath))
+	}
+
+	normalizedAgain, err := message.NormalizeLocalResourcePath(normalized)
+	if err != nil {
+		t.Fatalf("normalize canonical file URL: %v", err)
+	}
+	if normalizedAgain != normalized {
+		t.Fatalf("canonical file URL changed: got %q, want %q", normalizedAgain, normalized)
+	}
+
+	passthrough := []string{
+		"https://example.com/card.png",
+		"base64://cmVzb3VyY2U=",
+		"opaque-onebot-resource-id",
+		"adapter/cache/resource-id",
+		"0123456789abcdef0123456789abcdef.image",
+		"mxc://server/resource",
+	}
+	for _, input := range passthrough {
+		got, normalizeErr := message.NormalizeLocalResourcePath(input)
+		if normalizeErr != nil {
+			t.Fatalf("NormalizeLocalResourcePath(%q) error = %v", input, normalizeErr)
+		}
+		if got != input {
+			t.Fatalf("NormalizeLocalResourcePath(%q) = %q, want unchanged", input, got)
+		}
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	outside := filepath.Dir(cwd)
+	_, err = message.NormalizeLocalResourcePath(outside)
+	var fileErr *message.CQFileError
+	if !errors.As(err, &fileErr) || fileErr.Kind != message.CQFileErrRestricted {
+		t.Fatalf("outside path error = %v, want CQFileErrRestricted", err)
+	}
+}
+
+func TestConvertStringMessageNormalizesAllLocalResourceKinds(t *testing.T) {
+	imagePath := writeResourceFile(t, "image.png")
+	recordPath := writeResourceFile(t, "record.wav")
+	videoPath := writeResourceFile(t, "video.mp4")
+	filePath := writeResourceFile(t, "document.txt")
+
+	expectedImage, err := message.NormalizeLocalResourcePath(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedRecord, err := message.NormalizeLocalResourcePath(recordPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedVideo, err := message.NormalizeLocalResourcePath(videoPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedFile, err := message.NormalizeLocalResourcePath(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, element message.IMessageElement)
+	}{
+		{
+			name:  "explicit CQ image",
+			input: "[CQ:image,file=" + message.EscapeCQParam(imagePath) + "]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				imageElement, ok := element.(*message.ImageElement)
+				if !ok || imageElement.URL != expectedImage {
+					t.Fatalf("image element = %#v, want URL %q", element, expectedImage)
+				}
+			},
+		},
+		{
+			name:  "explicit CQ record",
+			input: "[CQ:record,file=" + message.EscapeCQParam(recordPath) + "]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				recordElement, ok := element.(*message.RecordElement)
+				if !ok || recordElement.File == nil || recordElement.File.URL != expectedRecord {
+					t.Fatalf("record element = %#v, want URL %q", element, expectedRecord)
+				}
+			},
+		},
+		{
+			name:  "explicit CQ video",
+			input: "[CQ:video,file=" + message.EscapeCQParam(videoPath) + ",cache=0]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				data := defaultElementData(t, element)
+				if data["file"] != expectedVideo || data["cache"] != "0" {
+					t.Fatalf("video data = %#v, want file=%q and cache=0", data, expectedVideo)
+				}
+			},
+		},
+		{
+			name:  "explicit CQ file",
+			input: "[CQ:file,file=" + message.EscapeCQParam(filePath) + "]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				fileElement, ok := element.(*message.FileElement)
+				if !ok || fileElement.URL != expectedFile {
+					t.Fatalf("file element = %#v, want URL %q", element, expectedFile)
+				}
+			},
+		},
+		{
+			name:  "Seal image",
+			input: "[图:" + imagePath + "]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				imageElement, ok := element.(*message.ImageElement)
+				if !ok || imageElement.URL != expectedImage {
+					t.Fatalf("image element = %#v, want URL %q", element, expectedImage)
+				}
+			},
+		},
+		{
+			name:  "Seal voice",
+			input: "[voice:" + recordPath + "]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				recordElement, ok := element.(*message.RecordElement)
+				if !ok || recordElement.File == nil || recordElement.File.URL != expectedRecord {
+					t.Fatalf("record element = %#v, want URL %q", element, expectedRecord)
+				}
+			},
+		},
+		{
+			name:  "Seal video",
+			input: "[视频:" + videoPath + "]",
+			check: func(t *testing.T, element message.IMessageElement) {
+				data := defaultElementData(t, element)
+				if data["file"] != expectedVideo {
+					t.Fatalf("video data = %#v, want file=%q", data, expectedVideo)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			elements := message.ConvertStringMessage(test.input)
+			if len(elements) != 1 {
+				t.Fatalf("element count = %d, want 1 (%#v)", len(elements), elements)
+			}
+			test.check(t, elements[0])
+		})
+	}
+}
+
+func TestConvertStringMessageLeavesNonLocalVideoReferencesUnchanged(t *testing.T) {
+	tests := []string{
+		"https://example.com/video.mp4",
+		"base64://dmlkZW8=",
+		"opaque-onebot-video-id",
+	}
+	for _, resource := range tests {
+		elements := message.ConvertStringMessage("[CQ:video,file=" + message.EscapeCQParam(resource) + ",cache=0]")
+		if len(elements) != 1 {
+			t.Fatalf("resource %q produced %d elements, want 1", resource, len(elements))
+		}
+		data := defaultElementData(t, elements[0])
+		if data["file"] != resource || data["cache"] != "0" {
+			t.Fatalf("resource %q converted to %#v", resource, data)
+		}
+	}
+
+	elements := message.ConvertStringMessage("[CQ:video,file=adapter-cache-id,url=https://example.com/video.mp4]")
+	data := defaultElementData(t, elements[0])
+	if data["file"] != "adapter-cache-id" || data["url"] != "https://example.com/video.mp4" {
+		t.Fatalf("video with URL converted to %#v", data)
 	}
 }


### PR DESCRIPTION
## 变更内容

- 将牌堆和帮助文档里的 `./`、`.\` 资源引用按来源文件解析为绝对 `file://` URL，使普通包移动到 SealPack 缓存目录后无需人工改写路径
- 统一处理 Seal 码和 CQ 码中的图片、语音、视频、文件路径，并保留 CQ 额外参数、远程 URL、Base64 和适配器资源 ID
- 允许现有许可根目录内的跨包引用，同时使用 `filepath.Rel` 严格判断本地路径边界
- OneBot 文件消息优先使用完整 URL，避免只发送文件名

## 安全与兼容性

- 路径规范化只执行路径解析与 `os.Stat`，不会读取内容或转成 Base64
- 本地资源仍只允许程序目录和系统临时目录
- Windows 输出标准 `file:///C:/...` 格式

## 验证

- `go test ./message`
- `go test ./dice -run 'Test(IsResourceCodeRecognizesAllAliases|RewriteRelativeResourcePathsUsesDeckSourceDirectory|RewriteRelativeResourcePathsHandlesCQAndCrossPackageReferences|ResolveRelativeResourcePathLeavesNonRelativeReferencesUnchanged|HelpManagerGetContentResolvesResourcesRelativeToSource|ConvertSealMsgToMessageChainUsesFileElementURL|ConvertSealMsgToMessageChainPreservesDefaultResourceParameters)$'`
- `git diff --check origin/master...HEAD`
- 全量 `go test ./...` 仅受现有 Windows 日志文件句柄清理用例 `TestDynamicFileCoreWritesQueryLoggerIntoDatabaseFile` 影响；本次相关包均通过
- 未运行 lint，由 CI 执行

## Summary by Sourcery

在 SealPack 卡组、帮助文档和 OneBot 文件消息中统一本地资源路径，将其规范化为绝对文件 URL，同时保留远程引用和附加参数。

New Features:
- 支持将 Seal 和 CQ 代码中的本地图片、音频、视频和文件路径规范化为绝对文件 URL。
- 基于源文件位置解析卡组和帮助文档中的相对资源路径，使得包可以被移动到缓存目录而无需手动修改路径。

Bug Fixes:
- 确保 OneBot 文件消息优先使用完整的资源 URL 而非仅有文件名，以避免发送不完整的文件引用。
- 通过更严格的路径边界检查，防止本地资源引用逃逸出允许的程序目录和临时目录根路径。

Enhancements:
- 在消息转换和文件元素创建中统一本地资源规范化的处理逻辑，避免重复的路径处理代码。
- 对未注册的 CQ 资源类型进行一致处理，在适用时规范化其本地文件参数。

Tests:
- 添加单元测试，覆盖资源代码检测、卡组和帮助文档的相对路径重写、本地资源规范化以及 OneBot 消息转换行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize local resource paths across SealPack decks, help documents, and OneBot file messages to use absolute file URLs while preserving remote references and additional parameters.

New Features:
- Support normalization of local image, audio, video, and file paths in Seal and CQ codes into absolute file URLs.
- Resolve relative resource paths in decks and help documents based on their source file location so packages can be moved into cache directories without manual path edits.

Bug Fixes:
- Ensure OneBot file messages prefer full resource URLs over bare filenames to avoid sending incomplete file references.
- Prevent local resource references from escaping the allowed program and temporary directory roots using stricter path boundary checks.

Enhancements:
- Unify handling of local resource normalization in message conversion and file element creation to avoid duplicated path logic.
- Treat unregistered CQ resource types consistently by normalizing their local file parameters when applicable.

Tests:
- Add unit tests covering resource code detection, relative path rewriting for decks and help docs, local resource normalization, and OneBot message conversion behavior.

</details>