### PR TITLE
fix(sealchat): 修复重连并发关闭导致的 panic (#1812)

### DIFF
--- a/dice/platform_adapter_sealchat.go
+++ b/dice/platform_adapter_sealchat.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -35,6 +36,7 @@ type PlatformAdapterSealChat struct {
 	RetryTimesLimit int  `json:"-" yaml:"-"`
 
 	// 心跳相关
+	heartbeatMu   sync.Mutex
 	heartbeatStop chan struct{}
 	lastPong      int64
 
@@ -232,12 +234,18 @@ func (pa *PlatformAdapterSealChat) tryReconnect(socket gowebsocket.Socket) bool 
 
 // startHeartbeat 启动心跳协程
 func (pa *PlatformAdapterSealChat) startHeartbeat() {
-	pa.stopHeartbeat()
-	pa.heartbeatStop = make(chan struct{})
+	pa.heartbeatMu.Lock()
+	if pa.heartbeatStop != nil {
+		close(pa.heartbeatStop)
+	}
+	heartbeatStop := make(chan struct{})
+	pa.heartbeatStop = heartbeatStop
+	pa.heartbeatMu.Unlock()
+
 	atomic.StoreInt64(&pa.lastPong, time.Now().Unix())
 	log := pa.EndPoint.Session.Parent.Logger
 
-	go func() {
+	go func(stop <-chan struct{}) {
 		ticker := time.NewTicker(15 * time.Second)
 		defer ticker.Stop()
 		for {
@@ -258,22 +266,20 @@ func (pa *PlatformAdapterSealChat) startHeartbeat() {
 					pa.Socket.Close()
 					return
 				}
-			case <-pa.heartbeatStop:
+			case <-stop:
 				return
 			}
 		}
-	}()
+	}(heartbeatStop)
 }
 
 // stopHeartbeat 停止心跳协程
 func (pa *PlatformAdapterSealChat) stopHeartbeat() {
+	pa.heartbeatMu.Lock()
+	defer pa.heartbeatMu.Unlock()
+
 	if pa.heartbeatStop != nil {
-		select {
-		case <-pa.heartbeatStop:
-			// 已关闭
-		default:
-			close(pa.heartbeatStop)
-		}
+		close(pa.heartbeatStop)
 		pa.heartbeatStop = nil
 	}
 }


### PR DESCRIPTION
- 原子移除 BOT 旧连接，避免重复关闭与重复统计
  - 互斥管理 heartbeatStop，确保通道只关闭一次
  - 心跳协程捕获当前 stop channel，隔离重连代际

修复 https://github.com/sealdice/sealdice-core/issues/1812

## Sourcery 摘要

在替换心跳连接时，防止并发的 SealChat 重连导致程序崩溃。

错误修复：
- 防止 SealChat 重连竞态多次关闭心跳停止通道，从而导致程序崩溃。
- 确保在重连期间，心跳 goroutine 始终与正确的连接代次关联。

增强功能：
- 同步心跳生命周期管理，确保在并发重连期间安全地启动和停止心跳工作线程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent concurrent SealChat reconnects from panicking while replacing heartbeat connections.

Bug Fixes:
- Prevent SealChat reconnect races from closing heartbeat stop channels more than once and causing panics.
- Ensure heartbeat goroutines remain associated with the correct connection generation during reconnects.

Enhancements:
- Synchronize heartbeat lifecycle management to make starting and stopping heartbeat workers safe under concurrent reconnects.

</details>