### PR TITLE
fix(package): 恢复 sealpack 规则模板的启动注册

### DIFF
--- a/dice/dice.go
+++ b/dice/dice.go
@@ -363,9 +363,6 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 
 	go d.StoreSetup()
 
-	// 初始化扩展包管理器
-	d.PackageSetup()
-
 	// 创建js运行时
 	if d.Config.JsEnable {
 		loggerInstance.Info("js扩展支持：开启")
@@ -374,6 +371,9 @@ func (d *Dice) Init(operator engine.DatabaseOperator, uiWriter *logger.UIWriter)
 	} else {
 		loggerInstance.Info("js扩展支持：关闭")
 	}
+
+	// 在 JS 初始化重建规则模板注册表后恢复扩展包及其模板。
+	d.PackageSetup()
 
 	for _, i := range d.ExtList {
 		if i.OnLoad != nil {
@@ -926,9 +926,15 @@ func (d *Dice) GameSystemTemplateReloadFiles(packageFiles []string) error {
 	return d.reloadGameSystemTemplates(files)
 }
 
-func (d *Dice) reloadGameSystemTemplates(files []string) error {
+// resetGameSystemTemplates 将规则模板注册表替换为仅包含内置模板的状态。
+// 调用方如需保留用户或 sealpack 模板，必须随后重新加载对应来源。
+func (d *Dice) resetGameSystemTemplates() {
 	d.GameSystemMap = new(SyncMap[string, *GameSystemTemplate])
 	d.RegisterBuiltinSystemTemplate()
+}
+
+func (d *Dice) reloadGameSystemTemplates(files []string) error {
+	d.resetGameSystemTemplates()
 
 	seen := make(map[string]struct{}, len(files))
 	count := 0
@@ -1169,5 +1175,9 @@ func (d *Dice) PackageSetup() {
 	d.PackageManager = NewPackageManager(d)
 	if err := d.PackageManager.Init(); err != nil {
 		d.Logger.Errorf("初始化扩展包管理器失败: %v", err)
+		return
+	}
+	if err := d.PackageManager.reloadTemplates(); err != nil {
+		d.Logger.Warnf("恢复扩展包规则模板失败: %v", err)
 	}
 }

--- a/dice/dice_jsvm.go
+++ b/dice/dice_jsvm.go
@@ -711,10 +711,15 @@ func (d *Dice) jsClear() {
 	d.CocExtraRules = map[int]*CocRuleInfo{}
 	// 清理脚本列表
 	d.JsScriptList = []*JsScriptInfo{}
-	// 清理规则模板
-	// Pinenutn: 由于切换成了其他的syncMap，所以初始化策略需要修改
-	d.GameSystemMap = new(SyncMap[string, *GameSystemTemplate])
-	d.RegisterBuiltinSystemTemplate()
+	// 清理 JS 注册的规则模板，同时恢复内置、用户和已启用扩展包模板。
+	if d.PackageManager == nil {
+		d.resetGameSystemTemplates()
+	} else if err := d.PackageManager.reloadTemplates(); err != nil {
+		d.resetGameSystemTemplates()
+		if d.Logger != nil {
+			d.Logger.Errorf("JS 环境清理后恢复用户及 sealpack 规则模板失败，当前仅保留内置模板: %v", err)
+		}
+	}
 	// JsEnable=false 的启动状态下 ExtLoopManager 可能尚未初始化
 	if d.ExtLoopManager != nil {
 		d.ExtLoopManager.SetLoop(nil)

--- a/dice/package_manager_test.go
+++ b/dice/package_manager_test.go
@@ -763,6 +763,80 @@ func TestPackageManagerReloadAllLoadsTemplateFilesFromEnabledPackages(t *testing
 	}
 }
 
+func TestPackageSetupRestoresEnabledPackageTemplatesAfterRestart(t *testing.T) {
+	_, pm := newTestPackageManager(t)
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const pkgID = "alice/template-restart-pack"
+	archive := createTestSealPack(t, "", pkgID, "1.0.0", map[string][]string{
+		"templates": {"templates/*.yaml"},
+	}, map[string]string{
+		"templates/restart.yaml": loadTemplateFixture(t, "restart-template"),
+	})
+	if err := pm.Install(archive); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if _, err := pm.Enable(pkgID); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+
+	restarted := &Dice{
+		BaseConfig:    BaseConfig{DataDir: "."},
+		Logger:        zap.NewNop().Sugar(),
+		GameSystemMap: new(SyncMap[string, *GameSystemTemplate]),
+	}
+	restarted.PackageSetup()
+
+	pkg, exists := restarted.PackageManager.Get(pkgID)
+	if !exists || pkg.State != sealpack.PackageStateEnabled {
+		t.Fatalf("expected package %s to be restored as enabled, got %#v", pkgID, pkg)
+	}
+	if _, exists := restarted.GameSystemMap.Load("restart-template"); !exists {
+		t.Fatal("expected enabled package template to be restored during PackageSetup")
+	}
+}
+
+func TestJsClearRestoresEnabledPackageTemplates(t *testing.T) {
+	testDice, pm := newTestPackageManager(t)
+	testDice.GameSystemMap = new(SyncMap[string, *GameSystemTemplate])
+	if err := pm.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	const pkgID = "alice/template-js-clear-pack"
+	archive := createTestSealPack(t, "", pkgID, "1.0.0", map[string][]string{
+		"templates": {"templates/*.yaml"},
+	}, map[string]string{
+		"templates/static.yaml": loadTemplateFixture(t, "static-template"),
+	})
+	if err := pm.Install(archive); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if _, err := pm.Enable(pkgID); err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+	if err := pm.reloadTemplates(); err != nil {
+		t.Fatalf("reloadTemplates() error = %v", err)
+	}
+
+	testDice.GameSystemTemplateAddEx(&GameSystemTemplate{
+		GameSystemTemplateV2: &GameSystemTemplateV2{Name: "js-only-template"},
+	}, true)
+	testDice.jsClear()
+
+	if _, exists := testDice.GameSystemMap.Load("static-template"); !exists {
+		t.Fatal("expected enabled package template to survive jsClear")
+	}
+	if _, exists := testDice.GameSystemMap.Load("js-only-template"); exists {
+		t.Fatal("expected JS-only template to be removed by jsClear")
+	}
+	if _, exists := testDice.GameSystemMap.Load("coc7"); !exists {
+		t.Fatal("expected builtin templates to remain available after jsClear")
+	}
+}
+
 func TestPackageManagerReloadHelpdocUsesReloadHelp(t *testing.T) {
 	testDice, pm := newTestPackageManager(t)
 	manager := &DiceManager{


### PR DESCRIPTION
## 变更

- 在初始 JS 注册表重建后恢复已启用 sealpack 的规则模板
- JS 环境清理时保留内置、用户和 sealpack 静态模板
- 增加重启恢复与 JS 清理场景的回归测试

## 验证

- `go test ./dice -run '^(TestPackageManagerReloadAllLoadsTemplateFilesFromEnabledPackages|TestPackageSetupRestoresEnabledPackageTemplatesAfterRestart|TestJsClearRestoresEnabledPackageTemplates|TestJsInit_WhenExtLoopManagerNil_DoesNotPanic)$' -count=1`
- `go test ./dice/...`
- `go vet ./...`
- `go test ./...` 除 `logger/TestDynamicFileCoreWritesQueryLoggerIntoDatabaseFile` 在 Windows 清理仍被占用的 `database.log` 时失败外，其余包通过；该 logger 测试隔离重跑仍可复现相同文件锁问题

## Summary by Sourcery

在 Dice 重启和 JS 环境重置后，恢复已启用的 sealpack 规则模板，并添加回归测试以覆盖这些场景。

Bug 修复：
- 确保在 Dice 重启后，已启用的 sealpack 规则模板能够被恢复。
- 确保在清空 JS 环境时，已启用的 sealpack 模板仍然保留，而仅 JS 的模板会被移除。

增强：
- 将包的初始化流程移动到 JS 初始化之后执行，以便在 JS 模板注册表重建后恢复包模板。
- 将游戏系统模板映射的重置逻辑集中到一个新的辅助函数中，该函数同时用于模板重载和 JS 清理。
- 扩展 PackageSetup，以便从已启用的包中重新加载规则模板，并在失败时记录日志，而不是静默继续。

测试：
- 添加回归测试，覆盖在重启后以及在清空 JS 环境后模板恢复的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore enabled sealpack rule templates across Dice restarts and JS environment resets, and add regression tests to cover these scenarios.

Bug Fixes:
- Ensure enabled sealpack rule templates are restored after Dice restart.
- Ensure enabled sealpack templates persist when the JS environment is cleared while JS-only templates are removed.

Enhancements:
- Move package setup to run after JS initialization so package templates are restored after the JS template registry is rebuilt.
- Centralize game system template map reset logic in a new helper used by both template reload and JS clearing.
- Extend PackageSetup to reload rule templates from enabled packages and log failures instead of silently continuing.

Tests:
- Add regression tests covering template restoration after restart and after JS environment clearing.

</details>