### PR TITLE
fix(lint): 抑制 golangci-lint 2.13+ 对 Slack 事件循环错误检查误报

### DIFF
--- a/dice/platform_adapter_slack.go
+++ b/dice/platform_adapter_slack.go
@@ -148,8 +148,8 @@ func (pa *PlatformAdapterSlack) Serve() int {
 	pa.Client = client
 	ctx, cancel := context.WithCancel(context.Background())
 	pa.cancel = cancel
-	err := sh.RunEventLoopContext(ctx)
-	if err != nil {
+	//nolint:staticcheck // golangci-lint 2.13+ 将该 error 的 nil 检查误报为恒真（外部库调用，staticcheck 回归）
+	if err := sh.RunEventLoopContext(ctx); err != nil {
 		log.Error("SlackEventLoopErr：", err.Error())
 		return 1
 	}


### PR DESCRIPTION
…3 误报

## Summary by Sourcery

错误修复：
- 防止 golangci-lint 2.13+ 错误地将 Slack 事件循环错误检查标记为问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent golangci-lint 2.13+ from incorrectly flagging the Slack event loop error check.

</details>