### PR TITLE
fix(log): 缓存链接失效时重新上传日志

### DIFF
--- a/dice/ext_log_upload_cache_test.go
+++ b/dice/ext_log_upload_cache_test.go
@@ -1,0 +1,135 @@
+//nolint:testpackage
+package dice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sealdiceLogger "sealdice-core/logger"
+	"sealdice-core/model"
+	"sealdice-core/utils/constant"
+)
+
+func TestLogSendToBackendReuploadsMissingCachedURL(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1004"
+	logName := "expired-upload"
+	appendTestLog(t, mockDB, groupID, logName)
+
+	oldURL := "https://logs.example/?key=Old1#123456"
+	db := mockDB.GetLogDB(constant.WRITE)
+	if err := db.Model(&model.LogInfo{}).
+		Where("group_id = ? AND name = ?", groupID, logName).
+		UpdateColumns(map[string]interface{}{
+			"upload_url":  oldURL,
+			"upload_time": time.Now().Add(time.Minute).Unix(),
+		}).Error; err != nil {
+		t.Fatalf("seed cached upload: %v", err)
+	}
+
+	var probeCount atomic.Int32
+	var uploadCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/dice/api/load_data":
+			probeCount.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodPut && r.URL.Path == "/dice/api/log":
+			uploadCount.Add(1)
+			_, _ = w.Write([]byte(`{"url":"https://logs.example/?key=New1#654321"}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	oldBackends := BackendUrls
+	BackendUrls = []string{server.URL}
+	t.Cleanup(func() { BackendUrls = oldBackends })
+
+	ctx := &MsgContext{
+		Dice: &Dice{
+			BaseConfig: BaseConfig{DataDir: t.TempDir()},
+			DBOperator: mockDB,
+			Logger:     sealdiceLogger.M(),
+		},
+		EndPoint: &EndPointInfo{EndPointInfoBase: EndPointInfoBase{UserID: "UI:1000"}},
+	}
+
+	_, gotURL, _, err := LogSendToBackend(ctx, groupID, logName)
+	if err != nil {
+		t.Fatalf("LogSendToBackend: %v", err)
+	}
+	if gotURL != "https://logs.example/?key=New1#654321" {
+		t.Fatalf("url = %q, want newly uploaded URL", gotURL)
+	}
+	if got := probeCount.Load(); got != 1 {
+		t.Fatalf("probe requests = %d, want 1", got)
+	}
+	if got := uploadCount.Load(); got != 1 {
+		t.Fatalf("upload requests = %d, want 1", got)
+	}
+}
+
+func TestLogSendToBackendFallsBackToCachedURLWhenProbeAndUploadFail(t *testing.T) {
+	mockDB := newLogAliasTestDB(t)
+	groupID := "QQ-Group:1005"
+	logName := "uncertain-upload"
+	appendTestLog(t, mockDB, groupID, logName)
+
+	oldURL := "https://logs.example/?key=Old2#123456"
+	db := mockDB.GetLogDB(constant.WRITE)
+	if err := db.Model(&model.LogInfo{}).
+		Where("group_id = ? AND name = ?", groupID, logName).
+		UpdateColumns(map[string]interface{}{
+			"upload_url":  oldURL,
+			"upload_time": time.Now().Add(time.Minute).Unix(),
+		}).Error; err != nil {
+		t.Fatalf("seed cached upload: %v", err)
+	}
+
+	var uploadCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/custom/path/load_data":
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+		case r.Method == http.MethodPut && r.URL.Path == "/custom/path/log":
+			uploadCount.Add(1)
+			http.Error(w, "upload failed", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	ctx := &MsgContext{
+		Dice: &Dice{
+			BaseConfig: BaseConfig{DataDir: t.TempDir()},
+			DBOperator: mockDB,
+			Logger:     sealdiceLogger.M(),
+			AdvancedConfig: AdvancedConfig{
+				Enable:             true,
+				StoryLogBackendUrl: server.URL + "/custom/path/log",
+			},
+		},
+		EndPoint: &EndPointInfo{EndPointInfoBase: EndPointInfoBase{UserID: "UI:1000"}},
+	}
+
+	_, gotURL, notice, err := LogSendToBackend(ctx, groupID, logName)
+	if err != nil {
+		t.Fatalf("LogSendToBackend: %v", err)
+	}
+	if gotURL != oldURL {
+		t.Fatalf("url = %q, want cached URL %q", gotURL, oldURL)
+	}
+	if !strings.Contains(notice, "重新上传日志失败") || !strings.Contains(notice, "可能仍然有效") {
+		t.Fatalf("notice = %q, want upload failure and uncertain cached URL warning", notice)
+	}
+	if got := uploadCount.Load(); got != 1 {
+		t.Fatalf("upload requests = %d, want 1", got)
+	}
+}

--- a/dice/storylog/cache_validation_test.go
+++ b/dice/storylog/cache_validation_test.go
@@ -1,0 +1,73 @@
+package storylog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestProbeCachedLogURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       cachedLogProbeResult
+	}{
+		{name: "alive", statusCode: http.StatusOK, want: cachedLogProbeAlive},
+		{name: "missing", statusCode: http.StatusNotFound, want: cachedLogProbeMissing},
+		{name: "gone", statusCode: http.StatusGone, want: cachedLogProbeMissing},
+		{name: "server error", statusCode: http.StatusInternalServerError, want: cachedLogProbeUnknown},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/custom/backend/load_data" {
+					t.Fatalf("path = %q, want /custom/backend/load_data", r.URL.Path)
+				}
+				if got := r.URL.Query().Get("key"); got != "AbCd" {
+					t.Fatalf("key = %q, want AbCd", got)
+				}
+				if got := r.URL.Query().Get("password"); got != "123456" {
+					t.Fatalf("password = %q, want 123456", got)
+				}
+				if got := r.Header.Get("Authorization"); got != "Bearer token" {
+					t.Fatalf("Authorization = %q, want Bearer token", got)
+				}
+				w.WriteHeader(test.statusCode)
+			}))
+			defer server.Close()
+
+			env := UploadEnv{
+				Backends: []string{server.URL + "/custom/backend/log"},
+				Token:    "token",
+				Log:      zap.NewNop().Sugar(),
+			}
+			if got := probeCachedLogURL(env, "https://logs.example/?key=AbCd#123456"); got != test.want {
+				t.Fatalf("probeCachedLogURL() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestProbeCachedLogURLNetworkFailureIsUnknown(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	backend := server.URL + "/dice/api/log"
+	server.Close()
+
+	env := UploadEnv{
+		Backends: []string{backend},
+		Log:      zap.NewNop().Sugar(),
+	}
+	if got := probeCachedLogURL(env, "https://logs.example/?key=AbCd#123456"); got != cachedLogProbeUnknown {
+		t.Fatalf("probeCachedLogURL() = %v, want %v", got, cachedLogProbeUnknown)
+	}
+}
+
+func TestProbeCachedLogURLRejectsUnusableCachedURL(t *testing.T) {
+	env := UploadEnv{Log: zap.NewNop().Sugar()}
+	if got := probeCachedLogURL(env, "https://logs.example/"); got != cachedLogProbeMissing {
+		t.Fatalf("probeCachedLogURL() = %v, want %v", got, cachedLogProbeMissing)
+	}
+}

--- a/dice/storylog/storylog.go
+++ b/dice/storylog/storylog.go
@@ -2,18 +2,31 @@ package storylog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
 	"sealdice-core/model"
 	"sealdice-core/utils/dboperator/engine"
+)
+
+const cachedLogProbeTimeout = 3 * time.Second
+
+type cachedLogProbeResult uint8
+
+const (
+	cachedLogProbeUnknown cachedLogProbeResult = iota
+	cachedLogProbeAlive
+	cachedLogProbeMissing
 )
 
 type UploadEnv struct {
@@ -55,6 +68,86 @@ func Upload(env UploadEnv) (string, string, error) {
 		return uploadV105(env)
 	}
 	return "", "", errors.New("未指定日志版本")
+}
+
+func checkCachedLogURL(env UploadEnv, rawURL string) cachedLogProbeResult {
+	result := probeCachedLogURL(env, rawURL)
+	switch result {
+	case cachedLogProbeMissing:
+		env.Log.Infof("之前上传的日志链接已失效，将重新上传 Log:%s.%s URL:%s", env.GroupID, env.LogName, rawURL)
+	case cachedLogProbeUnknown:
+		env.Log.Warnf("无法确认之前上传的日志链接是否有效，将尝试重新上传 Log:%s.%s URL:%s", env.GroupID, env.LogName, rawURL)
+	}
+	return result
+}
+
+func fallbackToCachedLogURL(env *UploadEnv, rawURL string, probeResult cachedLogProbeResult) (string, string, bool) {
+	if rawURL == "" || probeResult != cachedLogProbeUnknown {
+		return "", env.Notice, false
+	}
+	const notice = "重新上传日志失败，现返回之前缓存的链接；该链接可能仍然有效。"
+	env.appendNotice(notice)
+	env.Log.Warnf("%s Log:%s.%s URL:%s", notice, env.GroupID, env.LogName, rawURL)
+	return rawURL, env.Notice, true
+}
+
+func probeCachedLogURL(env UploadEnv, rawURL string) cachedLogProbeResult {
+	logURL, err := url.Parse(rawURL)
+	if err != nil {
+		return cachedLogProbeMissing
+	}
+	key, password := logURL.Query().Get("key"), logURL.Fragment
+	if key == "" || password == "" {
+		return cachedLogProbeMissing
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), cachedLogProbeTimeout)
+	defer cancel()
+
+	missing := false
+	for _, backend := range env.Backends {
+		backendURL, parseErr := url.Parse(backend)
+		if parseErr != nil {
+			continue
+		}
+		path := strings.TrimRight(backendURL.Path, "/")
+		if !strings.HasSuffix(path, "/log") {
+			continue
+		}
+		backendURL.Path = strings.TrimSuffix(path, "/log") + "/load_data"
+		backendURL.RawPath = ""
+		query := backendURL.Query()
+		query.Set("key", key)
+		query.Set("password", password)
+		backendURL.RawQuery = query.Encode()
+		backendURL.Fragment = ""
+
+		req, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, backendURL.String(), nil)
+		if requestErr != nil {
+			continue
+		}
+		req.Header.Set("Range", "bytes=0-0")
+		if env.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+env.Token)
+		}
+
+		resp, requestErr := http.DefaultClient.Do(req) //nolint:gosec
+		if requestErr != nil {
+			continue
+		}
+		_ = resp.Body.Close()
+
+		switch {
+		case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+			return cachedLogProbeAlive
+		case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+			missing = true
+		}
+	}
+	if missing {
+		return cachedLogProbeMissing
+	}
+	return cachedLogProbeUnknown
 }
 
 func uploadToBackend(env UploadEnv, backend string, data io.Reader) string {

--- a/dice/storylog/upload_v1.go
+++ b/dice/storylog/upload_v1.go
@@ -20,7 +20,12 @@ func uploadV1(env UploadEnv) (string, string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
+	cachedURL := url
+	probeResult := cachedLogProbeMissing
 	if len(url) > 0 && uploadTS > updateTS {
+		probeResult = checkCachedLogURL(env, url)
+	}
+	if probeResult == cachedLogProbeAlive {
 		// 已有URL且上传时间晚于Log更新时间（最后录入时间），直接返回
 		env.Log.Infof(
 			"查询到之前上传的URL, 直接使用 Log:%s.%s 上传时间:%s 更新时间:%s URL:%s",
@@ -33,7 +38,7 @@ func uploadV1(env UploadEnv) (string, string, error) {
 	}
 	if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
-	} else {
+	} else if uploadTS <= updateTS {
 		env.Log.Infof(
 			"Log上传后又有更新, 重新上传 Log:%s.%s 上传时间:%s 更新时间:%s",
 			env.GroupID, env.LogName,
@@ -71,6 +76,9 @@ func uploadV1(env UploadEnv) (string, string, error) {
 		env.Log.Errorf("记录Log上传信息失败: %v", errDB)
 	}
 	if len(url) == 0 {
+		if fallbackURL, notice, ok := fallbackToCachedLogURL(&env, cachedURL, probeResult); ok {
+			return fallbackURL, notice, nil
+		}
 		return "", env.Notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
 	return url, env.Notice, nil

--- a/dice/storylog/upload_v105.go
+++ b/dice/storylog/upload_v105.go
@@ -137,7 +137,12 @@ func uploadV105(env UploadEnv) (string, string, error) {
 	_ = os.MkdirAll(env.Dir, 0o755)
 
 	url, uploadTS, updateTS, _ := service.LogGetUploadInfo(env.Db, env.GroupID, env.LogName)
+	cachedURL := url
+	probeResult := cachedLogProbeMissing
 	if len(url) > 0 && uploadTS > updateTS {
+		probeResult = checkCachedLogURL(env, url)
+	}
+	if probeResult == cachedLogProbeAlive {
 		// 已有URL且上传时间晚于Log更新时间（最后录入时间），直接返回
 		env.Log.Infof(
 			"查询到之前上传的URL, 直接使用 Log:%s.%s 上传时间:%s 更新时间:%s URL:%s",
@@ -150,7 +155,7 @@ func uploadV105(env UploadEnv) (string, string, error) {
 	}
 	if len(url) == 0 {
 		env.Log.Infof("没有查询到之前上传的URL Log:%s.%s", env.GroupID, env.LogName)
-	} else {
+	} else if uploadTS <= updateTS {
 		env.Log.Infof(
 			"Log上传后又有更新, 重新上传 Log:%s.%s 上传时间:%s 更新时间:%s",
 			env.GroupID, env.LogName,
@@ -177,6 +182,9 @@ func uploadV105(env UploadEnv) (string, string, error) {
 		env.Log.Errorf("记录Log上传信息失败: %v", errDB)
 	}
 	if len(url) == 0 {
+		if fallbackURL, notice, ok := fallbackToCachedLogURL(&env, cachedURL, probeResult); ok {
+			return fallbackURL, notice, nil
+		}
 		return "", env.Notice, errors.New("上传 log 到服务器失败，未能获取染色器链接")
 	}
 	return url, env.Notice, nil


### PR DESCRIPTION
## 背景

SealDice 会在日志内容没有变化时，直接复用本地数据库中保存的 `upload_url`，不再请求日志后端。

当日志后端启用滚动清理后，远端日志数据可能已经被删除，但 SealDice 本地仍保留原链接。此时用户执行 `.log get` 或从 UI 提取日志，仍会得到已经失效的链接。

Fixes #1563

## 修改内容

在复用缓存日志链接前增加远端存活校验：

1. 从缓存链接中提取 `key` 和密码。
2. 根据实际上传地址推导查询地址，只将末尾的 `/log` 替换为 `/load_data`，不写死路径前缀：
   - `/dice/api/log` → `/dice/api/load_data`
   - `/custom/path/log` → `/custom/path/load_data`
3. 查询设置 3 秒总超时，并携带自定义后端的 Bearer Token。
4. 根据查询结果处理：
   - `2xx`：远端日志仍存在，继续复用缓存链接。
   - `404/410`：远端日志已明确失效，重新上传并保存新链接。
   - 网络错误、超时或 `5xx`：无法确认链接状态，尝试重新上传。
   - 无法确认且重新上传也失败：明确提示新上传失败，同时返回可能仍然有效的旧链接。
   - 已明确失效且重新上传失败：正常返回上传失败，不再提供已知失效的链接。

该逻辑同时应用于 V1 和 V105 日志格式，因此 `.log get` 与 UI 日志提取会保持一致。

## 改动范围

- 不修改数据库结构。
- 不修改 UI。
- 不修改日志后端协议。
- 日志内容发生变化时，仍沿用原有的直接重新上传逻辑。

## Sourcery 总结

确保在重复使用缓存的日志链接前对其进行验证，并在远程日志已过期时安全恢复。

错误修复：
- 在重复使用前验证缓存的日志链接；当确认远程资源缺失或无法验证其可用性时，重新上传日志。
- 对 V1 和 V105 日志格式一致地应用缓存链接恢复机制，包括在重新上传失败时提供明确的回退提示。

增强功能：
- 根据自定义或默认的上传路径推导远程可用性检查端点，并添加身份验证和有界请求超时。

测试：
- 增加对已过期缓存链接、不确定的探测和上传失败、端点推导、身份验证、状态处理以及格式错误的缓存 URL 的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在复用缓存日志链接前确认其仍然有效，并在失效时安全恢复日志上传。

Bug 修复：
- 在复用缓存日志链接前验证远端资源状态，发现链接失效时自动重新上传日志。
- 统一修复 V1 和 V105 日志格式在缓存链接失效、探测不确定或重新上传失败时的处理，并避免返回已明确失效的链接。

功能增强：
- 支持从默认或自定义日志上传路径推导可用性检查端点，并使用 Bearer Token 和 3 秒超时进行探测。

测试：
- 增加对缓存链接失效、不确定状态回退、端点推导、鉴权、状态码处理和无效缓存 URL 的测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在复用缓存日志链接前验证其有效性，并在失效或无法确认时安全地恢复日志上传。

错误修复：
- 验证缓存日志链接的远端状态，并在链接明确失效时重新上传日志，避免返回已失效的链接。
- 统一修复 V1 和 V105 日志格式在缓存链接失效、状态无法确认及重新上传失败时的处理。

改进：
- 支持从默认或自定义日志后端路径推导存活检查端点，并使用 Bearer Token 和有限超时进行请求。

测试：
- 增加对缓存链接状态探测、端点推导、鉴权、网络异常、上传失败回退及无效缓存 URL 的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在复用缓存日志链接前验证其有效性，并在失效或无法确认时安全地恢复日志上传。

Bug Fixes:
- 验证缓存日志链接的远端状态，并在链接明确失效时重新上传日志，避免返回已失效的链接。
- 统一修复 V1 和 V105 日志格式在缓存链接失效、状态无法确认及重新上传失败时的处理。

Enhancements:
- 支持从默认或自定义日志后端路径推导存活检查端点，并使用 Bearer Token 和有限超时进行请求。

Tests:
- 增加对缓存链接状态探测、端点推导、鉴权、网络异常、上传失败回退及无效缓存 URL 的测试。

</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>